### PR TITLE
Clean up review console UI

### DIFF
--- a/review/src/App.tsx
+++ b/review/src/App.tsx
@@ -100,12 +100,12 @@ export function App() {
   return (
     <div className="shell">
       <header className="topbar">
-        <div>
-          <div className="eyebrow">selfbench</div>
-          <h1>Task Review Console</h1>
+        <div className="topbar-title">
+          <span className="eyebrow">selfbench</span>
+          <h1>Task Review</h1>
         </div>
         <div className="meta topbar-actions">
-          <span>Models: {summaries.models.join(' · ')}</span>
+          <span className="topbar-models">{summaries.models.join(' · ')}</span>
           <button className="brand-button" type="button" onClick={() => void refresh()}>Refresh</button>
         </div>
       </header>
@@ -170,10 +170,10 @@ function Sidebar({ summaries, tasks, selected, filter, search, onFilter, onSearc
           <button key={task.task_id} className="task-row" data-active={task.task_id === selected} type="button" onClick={() => onSelect(task.task_id)}>
             <div className="task-title">
               <span className="task-id">{task.task_id}</span>
-              <span className="meta"><Badge value={task.review_status} /><Badge value={task.verdict} /></span>
+              <span className="meta task-statuses"><Badge value={`H: ${humanize(task.review_status)}`} kind={task.review_status} /><Badge value={`A: ${humanize(task.verdict)}`} kind={task.verdict} /></span>
             </div>
-            <div className="meta"><span>{task.workdir}</span><span>F2P {task.fail_to_pass_count}</span><span>P2P {task.pass_to_pass_count}</span></div>
-            <div className="meta">{Object.entries(task.model_results).map(([model, result]) => <Badge key={model} value={`${shortModel(model)}: ${result}`} kind={result} />)}</div>
+            <div className="meta task-meta"><span>{task.workdir}</span><span>F2P {task.fail_to_pass_count}</span><span>P2P {task.pass_to_pass_count}</span></div>
+            <div className="meta task-models">{Object.entries(task.model_results).map(([model, result]) => <span key={model} className={`model-pill ${result}`}>{shortModel(model)}: {result}</span>)}</div>
           </button>
         )) : <Empty>No tasks match this filter.</Empty>}
       </div>
@@ -195,7 +195,7 @@ function Detail({ detail, tab, previousTask, nextTask, onNavigate, onTab, onSave
     <section className="content">
       <div className="detail">
         <div className="queue-nav">
-          <span className="subtle">Use J / K to move through the queue.</span>
+          <span className="subtle">J / K moves through the queue</span>
           <div className="meta">
             <button type="button" disabled={!previousTask} onClick={() => previousTask && onNavigate(previousTask)}>← Previous</button>
             <button type="button" disabled={!nextTask} onClick={() => nextTask && onNavigate(nextTask)}>Next →</button>
@@ -231,15 +231,15 @@ function Summary({ summary }: { summary: TaskSummary }) {
     <section className="panel">
       <div className="panel-header">
         <div><div className="eyebrow">{summary.repo}</div><div className="panel-title">{summary.task_id}</div></div>
-        <div className="meta"><Badge value={summary.review_status} /><Badge value={summary.verdict} /><Badge value={summary.validation} /></div>
+        <div className="meta"><Badge value={`Human: ${humanize(summary.review_status)}`} kind={summary.review_status} /><Badge value={`Audit: ${humanize(summary.verdict)}`} kind={summary.verdict} /><Badge value={summary.validation} /></div>
       </div>
       <div className="panel-body">
-        <div className="summary-grid">
+        <dl className="summary-grid">
           <Stat label="Workdir">{summary.workdir}</Stat>
           <Stat label="Source">{summary.source_url ? <a href={summary.source_url} target="_blank" rel="noreferrer">PR {summary.source_pr}</a> : (summary.source_pr ?? '—')}</Stat>
           <Stat label="Signal">{summary.solver_signal}</Stat>
           <Stat label="Tests">F2P {summary.fail_to_pass_count} / P2P {summary.pass_to_pass_count}</Stat>
-        </div>
+        </dl>
         {(summary.blockers.length > 0 || summary.warnings.length > 0) && <div className="warning-list issues">
           {summary.blockers.map((item) => <div key={item} className="warning blocker">{item}</div>)}
           {summary.warnings.map((item) => <div key={item} className="warning">{item}</div>)}
@@ -276,14 +276,13 @@ function ReviewPanel({ detail, onSaved }: { detail: TaskDetail; onSaved: (detail
         <button className="primary-button" type="button" disabled={saving} onClick={() => void save()}>{saving ? 'Saving…' : 'Save Review'}</button>
       </div>
       <div className="panel-body review-grid">
-        <div>
+        <div className="review-field">
           <label className="label" htmlFor="review-status">Review Status</label>
           <select id="review-status" className="field-body" value={status} onChange={(event) => setStatus(event.target.value as ReviewStatus)}>
             {reviewStatuses.map((value) => <option key={value} value={value}>{humanize(value)}</option>)}
           </select>
-          <div className="panel-hint">Audit verdicts are automatic. This is the human curation decision.</div>
         </div>
-        <div><div className="label">Reviewed Warnings</div><div className="field-body">
+        <div className="review-field"><div className="label">Reviewed Warnings</div><div className="field-body">
           {detail.summary.warnings.length ? detail.summary.warnings.map((warning) => (
             <label className="check-row" key={warning}>
               <input type="checkbox" checked={[...reviewed].some((token) => warning.includes(token))} onChange={(event) => setReviewed((current) => {
@@ -295,7 +294,7 @@ function ReviewPanel({ detail, onSaved }: { detail: TaskDetail; onSaved: (detail
             </label>
           )) : <Empty>No active warnings.</Empty>}
         </div></div>
-        <div><div className="label">Notes</div><textarea className="field-body" value={notes} onChange={(event) => setNotes(event.target.value)} placeholder="Why this task is fair, what was manually checked, or why it should stay candidate-only." /></div>
+        <div className="review-field"><div className="label">Notes</div><textarea className="field-body" value={notes} onChange={(event) => setNotes(event.target.value)} placeholder="Why this task is fair, what was manually checked, or why it should stay candidate-only." /></div>
       </div>
     </section>
   );
@@ -373,7 +372,19 @@ function DiffViewer({ taskId, kind, label, modelSlug, compact = false }: { taskI
   }, [path]);
 
   return <div className={`diff-shell${expanded ? ' expanded' : ''}${compact ? ' compact' : ''}`}>
-    <div className="diff-toolbar"><span className="label">{label}</span><div className="meta"><button className="link-button" type="button" onClick={() => setExpanded(!expanded)}>{expanded ? 'Close full screen' : 'Open full screen'}</button><a href={path} target="_blank" rel="noreferrer">Raw patch</a></div></div>
+    <div className="diff-toolbar">
+      <span className="label">{label}</span>
+      <div className="diff-actions">
+        <button className="utility-button" type="button" onClick={() => setExpanded(!expanded)}>
+          <ExpandIcon />
+          <span>{expanded ? 'Close' : 'Full screen'}</span>
+        </button>
+        <a className="utility-button" href={path} target="_blank" rel="noreferrer">
+          <CodeFileIcon />
+          <span>Raw patch</span>
+        </a>
+      </div>
+    </div>
     <div className="diff-body">
       {error ? <div className="warning blocker">{error}</div> : patch ? (
         <DiffErrorBoundary key={path}>
@@ -450,9 +461,15 @@ function Tail({ title, value }: { title: string; value: unknown }) {
   return <div><div className="label tail-title">{title}</div><Code>{value}</Code></div>;
 }
 
+function ExpandIcon() {
+  return <svg aria-hidden="true" viewBox="0 0 16 16"><path d="M6 2H2v4M10 2h4v4M6 14H2v-4M10 14h4v-4" /></svg>;
+}
+function CodeFileIcon() {
+  return <svg aria-hidden="true" viewBox="0 0 16 16"><path d="M3 1.5h6l4 4v9H3zM9 1.5v4h4M7 8 5 10l2 2M9 8l2 2-2 2" /></svg>;
+}
 function Count({ label, value }: { label: string; value: number }) { return <div className="count"><div className="label">{label}</div><div className="value">{value}</div></div>; }
 function Badge({ value, kind }: { value: string; kind?: string }) { return <span className={`badge ${kind ?? value}`}>{value}</span>; }
-function Stat({ label, children }: React.PropsWithChildren<{ label: string }>) { return <div className="stat"><div className="label">{label}</div><div className="stat-value">{children}</div></div>; }
+function Stat({ label, children }: React.PropsWithChildren<{ label: string }>) { return <div className="stat"><dt className="label">{label}</dt><dd className="stat-value">{children}</dd></div>; }
 function Code({ children }: { children: string }) { return <pre className="code">{children}</pre>; }
 function Empty({ children }: React.PropsWithChildren) { return <div className="empty">{children}</div>; }
 function ErrorState({ error, onRetry }: { error: string; onRetry: () => void }) { return <div className="page-state"><div className="warning blocker">{error}</div><button type="button" onClick={onRetry}>Retry</button></div>; }

--- a/review/src/styles.css
+++ b/review/src/styles.css
@@ -3,8 +3,9 @@
   --foreground: 30 8% 93%;
   --card: 30 5% 6%;
   --muted: 30 5% 8%;
-  --muted-foreground: 30 5% 60%;
-  --border: 30 5% 14%;
+  --muted-foreground: 30 5% 58%;
+  --border: 30 5% 13%;
+  --border-soft: 30 5% 10%;
   --brand: 38 95% 55%;
   --destructive: 0 72% 45%;
   --ok: 90 40% 48%;
@@ -12,105 +13,208 @@
 
 * { box-sizing: border-box; }
 html, body, #root { min-height: 100%; }
-body { margin: 0; background: hsl(var(--background)); color: hsl(var(--foreground)); font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; line-height: 1.5; -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
-button, input, select, textarea { border: 1px solid hsl(var(--border)); border-radius: 0; background: hsl(var(--background)); color: hsl(var(--foreground)); font: inherit; }
+body {
+  margin: 0;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px; line-height: 1.5;
+  -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+}
+
+button, input, select, textarea {
+  border: 1px solid hsl(var(--border));
+  border-radius: 0;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font: inherit;
+}
 button { padding: 0.4rem 0.7rem; font-size: 12px; cursor: pointer; }
 button:hover { background: hsl(var(--muted)); }
-button:disabled { cursor: not-allowed; opacity: 0.5; }
+button:disabled { cursor: not-allowed; opacity: 0.45; }
 input, select, textarea { width: 100%; padding: 0.45rem 0.6rem; font-size: 12px; }
-input:focus-visible, textarea:focus-visible, select:focus-visible, button:focus-visible { outline: 1px solid hsl(var(--brand)); outline-offset: -1px; }
+input:focus-visible, textarea:focus-visible, select:focus-visible, button:focus-visible {
+  outline: 1px solid hsl(var(--brand)); outline-offset: -1px;
+}
 textarea { min-height: 7rem; resize: vertical; line-height: 1.5; }
 a, .link-button { color: hsl(var(--brand)); text-decoration: none; }
 a:hover, .link-button:hover { text-decoration: underline; }
 .link-button { border: 0; background: transparent; padding: 0; }
+
 .label { color: hsl(var(--muted-foreground)); font-size: 10px; text-transform: uppercase; letter-spacing: 0.14em; }
 .subtle { color: hsl(var(--muted-foreground)); }
+
+/* ---------- Shell ---------- */
 .shell { min-height: 100vh; display: grid; grid-template-rows: auto 1fr; }
-.topbar { border-bottom: 1px solid hsl(var(--border)); background: hsl(var(--card)); padding: 0.75rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
-.topbar-actions { justify-content: flex-end; }
-.eyebrow { color: hsl(var(--brand)); font-size: 10px; text-transform: uppercase; letter-spacing: 0.16em; }
-h1 { margin: 0.15rem 0 0; font-size: 13px; font-weight: 500; }
-.main { display: grid; grid-template-columns: 380px minmax(0, 1fr); min-height: 0; }
-.sidebar { border-right: 1px solid hsl(var(--border)); min-height: 0; display: grid; grid-template-rows: auto 1fr; }
-.filters { border-bottom: 1px solid hsl(var(--border)); padding: 0.75rem; display: grid; gap: 0.6rem; }
-.counts { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid hsl(var(--border)); }
-.count { padding: 0.5rem 0.6rem; border-right: 1px solid hsl(var(--border)); }
+
+.topbar {
+  border-bottom: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  padding: 0.6rem 1.1rem;
+  display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+}
+.topbar-title { display: flex; flex-direction: column; gap: 0.1rem; }
+.eyebrow { color: hsl(var(--brand)); font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em; }
+h1 { margin: 0; font-size: 13px; font-weight: 500; letter-spacing: 0.02em; }
+.topbar-actions { display: flex; align-items: center; gap: 1rem; justify-content: flex-end; }
+.topbar-models { font-size: 11px; }
+
+.main { display: grid; grid-template-columns: 360px minmax(0, 1fr); min-height: 0; }
+
+/* ---------- Sidebar ---------- */
+.sidebar { border-right: 1px solid hsl(var(--border)); min-height: 0; display: grid; grid-template-rows: auto 1fr; background: hsl(var(--card)); }
+
+.filters { border-bottom: 1px solid hsl(var(--border)); padding: 0.85rem 0.85rem 0.75rem; display: grid; gap: 0.6rem; }
+.counts { display: grid; grid-template-columns: repeat(3, 1fr); }
+.count { padding: 0.45rem 0.55rem; border-right: 1px solid hsl(var(--border-soft)); }
 .count:last-child { border-right: 0; }
-.count .value { margin-top: 0.15rem; font-size: 13px; }
+.count:first-child { padding-left: 0; }
+.count .value { margin-top: 0.15rem; font-size: 14px; font-weight: 500; color: hsl(var(--foreground)); }
+
 .task-list { overflow: auto; min-height: 0; }
-.task-row { width: 100%; text-align: left; border-width: 0 0 1px; padding: 0.65rem 0.75rem; display: grid; gap: 0.4rem; font-size: 13px; }
-.task-row[data-active="true"] { background: hsl(var(--brand) / 0.08); border-left: 2px solid hsl(var(--brand)); padding-left: calc(0.75rem - 2px); }
-.task-title, .panel-header, .run-head, .diff-toolbar, .source-line, .queue-nav { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
-.queue-nav { min-height: 2rem; }
-.task-id { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.task-row {
+  width: 100%; text-align: left; border: 0; border-bottom: 1px solid hsl(var(--border-soft));
+  padding: 0.7rem 0.85rem; display: grid; gap: 0.35rem; font-size: 13px;
+  background: transparent;
+}
+.task-row:hover { background: hsl(var(--muted) / 0.5); }
+.task-row[data-active="true"] { background: hsl(var(--brand) / 0.07); border-left: 2px solid hsl(var(--brand)); padding-left: calc(0.85rem - 2px); }
+.task-title { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.6rem; }
+.task-id { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.task-statuses { flex-direction: column; align-items: flex-end; gap: 0.25rem; flex-wrap: nowrap; margin-top: -0.05rem; }
+.task-meta { font-size: 11px; gap: 0.3rem 0.55rem; }
+.task-models { font-size: 10px; gap: 0.3rem 0.4rem; }
+.model-pill {
+  border: 1px solid hsl(var(--border)); padding: 0.05rem 0.3rem;
+  color: hsl(var(--muted-foreground)); text-transform: lowercase; letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+.model-pill.pass, .model-pill.resolved { border-color: hsl(var(--ok) / 0.45); color: hsl(var(--ok)); }
+.model-pill.fail, .model-pill.failed { border-color: hsl(var(--destructive) / 0.5); color: hsl(var(--destructive)); }
+.model-pill.stale, .model-pill.missing { border-color: hsl(var(--brand) / 0.45); color: hsl(var(--brand)); }
+
 .meta { color: hsl(var(--muted-foreground)); display: flex; flex-wrap: wrap; align-items: center; gap: 0.35rem 0.6rem; font-size: 11px; }
-.badge { border: 1px solid hsl(var(--border)); padding: 0.1rem 0.3rem; color: hsl(var(--muted-foreground)); font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; white-space: nowrap; }
-.badge.accepted, .badge.approved, .badge.pass, .badge.resolved { border-color: hsl(var(--ok) / 0.5); color: hsl(var(--ok)); background: hsl(var(--ok) / 0.08); }
-.badge.needs_review, .badge.in_review, .badge.missing, .badge.stale { border-color: hsl(var(--brand) / 0.45); color: hsl(var(--brand)); background: hsl(var(--brand) / 0.08); }
-.badge.rejected, .badge.changes_requested, .badge.fail, .badge.failed, .badge.invalid { border-color: hsl(var(--destructive) / 0.55); color: hsl(var(--destructive)); background: hsl(var(--destructive) / 0.1); }
-.content { min-width: 0; overflow: auto; }
-.detail { padding: 0.75rem; display: grid; gap: 0.75rem; }
+
+/* ---------- Badges ---------- */
+.badge {
+  border: 1px solid hsl(var(--border)); padding: 0.08rem 0.32rem;
+  color: hsl(var(--muted-foreground)); font-size: 9.5px;
+  text-transform: uppercase; letter-spacing: 0.12em; white-space: nowrap;
+}
+.badge.accepted, .badge.approved, .badge.pass, .badge.resolved { border-color: hsl(var(--ok) / 0.5); color: hsl(var(--ok)); background: hsl(var(--ok) / 0.07); }
+.badge.needs_review, .badge.in_review, .badge.missing, .badge.stale { border-color: hsl(var(--brand) / 0.45); color: hsl(var(--brand)); background: hsl(var(--brand) / 0.07); }
+.badge.rejected, .badge.changes_requested, .badge.fail, .badge.failed, .badge.invalid { border-color: hsl(var(--destructive) / 0.55); color: hsl(var(--destructive)); background: hsl(var(--destructive) / 0.09); }
+
+/* ---------- Detail ---------- */
+.content { min-width: 0; overflow: auto; background: hsl(var(--background)); }
+.detail { padding: 1rem 1.25rem 2rem; display: grid; gap: 1rem; max-width: 1400px; }
+
+.queue-nav { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; min-height: 1.5rem; }
+.queue-nav .meta { gap: 0.5rem; }
+
+/* ---------- Panels ---------- */
 .panel { border: 1px solid hsl(var(--border)); background: hsl(var(--card)); }
-.panel-header { padding: 0.65rem 0.75rem; border-bottom: 1px solid hsl(var(--border)); }
+.panel-header { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; padding: 0.6rem 0.85rem; border-bottom: 1px solid hsl(var(--border-soft)); }
 .panel-title { font-size: 13px; font-weight: 500; }
 .panel-hint { margin-top: 0.2rem; color: hsl(var(--muted-foreground)); font-size: 11px; }
-.panel-body { padding: 0.75rem; }
-.tab-panel { display: grid; grid-template-columns: 150px minmax(0, 1fr); }
-.tab-content { min-width: 0; }
-.summary-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.6rem; }
-.stat { border: 1px solid hsl(var(--border)); background: hsl(var(--muted) / 0.32); padding: 0.5rem 0.6rem; min-width: 0; }
-.stat-value { margin-top: 0.25rem; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.tabs { display: flex; flex-direction: column; border-right: 1px solid hsl(var(--border)); background: hsl(var(--muted) / 0.16); }
-.tab { width: 100%; border: 0; border-bottom: 1px solid hsl(var(--border)); border-left: 2px solid transparent; background: transparent; padding: 0.65rem 0.75rem; color: hsl(var(--muted-foreground)); font-size: 12px; text-align: left; white-space: nowrap; }
-.tab[data-active="true"] { border-left-color: hsl(var(--brand)); background: hsl(var(--brand) / 0.08); color: hsl(var(--foreground)); }
-.code { margin: 0; overflow: auto; white-space: pre-wrap; word-break: break-word; line-height: 1.5; font-size: 12px; color: hsl(var(--foreground)); background: hsl(var(--background)); border: 1px solid hsl(var(--border)); padding: 0.75rem; max-height: 70vh; }
-.warning-list { display: grid; gap: 0.5rem; align-content: start; }
-.warning { border: 1px solid hsl(var(--brand) / 0.35); background: hsl(var(--brand) / 0.07); padding: 0.5rem 0.6rem; font-size: 12px; }
-.blocker { border-color: hsl(var(--destructive) / 0.5); background: hsl(var(--destructive) / 0.08); }
-.issues { margin-top: 0.75rem; }
-.run-body { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
-.review-grid { display: grid; grid-template-columns: minmax(170px, 0.45fr) 1fr 1fr; gap: 0.75rem; align-items: start; }
+.panel-body { padding: 0.85rem; }
+
+/* ---------- Summary ---------- */
+.summary-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0; margin: 0; }
+.stat { padding: 0.5rem 0.9rem; border-right: 1px solid hsl(var(--border-soft)); min-width: 0; }
+.stat:last-child { border-right: 0; padding-right: 0; }
+.stat:first-child { padding-left: 0; }
+.stat-value { margin: 0.35rem 0 0; font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: hsl(var(--foreground)); }
+.stat-value dd { margin: 0; }
+
+/* ---------- Tabs ---------- */
+.tab-panel { display: grid; grid-template-rows: auto 1fr; }
+.tabs { display: flex; flex-direction: row; border-bottom: 1px solid hsl(var(--border)); background: hsl(var(--muted) / 0.12); overflow-x: auto; }
+.tab {
+  width: auto; border: 0; border-bottom: 2px solid transparent; background: transparent;
+  padding: 0.6rem 0.95rem; color: hsl(var(--muted-foreground)); font-size: 12px;
+  text-align: left; white-space: nowrap;
+}
+.tab:hover { background: hsl(var(--muted) / 0.4); }
+.tab[data-active="true"] { border-bottom-color: hsl(var(--brand)); background: hsl(var(--brand) / 0.06); color: hsl(var(--foreground)); }
+.tab-content { min-width: 0; padding: 0.85rem; }
+
+/* ---------- Code ---------- */
+.code {
+  margin: 0; overflow: auto; white-space: pre-wrap; word-break: break-word;
+  line-height: 1.5; font-size: 12px; color: hsl(var(--foreground));
+  background: hsl(var(--background)); border: 1px solid hsl(var(--border-soft));
+  padding: 0.85rem; max-height: 70vh;
+}
+
+/* ---------- Warnings ---------- */
+.warning-list { display: grid; gap: 0.4rem; align-content: start; }
+.warning { border-left: 2px solid hsl(var(--brand) / 0.6); background: hsl(var(--brand) / 0.06); padding: 0.45rem 0.6rem; font-size: 12px; }
+.blocker { border-left-color: hsl(var(--destructive) / 0.7); background: hsl(var(--destructive) / 0.07); }
+.issues { margin-top: 0.85rem; }
+
+/* ---------- Review panel ---------- */
+.review-grid { display: grid; grid-template-columns: minmax(170px, 0.4fr) 1fr 1fr; gap: 1rem; align-items: start; }
+.review-field { min-width: 0; }
 .field-body { margin-top: 0.5rem; }
-.check-row { display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.35rem 0; color: hsl(var(--muted-foreground)); font-size: 12px; }
+.check-row { display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.3rem 0; color: hsl(var(--muted-foreground)); font-size: 12px; }
 .check-row input { width: auto; margin-top: 0.15rem; accent-color: hsl(var(--brand)); }
-.run-card { border: 1px solid hsl(var(--border)); margin-bottom: 0.6rem; }
+
+/* ---------- Runs ---------- */
+.run-card { border: 1px solid hsl(var(--border)); background: hsl(var(--card)); margin-bottom: 0.75rem; }
 .run-card:last-child { margin-bottom: 0; }
-.run-head, .diff-toolbar { padding: 0.5rem 0.6rem; border-bottom: 1px solid hsl(var(--border)); font-size: 12px; }
+.run-head { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; padding: 0.5rem 0.75rem; border-bottom: 1px solid hsl(var(--border-soft)); font-size: 12px; }
 .stale-run { border-width: 0 0 1px; }
-.run-body { padding: 0.6rem; gap: 0.6rem; }
+.run-body { display: grid; grid-template-columns: minmax(0, 1fr); gap: 0.75rem; padding: 0.75rem; }
 .tail-title { margin-bottom: 0.3rem; }
-.source-line { justify-content: flex-start; margin-bottom: 0.5rem; }
-.prompt-provenance { margin-bottom: 0.5rem; }
+
+/* ---------- Source session ---------- */
 .source-session { display: grid; gap: 0.75rem; }
-.source-session-header, .source-message-header { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
-.source-session-header { border-bottom: 1px solid hsl(var(--border)); padding-bottom: 0.75rem; }
-.source-messages { display: grid; gap: 0.6rem; }
-.source-message { border: 1px solid hsl(var(--border)); background: hsl(var(--background)); min-width: 0; }
-.source-message[data-role="user"] { border-left: 2px solid hsl(var(--brand) / 0.7); }
-.source-message[data-role="assistant"] { background: hsl(var(--muted) / 0.18); }
-.source-message[data-selected="true"] { background: hsl(var(--brand) / 0.08); }
-.source-message-header { border-bottom: 1px solid hsl(var(--border)); padding: 0.45rem 0.6rem; color: hsl(var(--muted-foreground)); font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; }
+.source-session-header { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; border-bottom: 1px solid hsl(var(--border-soft)); padding-bottom: 0.75rem; }
+.source-messages { display: grid; gap: 0.5rem; }
+.source-message { border: 1px solid hsl(var(--border-soft)); background: hsl(var(--background)); min-width: 0; }
+.source-message[data-role="user"] { border-left: 2px solid hsl(var(--brand) / 0.65); }
+.source-message[data-role="assistant"] { background: hsl(var(--muted) / 0.16); }
+.source-message[data-selected="true"] { background: hsl(var(--brand) / 0.07); }
+.source-message-header { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; border-bottom: 1px solid hsl(var(--border-soft)); padding: 0.4rem 0.6rem; color: hsl(var(--muted-foreground)); font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; }
 .source-message-content { margin: 0; max-height: 32rem; overflow: auto; padding: 0.65rem; white-space: pre-wrap; word-break: break-word; color: hsl(var(--foreground)); font: inherit; font-size: 12px; line-height: 1.5; }
+
+/* ---------- Diffs ---------- */
+.source-line { display: flex; align-items: center; justify-content: flex-start; gap: 0.75rem; margin-bottom: 0.6rem; }
+.prompt-provenance { margin-bottom: 0.6rem; }
 .diff-shell { border: 1px solid hsl(var(--border)); background: hsl(var(--background)); }
 .diff-shell.compact .diff-body { max-height: 560px; }
+.diff-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; padding: 0.45rem 0.55rem 0.45rem 0.7rem; border-bottom: 1px solid hsl(var(--border-soft)); font-size: 12px; }
+.diff-actions { display: flex; align-items: center; gap: 0.4rem; }
+.utility-button {
+  display: inline-flex; align-items: center; gap: 0.35rem;
+  padding: 0.3rem 0.55rem; font-size: 11px; line-height: 1;
+  color: hsl(var(--muted-foreground)); background: transparent;
+  border: 1px solid hsl(var(--border)); text-decoration: none;
+}
+.utility-button:hover { color: hsl(var(--foreground)); background: hsl(var(--muted) / 0.6); text-decoration: none; }
+.utility-button svg { width: 13px; height: 13px; fill: none; stroke: currentColor; stroke-width: 1.4; stroke-linecap: square; }
 .diff-body { max-height: min(76vh, 980px); overflow: auto; }
 .patch-files { display: grid; gap: 0.75rem; }
 .diff-shell.expanded { position: fixed; inset: 0; z-index: 50; display: grid; grid-template-rows: auto 1fr; }
 .diff-shell.expanded .diff-body { max-height: none; }
-.empty, .page-state { border: 1px solid hsl(var(--border)); background: hsl(var(--muted) / 0.2); color: hsl(var(--muted-foreground)); padding: 0.75rem; font-size: 12px; }
-.page-state { margin: 1rem; display: grid; gap: 0.75rem; justify-items: start; }
+
+/* ---------- States ---------- */
+.empty, .page-state { border: 1px solid hsl(var(--border-soft)); background: hsl(var(--muted) / 0.18); color: hsl(var(--muted-foreground)); padding: 0.85rem; font-size: 12px; }
+.page-state { margin: 1.25rem; display: grid; gap: 0.75rem; justify-items: start; }
 .brand-button { border-color: hsl(var(--brand) / 0.5); color: hsl(var(--brand)); }
 .primary-button { background: hsl(var(--foreground)); color: hsl(var(--background)); border-color: hsl(var(--foreground)); }
+.primary-button:hover { background: hsl(var(--foreground) / 0.88); color: hsl(var(--background)); }
 diffs-container { display: block; font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace; }
 
+/* ---------- Responsive ---------- */
 @media (max-width: 980px) {
   .main { grid-template-columns: 1fr; }
   .sidebar { border-right: 0; border-bottom: 1px solid hsl(var(--border)); max-height: 55vh; }
   .summary-grid, .run-body, .review-grid { grid-template-columns: 1fr; }
-  .tab-panel { grid-template-columns: minmax(0, 1fr); }
-  .tabs { flex-direction: row; border-right: 0; border-bottom: 1px solid hsl(var(--border)); overflow-x: auto; }
-  .tab { width: auto; border-bottom: 2px solid transparent; border-left: 0; padding: 0.6rem 0.75rem; }
-  .tab[data-active="true"] { border-bottom-color: hsl(var(--brand)); }
+  .stat { border-right: 0; border-bottom: 1px solid hsl(var(--border-soft)); padding: 0.35rem 0; }
+  .stat:last-child { border-bottom: 0; }
   .source-session-header { align-items: flex-start; flex-direction: column; }
   .topbar { align-items: flex-start; }
+  .detail { padding: 0.75rem; }
 }


### PR DESCRIPTION
## Summary

Restructures the task review console so the queue, summary, review form, and patch views are visually calmer and easier to scan. No workflow, data, API, or interaction changes — all filters, keyboard navigation, URL state, diff rendering, and review persistence are unchanged.

## Design

### Review console (`review/src/App.tsx`)

- **Topbar** — tightened from "Task Review Console" with a verbose models line to a compact "Task Review" header with quiet model pills.
- **Sidebar rows** — replaced the 380px-wide heavy queue with flatter 360px rows: smaller badges, result pills instead of full badges for model outcomes, clearer hover/active states.
- **Status badges** — added explicit labels (`Human: Approved`, `Audit: Needs Review`) so the two verdict types stop looking like duplicates. Sidebar versions use compact `H:` / `A:` prefixes.
- **Summary stats** — flattened from four bordered cards into a single row with subtle dividers.
- **Detail tabs** — replaced the 150px vertical tab rail with a horizontal tab strip at the top of the tab panel.
- **Review panel** — wrapped form fields in `review-field` containers; removed the redundant "Audit verdicts are automatic" hint.
- **Diff toolbar** — replaced the floating amber text links with compact neutral buttons that have SVG icons (expand / code-file).
- **Runs view** — changed `run-body` from forced two-column to single-column so agent patches span the full width.
- **Primary button** — added a hover state so "Save Review" doesn't vanish when the mouse is over it.

### Styles (`review/src/styles.css`)

- Introduced `--border-soft` (slightly darker than `--border`) so internal dividers are quieter than outer panel borders.
- Reduced sidebar width from 380px to 360px; removed the outer border on `.counts` and used internal dividers instead.
- Replaced warning full-borders with left-edge indicators.
- Tightened internal padding across panels while increasing top-level detail spacing.
- Reorganized the stylesheet with section comments for readability.

## Validation

- `bun run typecheck:review` — passed (0 errors)
- `bun run build:review` — passed; pre-existing Vite large-chunk warning only
- `git diff --check` — clean
- Visually inspected prompt view, test patch diff view, runs view, and sidebar against real task/result data at 1440×900
