### PR TITLE
Add batched task creation without implicit solver runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ bun install --frozen-lockfile
 
 ## Create a task with the bundled skill
 
-`selfbench create` launches a host Pi session with the bundled task-building skill. With no positional request, the agent inspects merged pull requests, excludes PRs already represented anywhere under the task root (including rejected candidates), ranks unseen changes, and builds the strongest viable task or tasks. It follows the full construction checklist: candidate discovery, prompt provenance, patch split, test selection, validation, and audit. By default it opens an interactive Pi session; pass `--print` for one-shot execution.
+`selfbench create` launches a host Pi session with the bundled task-building skill. With no positional request, the agent inspects merged pull requests, excludes PRs already represented anywhere under the task root (including rejected candidates), ranks unseen changes, and builds the strongest viable task or tasks. It authors the full batch first, then may run deterministic nop/oracle validation and static quality audit. It never runs coding-agent/model solver trials unless explicitly requested; `selfbench run` and coding-model Harbor trials are separate operations. By default it opens an interactive Pi session; pass `--print` for one-shot creation.
 
 ```bash
-# Let Pi discover and choose merged PRs itself.
+# Let Pi discover and choose three merged PRs itself.
 uv run selfbench create \
   --repo ~/code/example-project \
+  --count 3 \
   --provider openai --model gpt-5.5 --thinking high
 
 # Or nominate/scope candidates explicitly.
@@ -58,6 +59,7 @@ uv run selfbench create \
 Flags:
 
 - `--repo <path>`: local clone of the repository being benchmarked (defaults to the current working directory).
+- `-n, --count <number>`: target number of complete benchmark tasks to create; omitted means the agent chooses a reasonable batch size.
 - `--tasks-root <dir>`: authoring task root (default `tasks`).
 - `--provider`, `--model`, `--thinking`: Pi session options for the authoring agent.
 - `--print`: non-interactive mode; process the prompt and exit.
@@ -213,11 +215,11 @@ uv run selfbench report results --tasks tasks
 
 Audit verdicts are:
 
-- `accepted`: validation and quality gates pass, with mixed outcomes across the expected model ladder;
-- `needs_review`: the task executes but has a warning or inconclusive solver signal;
+- `accepted`: validation and static quality gates pass without unresolved warnings;
+- `needs_review`: the task executes but has a static warning requiring judgment;
 - `rejected`: a blocking quality requirement or current validation fails.
 
-Use `--strict` when automation should fail unless every task is accepted. The default audit expects at least two model runs (`openai__gpt-5.5` and `fireworks__glm-5p2`) for solver-signal analysis. Override this list with `--models`.
+Use `--strict` when automation should fail unless every task is accepted. Audit does not require or select coding models. Run Harbor/model trials separately when you want solver signal. To display already-indexed model results as informational signal, pass their result-directory slugs explicitly with `--models`; those outcomes do not change the quality verdict.
 
 ## Review tasks in a browser
 

--- a/src/selfbench/cli.py
+++ b/src/selfbench/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from .create import launch_create_agent
 from .harbor import build_harbor_task
 from .prompt_generation import generate_prompt, save_generated_prompt
-from .quality import DEFAULT_SIGNAL_MODELS, audit_task, format_audit_markdown
+from .quality import audit_task, format_audit_markdown
 from .result_schema import RESULT_SCHEMA_VERSION
 from .review import cmd_review
 from .runner import run_task, save_result, validate_task
@@ -24,6 +24,13 @@ def _model_slug(provider: str, model: str) -> str:
         if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", value):
             raise ValueError(f"{label} must end in a path-safe identifier")
     return f"{provider}__{model_name}"
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
 
 
 def cmd_generate_prompt(args: argparse.Namespace) -> int:
@@ -127,7 +134,7 @@ def cmd_report(args: argparse.Namespace) -> int:
     }
     allowed_task_ids: set[str] | None = None
     if args.verdict:
-        audit_models = args.models or list(DEFAULT_SIGNAL_MODELS)
+        audit_models = args.models or []
         audits = [
             audit_task(task, root, audit_models)
             for task in tasks_by_id.values()
@@ -197,6 +204,7 @@ def cmd_create(args: argparse.Namespace) -> int:
         args.request,
         repo=Path(args.repo) if args.repo else Path.cwd(),
         tasks_root=Path(args.tasks_root),
+        count=args.count,
         provider=args.provider,
         model=args.model,
         thinking=args.thinking,
@@ -210,14 +218,15 @@ def cmd_audit(args: argparse.Namespace) -> int:
     if not task_dirs:
         print("no task dirs found", file=sys.stderr)
         return 1
+    models = args.models or []
     results = [
-        audit_task(load_task(task_dir), Path(args.results), args.models)
+        audit_task(load_task(task_dir), Path(args.results), models)
         for task_dir in task_dirs
     ]
     if args.json:
         print(json.dumps([r.as_dict() for r in results], indent=2))
     else:
-        print(format_audit_markdown(results, args.models))
+        print(format_audit_markdown(results, models))
     return 1 if args.strict and any(r.verdict != "accepted" for r in results) else 0
 
 
@@ -288,8 +297,7 @@ def main() -> None:
     p_audit.add_argument(
         "--models",
         nargs="+",
-        default=list(DEFAULT_SIGNAL_MODELS),
-        help="result subdirs used as the solver-signal ladder",
+        help="optional result subdirs to display as informational solver signal",
     )
     p_audit.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     p_audit.add_argument("--strict", action="store_true", help="exit nonzero unless every task is accepted")
@@ -301,8 +309,7 @@ def main() -> None:
     p_review.add_argument(
         "--models",
         nargs="+",
-        default=list(DEFAULT_SIGNAL_MODELS),
-        help="result subdirs used as the solver-signal ladder",
+        help="optional result subdirs to display as informational solver signal",
     )
     p_review.add_argument("--host", default="127.0.0.1", help="bind host (default: 127.0.0.1)")
     p_review.add_argument("--port", type=int, default=8765, help="bind port (default: 8765)")
@@ -325,6 +332,12 @@ def main() -> None:
     )
     p_create.add_argument("--repo", help="source repository path (defaults to cwd)")
     p_create.add_argument("--tasks-root", default="tasks", help="authoring task root (default: tasks)")
+    p_create.add_argument(
+        "-n",
+        "--count",
+        type=_positive_int,
+        help="target number of complete benchmark tasks to create",
+    )
     p_create.add_argument("--provider", help="Pi provider (e.g. openai, anthropic)")
     p_create.add_argument("--model", help="Pi model ID")
     p_create.add_argument("--thinking", help="Pi thinking level (off, minimal, low, medium, high, xhigh, max)")

--- a/src/selfbench/create.py
+++ b/src/selfbench/create.py
@@ -13,13 +13,26 @@ def build_create_request(
     *,
     repo: Path | None = None,
     tasks_root: Path = Path("tasks"),
+    count: int | None = None,
 ) -> str:
     """Build the initial instruction passed to the task-building agent."""
     tasks_root = tasks_root.expanduser().resolve()
     lines = [
         "Use the loaded selfbench skill to discover and create benchmark tasks.",
         f"Write authoring artifacts under: {tasks_root}",
+        (
+            "After authoring the full batch, deterministic nop/oracle validation and static audit are allowed. "
+            "Do not run benchmark solver trials: never invoke selfbench run or start Harbor with a coding "
+            "agent/model unless the user explicitly asks."
+        ),
     ]
+    if count is not None:
+        if count < 1:
+            raise ValueError("task count must be a positive integer")
+        lines.append(
+            f"Target batch size: {count}. Create exactly {count} complete benchmark "
+            "task directories unless a genuine hard blocker exhausts the viable candidates."
+        )
     if repo is not None:
         repo = repo.expanduser().resolve()
         if not repo.is_dir():
@@ -47,6 +60,7 @@ def launch_create_agent(
     *,
     repo: Path | None = None,
     tasks_root: Path = Path("tasks"),
+    count: int | None = None,
     provider: str | None = None,
     model: str | None = None,
     thinking: str | None = None,
@@ -55,7 +69,7 @@ def launch_create_agent(
     skill_path: Path | None = None,
 ) -> int:
     """Run Pi with the bundled skill and return its exit code."""
-    prompt = build_create_request(request, repo=repo, tasks_root=tasks_root)
+    prompt = build_create_request(request, repo=repo, tasks_root=tasks_root, count=count)
 
     def run(resolved_skill: Path) -> int:
         command = [pi_executable, "--skill", str(resolved_skill)]

--- a/src/selfbench/quality.py
+++ b/src/selfbench/quality.py
@@ -16,9 +16,6 @@ from typing import Any
 from .result_schema import RESULT_SCHEMA_VERSION
 from .task import Task
 
-DEFAULT_SIGNAL_MODELS = ("openai__gpt-5.5", "fireworks__glm-5p2")
-
-
 @dataclass
 class AuditResult:
     task_id: str
@@ -141,27 +138,15 @@ def audit_task(task: Task, results_root: Path, model_slugs: list[str]) -> AuditR
         required_task_fingerprints=task.evaluation_fingerprints,
     )
     solver_signal = _solver_signal(model_results)
-    if any(result == "stale" for result in model_results.values()):
-        warnings.append(
-            "one or more standard model runs use stale benchmark inputs or result schema and must be rerun"
-        )
-    elif solver_signal == "missing":
-        warnings.append("missing one or more standard model runs")
-    elif solver_signal == "single_model":
-        warnings.append("need at least two model runs to measure task signal")
-    elif solver_signal == "all_solved":
-        warnings.append("all standard models solved this task; do not count it in headline signal")
-    elif solver_signal == "none_solved":
-        warnings.append("no standard model solved this task; inspect traces for brittleness or missing context")
 
     warnings = _suppress_reviewed_warnings(warnings, task.quality)
 
     if blockers:
         verdict = "rejected"
-    elif solver_signal == "mixed":
-        verdict = "accepted"
-    else:
+    elif warnings:
         verdict = "needs_review"
+    else:
+        verdict = "accepted"
 
     return AuditResult(
         task_id=task.task_id,
@@ -227,6 +212,8 @@ def _model_results(
 
 def _solver_signal(model_results: dict[str, str]) -> str:
     outcomes = list(model_results.values())
+    if not outcomes:
+        return "not_requested"
     if any(v in {"missing", "unreadable", "stale"} for v in outcomes):
         return "missing"
     solved = sum(v == "pass" for v in outcomes)
@@ -451,11 +438,10 @@ def _suppress_reviewed_warnings(warnings: list[str], quality: dict[str, object])
 
 
 def format_audit_markdown(results: list[AuditResult], model_slugs: list[str]) -> str:
+    headings = ["task", "verdict", "validation", "solver signal", *model_slugs, "notes"]
     lines = [
-        "| task | verdict | validation | solver signal | "
-        + " | ".join(model_slugs)
-        + " | notes |",
-        "|---" * (5 + len(model_slugs)) + "|",
+        "| " + " | ".join(headings) + " |",
+        "|" + "---|" * len(headings),
     ]
     icon = {"pass": "✅", "fail": "❌", "missing": "—", "stale": "⏳", "unreadable": "?"}
     for result in sorted(results, key=lambda r: r.task_id):

--- a/src/selfbench/review.py
+++ b/src/selfbench/review.py
@@ -320,7 +320,7 @@ def cmd_review(args: argparse.Namespace) -> int:
     serve_review_site(
         tasks_root=Path(args.tasks).resolve(),
         results_root=Path(args.results).resolve(),
-        model_slugs=args.models,
+        model_slugs=args.models or [],
         host=args.host,
         port=args.port,
     )

--- a/src/selfbench/skills/selfbench/SKILL.md
+++ b/src/selfbench/skills/selfbench/SKILL.md
@@ -57,8 +57,9 @@ When the user supplies a pull request or commit, evaluate that candidate directl
 
 1. Resolve the repository slug from its `origin` remote and list merged pull requests with `gh`. Start with recent changes and expand the search window if the first batch yields no strong candidates.
 2. Read every `task.json` below the requested task root, including rejected-task directories. Exclude pull requests already represented by `source_pr` or `source_url`; do not retry a known rejection under a new task name unless the user explicitly asks.
-3. Triage unseen pull requests from metadata and changed paths. Prioritize changes that modify separable implementation and test files, have a focused behavioral requirement, are small enough to understand, and are likely reproducible in a clean checkout. Metadata filtering is only a shortlist: inspect the actual diff, test design, and provenance before accepting a candidate.
-4. Rank the shortlist and work through the strongest candidates. Reject weak candidates quickly and continue to the next one. Do not ask the user to nominate a PR unless repository access or another hard blocker prevents autonomous selection.
+3. Triage unseen pull requests from metadata and changed paths. Prioritize changes that modify separable implementation and test files, have a focused behavioral requirement, are small enough to understand, and are likely reproducible in a clean checkout. Metadata filtering is only a shortlist: inspect the actual diff and test design before accepting a candidate.
+4. Search thoroughly for authentic pre-implementation provenance for the whole shortlist before authoring tasks. Check local Pi, Claude Code, Codex, and relaymux sessions, worktree names, implementation journals, linked issues, and other original request artifacts. Read the human turns, not just filenames or keyword hits. Reject candidates whose request cannot be recovered without reconstructing it from the PR, implementation, or tests.
+5. Rank the provenance-backed shortlist and set a batch target `N` before creating anything. Use the user's requested count when supplied; otherwise choose and record a reasonable target from the strong candidates available. Reject weak candidates quickly and continue down the ranking. Do not ask the user to nominate PRs unless repository access or another hard blocker prevents autonomous selection.
 
 For a GitHub repository, a useful initial query is:
 
@@ -129,6 +130,18 @@ A test from the source change is not automatically a valid held-out test. Before
 
 Use at least three meaningful pass-to-pass entries when possible. Avoid broad suites that make every rollout slow when focused package or test-file targets exist.
 
+## Required batch-first ordering
+
+`selfbench create` may author, deterministically validate, and statically audit tasks. It must never run coding-agent/model solver trials unless the user explicitly asks. During creation:
+
+1. For each ranked candidate, complete Steps 2–4 and write the full authoring directory: provenance input, exactly one eval prompt source, `task.json`, `test.patch`, and `gold.patch`.
+2. If a candidate fails provenance, separability, equivalent-design, or reproducibility review while being authored, record the rejection and replace it with the next ranked candidate. Keep going until `N` complete task directories exist or a genuine hard blocker exhausts the viable shortlist.
+3. Do not validate or audit any task until the full target batch has been authored. In particular, do not let an early task's result change which later candidates get created.
+4. Once all `N` task directories exist, validate every task with the deterministic nop/oracle validator, then run the static quality audit. Stop after reporting those results.
+5. Do not invoke `selfbench run` or start Harbor with a coding agent/model. Solver trials are a separate operation that requires an explicit user request.
+
+Static authoring checks such as confirming commits exist, inspecting diffs, checking patch separation, and reviewing test equivalence are part of creation. Deterministic validation may execute task setup and tests only after the batch is fully authored; it does not authorize coding-model evaluation.
+
 Common command templates include:
 
 | Project | Setup | Test command |
@@ -138,9 +151,9 @@ Common command templates include:
 | Bun | `bun install --frozen-lockfile` | `bun test {tests}` |
 | npm | `npm ci` | `npm test -- {tests}` |
 
-## Step 5: validate
+## Step 5: validate and statically audit
 
-Run the gold validator before any model rollouts:
+Run the gold validator after the full batch is authored and before any separately requested model rollouts:
 
 ```bash
 selfbench validate tasks/<task> --repo <local-repo>
@@ -158,17 +171,17 @@ The validator uses separate Docker containers for the base and gold checks. A ro
 
 If validation fails, correct the base commit, patch split, setup command, or test IDs. Do not weaken a legitimate test merely to make the task pass.
 
-Run the quality audit once before spending model calls:
+Run the static quality audit:
 
 ```bash
 selfbench audit tasks/<task> --results results
 ```
 
-Missing rollout signal is expected at this stage, but any blocker about gold-coupled private identifiers must be fixed by replacing the test or rejecting the candidate.
+Audit is independent of coding-model selection. Fix any blocker about gold-coupled private identifiers by replacing the test or rejecting the candidate.
 
-## Step 6: run models
+## Separate operation: optionally run Harbor/model trials
 
-Run at least two representative models so the task has measurable solver signal:
+Do not run coding models as part of task creation unless the user explicitly requests them. When solver signal is wanted, choose the provider/model set for that evaluation and run it separately:
 
 ```bash
 selfbench run tasks/<task> --repo <local-repo> --provider <provider> --model <model>
@@ -176,29 +189,31 @@ selfbench run tasks/<task> --repo <local-repo> --provider <provider> --model <mo
 
 Each rollout receives the resolved engineer prompt, edits a clean snapshot, and produces an agent patch. The grader removes held-out test edits, applies `test.patch`, and runs fail-to-pass plus pass-to-pass tests.
 
-Each run is preserved under `results/<task>/<model>/runs/<run-id>/`; the model directory's top-level `result.json` is only the latest-result compatibility view. Changing task inputs or the result schema makes prior validation and rollout artifacts stale, so rerun validation before interpreting new scores.
+Each run is preserved under `results/<task>/<model>/runs/<run-id>/`; the model directory's top-level `result.json` is only the latest-result compatibility view. Changing task inputs or the result schema makes prior validation and rollout artifacts stale, so rerun validation before interpreting new scores. Pass explicit result-directory slugs to `selfbench audit --models ...` only when informational solver signal should be displayed; model outcomes do not determine the static audit verdict.
 
-## Step 7: audit and review
+## Separate operation: review
 
-Run the quality audit:
+The static audit may be rerun at any time:
 
 ```bash
 selfbench audit tasks/<task> --results results
 ```
 
-Then open the review console:
+Do not open the review console automatically during `selfbench create`. When review is separately requested:
 
 ```bash
 selfbench review --host 0.0.0.0 --port 8765 --tasks tasks --results results
 ```
 
-Check the generated prompt against the human turns in Original Session when a source trace is attached. Then review the patch split, validation tails, rollout output, and model patches. Generated-prompt rollouts must show a current prompt fingerprint; stale results do not count as solver signal. Record any reviewed warnings and rationale in the review panel.
+Check the generated prompt against the human turns in Original Session when a source trace is attached. Then review the patch split and validation tails. If separate Harbor/model trials were run, also review their output and patches; generated-prompt rollouts must show a current prompt fingerprint before their solver signal is interpreted. Record any reviewed warnings and rationale in the review panel.
 
 The final verdicts are:
 
-- `accepted`: validation passes, quality gates pass, and the standard model outcomes are mixed.
-- `needs_review`: the task executes but lacks clean solver signal or has a warning requiring judgment.
+- `accepted`: validation and static quality gates pass without unresolved warnings.
+- `needs_review`: the task executes but has a static warning requiring judgment.
 - `rejected`: validation or a blocking quality requirement fails.
+
+Solver outcomes are reported separately and do not determine these quality verdicts.
 
 ## Quality rules
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -24,6 +24,13 @@ class BuildCreateRequestTest(unittest.TestCase):
         self.assertIn("existing tasks and rejected candidates", result)
         self.assertIn("Do not ask me to nominate PR numbers", result)
 
+    def test_creation_allows_validation_but_stops_before_solver_trials(self) -> None:
+        result = build_create_request([])
+        self.assertIn("deterministic nop/oracle validation and static audit are allowed", result)
+        self.assertIn("Do not run benchmark solver trials", result)
+        self.assertIn("never invoke selfbench run", result)
+        self.assertIn("coding agent/model unless the user explicitly asks", result)
+
     def test_joins_request_segments(self) -> None:
         result = build_create_request(["Create", "a task", "from PR 42"])
         self.assertIn("Create a task from PR 42", result)
@@ -41,6 +48,15 @@ class BuildCreateRequestTest(unittest.TestCase):
     def test_tasks_root_customization(self) -> None:
         result = build_create_request([], tasks_root=Path("my-tasks"))
         self.assertIn("my-tasks", result)
+
+    def test_count_sets_explicit_batch_target(self) -> None:
+        result = build_create_request([], count=4)
+        self.assertIn("Target batch size: 4", result)
+        self.assertIn("exactly 4 complete benchmark task directories", result)
+
+    def test_count_must_be_positive(self) -> None:
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            build_create_request([], count=0)
 
 
 class LaunchCreateAgentTest(unittest.TestCase):
@@ -75,6 +91,15 @@ class LaunchCreateAgentTest(unittest.TestCase):
         self.assertIn("--thinking", command)
         self.assertIn("--print", command)
         self.assertIn(self.root.name, " ".join(command))
+
+    @patch("selfbench.create.subprocess.run")
+    def test_count_is_forwarded_in_prompt(self, run_mock) -> None:
+        run_mock.return_value.returncode = 0
+
+        launch_create_agent([], count=3, print_mode=True)
+
+        prompt = run_mock.call_args.args[0][-1]
+        self.assertIn("Target batch size: 3", prompt)
 
     @patch("selfbench.create.subprocess.run")
     def test_respects_custom_pi_executable(self, run_mock) -> None:

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -102,6 +102,58 @@ class RequestProvenanceTest(unittest.TestCase):
         )
 
 
+class AuditModelIndependenceTest(unittest.TestCase):
+    def test_clean_audit_does_not_require_or_depend_on_model_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            task_dir = root / "task"
+            task_dir.mkdir()
+            (task_dir / "prompt.md").write_text(" ".join(["requirement"] * 100))
+            (task_dir / "test.patch").write_text(
+                "diff --git a/tests/x.py b/tests/x.py\n+def test_expected(): pass\n"
+            )
+            (task_dir / "gold.patch").write_text(
+                "diff --git a/src/x.py b/src/x.py\n+implemented = True\n"
+            )
+            task = Task(
+                task_id="task",
+                repo="example/repo",
+                base_commit="abc123",
+                workdir=".",
+                setup_cmd="true",
+                test_cmd="pytest {tests}",
+                fail_to_pass=["tests/x.py::test_expected"],
+                pass_to_pass=["tests/a.py", "tests/b.py", "tests/c.py"],
+                test_paths=["tests/x.py"],
+                trace_source={"path": "inputs/session.jsonl", "format": "generic"},
+                dir=task_dir,
+            )
+            validation = root / "results" / "task" / "validation" / "result.json"
+            validation.parent.mkdir(parents=True)
+            validation.write_text(json.dumps({
+                "valid": True,
+                "result_schema_version": RESULT_SCHEMA_VERSION,
+                "task_fingerprints": task.evaluation_fingerprints,
+            }))
+
+            without_models = audit_task(task, root / "results", [])
+            self.assertEqual(without_models.verdict, "accepted")
+            self.assertEqual(without_models.solver_signal, "not_requested")
+            self.assertEqual(without_models.model_results, {})
+
+            for slug in ("model-a", "model-b"):
+                result = root / "results" / "task" / slug / "result.json"
+                result.parent.mkdir(parents=True)
+                result.write_text(json.dumps({
+                    "resolved": True,
+                    "result_schema_version": RESULT_SCHEMA_VERSION,
+                    "task_fingerprints": task.evaluation_fingerprints,
+                }))
+            with_models = audit_task(task, root / "results", ["model-a", "model-b"])
+            self.assertEqual(with_models.verdict, "accepted")
+            self.assertEqual(with_models.solver_signal, "all_solved")
+
+
 class ModelResultFreshnessTest(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## Summary
Add explicit batch sizing to `selfbench create` while keeping coding-model solver runs separate and opt-in.

- Support `-n/--count` for exact task batch targets.
- Allow deterministic nop/oracle validation and static audit during creation, but never start solver trials implicitly.
- Remove hard-coded audit model expectations so model outcomes remain informational.

## Design
### Task creation workflow
- `src/selfbench/create.py` — carries the requested count into the Pi authoring prompt and explicitly permits deterministic validation while prohibiting `selfbench run` and coding-model Harbor trials without user approval.
- `src/selfbench/cli.py` — adds positive-integer parsing and the `-n/--count` CLI option.
- `src/selfbench/skills/selfbench/SKILL.md` — requires the full batch to be authored before validation/audit and makes solver trials a separate explicit operation.
- `tests/test_create.py` — covers count validation/forwarding and the boundary between validation and solver execution.

### Quality audit
- `src/selfbench/quality.py` — removes the fixed model ladder, reports `not_requested` when no models are supplied, and derives quality verdicts from validation and static quality findings rather than solver outcomes.
- `src/selfbench/cli.py` and `src/selfbench/review.py` — make `--models` optional and informational for audit, report filtering, and review.
- `tests/test_quality.py` — verifies that clean tasks can be accepted without model runs and that explicit solver results do not change the static quality verdict.

### Documentation
- `README.md` — documents batch sizing, deterministic validation, and the opt-in solver-run boundary.

## Validation
- `uv run python -m unittest discover -s tests -v` — 64 tests passed.
- `uv run python -m compileall -q src/selfbench tests` — passed.
- `git diff --check` — passed.
- Ruff was not available in the project environment, so no Ruff check was run.
