### PR TITLE
Default validation to Modal; keep Docker as explicit override

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ During a rollout, the coding agent receives only a history-free archive of the b
 
 ## Install
 
-You need Python 3.12+, [uv](https://docs.astral.sh/uv/), [Docker](https://www.docker.com/), a local clone of the repository being benchmarked, and an API key for the model provider used by a rollout. [Bun](https://bun.sh/) is required only for the review console.
+You need Python 3.12+, [uv](https://docs.astral.sh/uv/), [Docker](https://www.docker.com/) (for local debugging), a local clone of the repository being benchmarked, and an API key for the model provider used by a rollout. Public validation on the default Modal environment also needs the `modal` extra (`uv sync --extra modal`) and Modal credentials ([Bun](https://bun.sh/) is required only for the review console).
 
 ```bash
 git clone https://github.com/mupt-ai/selfbench.git
@@ -157,10 +157,42 @@ The generator receives the redacted source conversation and basic repository con
 
 ## Validate before running a model
 
-Validation compiles the authoring task into a native Harbor task directory (under `harbor-tasks/`), then runs a **nop** (no-op agent) and an **oracle** (gold patch applied) trial in separate Docker containers:
+Validation compiles the authoring task into a native Harbor task directory (under `harbor-tasks/`), then runs a **nop** (no-op agent) and an **oracle** (gold patch applied) trial as a pair of Harbor trials. It runs on the [Modal](https://modal.com) environment by default so a whole public task set can fan out without contending for a single local Docker daemon; pass `--env docker` (or any other Harbor environment) to debug offline/local. Modal authentication and per-task errors are always surfaced, never hidden:
 
 ```bash
+# Modal is the default environment.
 uv run selfbench validate tasks/example-fix --repo ~/code/example-project
+
+# Local/offline debugging on a single Docker daemon.
+uv run selfbench validate tasks/example-fix --repo ~/code/example-project --env docker
+```
+
+> Modal is an opt-in dependency. Install it with `uv sync --extra modal` and
+> authenticate with `modal token set` (Harbor also accepts `MODAL_TOKEN_ID` and
+> `MODAL_TOKEN_SECRET`). Without the extra, `--env modal` fails immediately
+> with a clear missing-SDK error rather than silently falling back to Docker.
+
+### Validate many tasks at once
+
+`selfbench validate-batch` validates every task under one or more task dirs
+concurrently, skipping tasks that already have a current, valid result. It
+also defaults to Modal, and by default it runs **all** tasks concurrently
+(concurrency = task count); throttle with `--concurrency <n>` or the
+`SELFBENCH_VALIDATION_CONCURRENCY` environment variable. Each task keeps its
+own result and its own log under `--logs` so failures stay attributable:
+
+```bash
+# Run every task in tasks/ at once on Modal. Repos resolve as <repos-root>/<repo name>.
+uv run selfbench validate-batch tasks \
+  --repos-root ~/code --results results
+
+# Throttled local validation with an explicit Docker override.
+SELFBENCH_VALIDATION_CONCURRENCY=4 \
+  uv run selfbench validate-batch tasks \
+  --repos-root ~/code --env docker --results results
+
+# A shell pass-through wrapper with the same defaults and env overrides.
+scripts/validate-batch.sh tasks --repos-root ~/code
 ```
 
 Six checks must all pass:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,16 @@ dependencies = [
     "harbor>=0.20,<0.21",
 ]
 
+[project.optional-dependencies]
+# Modal execution environment for public validation that fans out without a
+# local Docker daemon. Harbor lazily imports the Modal SDK only when
+# `--env modal` is requested, so this extra is opt-in. Install with
+# `uv sync --extra modal`.
+modal = [
+    "modal>=1.5.1",
+    "dockerfile-parse>=2.0.1",
+]
+
 [tool.uv-build]
 package-data = { "selfbench" = ["skills/selfbench/SKILL.md", "review_dist/**/*"] }
 

--- a/scripts/validate-batch.sh
+++ b/scripts/validate-batch.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# validate-batch.sh — validate all selfbench tasks concurrently on Harbor.
+#
+# Defaults to the Modal environment so the whole public task set can fan out
+# without contending for a single local Docker daemon. Set SELFBENCH_ENV
+# (or pass --env) to override, e.g. SELFBENCH_ENV=docker for offline debugging.
+#
+# Concurrency defaults to the number of tasks (run everything at once on
+# Modal). Set SELFBENCH_CONCURRENCY to throttle, e.g. SELFBENCH_CONCURRENCY=4.
+#
+# Idempotent: tasks that already have a current, valid validation result are
+# skipped. Per-task results and per-task logs are preserved.
+#
+# Usage (run from the selfbench repo root):
+#   scripts/validate-batch.sh <tasks-root> \
+#       --repos-root <repos-root> \
+#       [--results <results>] [--jobs <harbor-jobs>] \
+#       [--harbor-tasks <harbor-tasks>] [--logs <logs>] \
+#       [--env <env>] [--concurrency <n>] [--repo-map REPO=PATH ...]
+#
+# Environment overrides:
+#   SELFBENCH_ENV                        Harbor environment (default: modal)
+#   SELFBENCH_CONCURRENCY                tasks to validate concurrently (default: all)
+#   SELFBENCH_VALIDATION_ENV             same as SELFBENCH_ENV
+#   SELFBENCH_VALIDATION_CONCURRENCY     same as SELFBENCH_CONCURRENCY
+set -uo pipefail
+
+args=(validate-batch)
+if [ -n "${SELFBENCH_CONCURRENCY:-${SELFBENCH_VALIDATION_CONCURRENCY:-}}" ]; then
+  args+=(--concurrency "${SELFBENCH_CONCURRENCY:-${SELFBENCH_VALIDATION_CONCURRENCY}}")
+fi
+if [ -n "${SELFBENCH_ENV:-${SELFBENCH_VALIDATION_ENV:-}}" ]; then
+  args+=(--env "${SELFBENCH_ENV:-${SELFBENCH_VALIDATION_ENV}}")
+fi
+# Forward caller-provided flags and the positional task dirs so this wrapper
+# stays a thin pass-through to `selfbench validate-batch`.
+args+=("$@")
+
+exec uv run selfbench "${args[@]}"

--- a/src/selfbench/cli.py
+++ b/src/selfbench/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -14,8 +15,15 @@ from .prompt_generation import generate_prompt, save_generated_prompt
 from .quality import audit_task, format_audit_markdown
 from .result_schema import RESULT_SCHEMA_VERSION
 from .review import cmd_review
-from .runner import run_task, save_result, validate_task
-from .task import load_task
+from .runner import (
+    DEFAULT_ROLLOUT_ENVIRONMENT,
+    DEFAULT_VALIDATION_ENVIRONMENT,
+    run_task,
+    save_result,
+    validate_batch,
+    validate_task,
+)
+from .task import Task, load_task
 
 
 def _model_slug(provider: str, model: str) -> str:
@@ -89,7 +97,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
         Path(args.repo).resolve(),
         harbor_root=Path(args.harbor_tasks),
         jobs_root=Path(args.jobs),
-        environment=args.env,
+        environment=args.env or DEFAULT_VALIDATION_ENVIRONMENT,
         rebuild=args.rebuild,
         verbose=not args.quiet,
     )
@@ -97,6 +105,68 @@ def cmd_validate(args: argparse.Namespace) -> int:
     print(json.dumps({k: result[k] for k in ("task_id", "valid", "checks", "duration_s")}, indent=2))
     print(f"full result: {path}")
     return 0 if result["valid"] else 1
+
+
+def _repo_map(values: list[str]) -> dict[str, Path]:
+    mapping: dict[str, Path] = {}
+    for value in values:
+        key, separator, raw_path = value.partition("=")
+        if not separator or not key or not raw_path:
+            raise ValueError(f"repo mapping must be REPO=PATH, got {value!r}")
+        mapping[key] = Path(raw_path).expanduser().resolve()
+    return mapping
+
+
+def cmd_validate_batch(args: argparse.Namespace) -> int:
+    task_dirs = _iter_task_dirs(args.task_dirs)
+    if not task_dirs:
+        print("no task dirs found", file=sys.stderr)
+        return 1
+
+    tasks = [load_task(task_dir) for task_dir in task_dirs]
+    task_ids = [task.task_id for task in tasks]
+    if len(task_ids) != len(set(task_ids)):
+        print("duplicate task_id in batch", file=sys.stderr)
+        return 1
+
+    try:
+        overrides = _repo_map(args.repo_map or [])
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    repos_root = Path(args.repos_root).expanduser().resolve() if args.repos_root else None
+
+    def repo_for(task: Task) -> Path:
+        if task.repo in overrides:
+            return overrides[task.repo]
+        if repos_root is None:
+            raise ValueError(
+                f"no local repository for {task.repo}; pass --repo-map {task.repo}=PATH "
+                "or --repos-root"
+            )
+        return repos_root / task.repo.rsplit("/", 1)[-1]
+
+    environment = args.env or DEFAULT_VALIDATION_ENVIRONMENT
+    concurrency = args.concurrency or len(tasks)
+    outcomes = validate_batch(
+        tasks,
+        repo_for,
+        results_root=Path(args.results),
+        harbor_root=Path(args.harbor_tasks),
+        jobs_root=Path(args.jobs),
+        environment=environment,
+        concurrency=concurrency,
+        rebuild=True,
+        log_dir=Path(args.logs),
+    )
+    summary = {
+        "environment": environment,
+        "concurrency": concurrency,
+        "tasks": len(tasks),
+        "outcomes": [outcome.as_dict() for outcome in outcomes],
+    }
+    print(json.dumps(summary, indent=2))
+    return 0 if all(outcome.status in {"valid", "skipped"} for outcome in outcomes) else 1
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -110,7 +180,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         agent=args.agent,
         harbor_root=Path(args.harbor_tasks),
         jobs_root=Path(args.jobs),
-        environment=args.env,
+        environment=args.env or DEFAULT_ROLLOUT_ENVIRONMENT,
         rebuild=args.rebuild,
         verbose=not args.quiet,
     )
@@ -230,7 +300,8 @@ def cmd_audit(args: argparse.Namespace) -> int:
     return 1 if args.strict and any(r.verdict != "accepted" for r in results) else 0
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the selfbench CLI argument parser."""
     parser = argparse.ArgumentParser(prog="selfbench", description="benchmark coding agents on your own merged PRs")
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -240,7 +311,14 @@ def main() -> None:
     common.add_argument("--results", default="results", help="lightweight result index (default: results)")
     common.add_argument("--harbor-tasks", default="harbor-tasks", help="compiled Harbor task root")
     common.add_argument("--jobs", default="harbor-jobs", help="canonical Harbor jobs root")
-    common.add_argument("--env", default="docker", help="Harbor environment provider (default: docker)")
+    common.add_argument(
+        "--env",
+        default=None,
+        help=(
+            "Harbor environment provider; per-command default is modal for validate "
+            "and docker for run. Pass docker for local/offline validation."
+        ),
+    )
     common.add_argument("--rebuild", action="store_true", help="rebuild the compiled Harbor task")
     common.add_argument("--quiet", action="store_true", help="suppress per-trial Harbor progress")
 
@@ -271,6 +349,57 @@ def main() -> None:
 
     p_val = sub.add_parser("validate", parents=[common], help="validate with Harbor nop and oracle trials")
     p_val.set_defaults(fn=cmd_validate)
+
+    p_batch = sub.add_parser(
+        "validate-batch",
+        help="validate many tasks concurrently (default environment: Modal)",
+        description=(
+            "Validate every task under the given task dirs concurrently on Harbor. "
+            "Defaults to the Modal environment so the whole public set can fan out "
+            "without a local Docker daemon; pass --env docker to debug offline. "
+            "Tasks that already have a current, valid result are skipped (idempotent). "
+            "Per-task results and logs are preserved."
+        ),
+    )
+    p_batch.add_argument("task_dirs", nargs="+", help="task dir(s), or parent dirs containing task dirs")
+    p_batch.add_argument("--results", default="results", help="results root (default: results)")
+    p_batch.add_argument("--harbor-tasks", default="harbor-tasks", help="compiled Harbor task root")
+    p_batch.add_argument("--jobs", default="harbor-jobs", help="canonical Harbor jobs root")
+    p_batch.add_argument("--logs", default="logs/validate", help="per-task log directory")
+    p_batch.add_argument(
+        "--env",
+        default=os.getenv("SELFBENCH_VALIDATION_ENV", DEFAULT_VALIDATION_ENVIRONMENT),
+        help=(
+            f"Harbor environment provider (default: {DEFAULT_VALIDATION_ENVIRONMENT}; "
+            "use docker for local/offline validation). Also honors SELFBENCH_VALIDATION_ENV."
+        ),
+    )
+    p_batch.add_argument(
+        "--concurrency",
+        type=_positive_int,
+        default=os.getenv("SELFBENCH_VALIDATION_CONCURRENCY"),
+        help=(
+            "how many tasks to validate at once; defaults to the task count (run all "
+            "concurrently). Also honors SELFBENCH_VALIDATION_CONCURRENCY to throttle."
+        ),
+    )
+    p_batch.add_argument(
+        "--repo-map",
+        action="append",
+        metavar="REPO=PATH",
+        help=(
+            "map a task.json repo (e.g. fastapi/fastapi) to a local clone path; "
+            "repeatable. Falls back to --repos-root/<repo name> otherwise."
+        ),
+    )
+    p_batch.add_argument(
+        "--repos-root",
+        help=(
+            "directory of local repo clones, one per task.json repo name "
+            "(e.g. --repos-root ~/code/repos resolves fastapi/fastapi to that dir/fastapi)"
+        ),
+    )
+    p_batch.set_defaults(fn=cmd_validate_batch)
 
     p_run = sub.add_parser("run", parents=[common], help="run one native Harbor agent trial")
     p_run.add_argument("--provider", required=True, help="pi provider, e.g. openai|fireworks")
@@ -354,5 +483,10 @@ def main() -> None:
     )
     p_create.set_defaults(fn=cmd_create)
 
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
     sys.exit(args.fn(args))

--- a/src/selfbench/harbor.py
+++ b/src/selfbench/harbor.py
@@ -103,6 +103,7 @@ def run_harbor_task(
     agent_kwargs: dict[str, str] | None = None,
     agent_env: dict[str, str] | None = None,
     quiet: bool = False,
+    log_path: Path | None = None,
 ) -> HarborRun:
     """Run one native Harbor trial and return its canonical result artifacts."""
     harbor = _require_harbor()
@@ -136,11 +137,24 @@ def run_harbor_task(
     if quiet:
         command.append("--quiet")
 
-    result = subprocess.run(command, text=True, check=False)
+    if log_path is None:
+        result = subprocess.run(command, text=True, check=False)
+    else:
+        log_path = log_path.resolve()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a") as log:
+            result = subprocess.run(
+                command,
+                text=True,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
     job_dir = jobs_root / job_name
     if result.returncode != 0:
+        log_hint = f" Full log: {log_path}." if log_path is not None else ""
         raise RuntimeError(
-            f"Harbor exited {result.returncode}. Partial artifacts, if any: {job_dir}"
+            f"Harbor exited {result.returncode}. Partial artifacts, if any: {job_dir}.{log_hint}"
         )
     return load_harbor_run(job_dir)
 

--- a/src/selfbench/runner.py
+++ b/src/selfbench/runner.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from .harbor import (
     build_harbor_task,
@@ -13,6 +16,7 @@ from .harbor import (
     run_harbor_task,
     validation_result,
 )
+from .result_schema import RESULT_SCHEMA_VERSION
 from .task import Task
 
 # Harbor's built-in Pi agent forwards credentials for openai, anthropic,
@@ -22,6 +26,15 @@ _PROVIDER_ENV_KEYS: dict[str, str] = {
     "fireworks": "FIREWORKS_API_KEY",
 }
 
+# Default Harbor execution environments. Public selfbench validation runs on
+# Modal so a large public task set can fan out without contending for a single
+# Docker daemon; ``docker`` (and ``local`` where Harbor supports it) remain
+# available as explicit overrides for offline/local debugging. Agent rollouts
+# still default to Docker, unchanged, because they are run deliberately and
+# in smaller batches.
+DEFAULT_VALIDATION_ENVIRONMENT = "modal"
+DEFAULT_ROLLOUT_ENVIRONMENT = "docker"
+
 
 def validate_task(
     task: Task,
@@ -29,9 +42,10 @@ def validate_task(
     *,
     harbor_root: Path = Path("harbor-tasks"),
     jobs_root: Path = Path("harbor-jobs"),
-    environment: str = "docker",
+    environment: str = DEFAULT_VALIDATION_ENVIRONMENT,
     rebuild: bool = False,
     verbose: bool = True,
+    log_path: Path | None = None,
 ) -> dict:
     """Validate base failure and oracle success as canonical Harbor trials."""
     harbor_task = build_harbor_task(
@@ -46,6 +60,7 @@ def validate_task(
         agent="nop",
         environment=environment,
         quiet=not verbose,
+        log_path=log_path,
     )
     oracle = run_harbor_task(
         harbor_task,
@@ -53,8 +68,142 @@ def validate_task(
         agent="oracle",
         environment=environment,
         quiet=not verbose,
+        log_path=log_path,
     )
     return validation_result(task, base, oracle)
+
+
+def is_currently_valid(task: Task, results_root: Path) -> bool:
+    """True when an existing validation result is valid and not stale."""
+    path = results_root / task.task_id / "validation" / "result.json"
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return False
+    if data.get("result_schema_version") != RESULT_SCHEMA_VERSION:
+        return False
+    if data.get("task_fingerprints") != task.evaluation_fingerprints:
+        return False
+    return bool(data.get("valid"))
+
+
+@dataclass
+class BatchValidationOutcome:
+    """Per-task outcome for a batch validation run."""
+
+    task_id: str
+    status: str  # "skipped", "valid", "invalid", "error"
+    exit_code: int = 0
+    error: str | None = None
+    result_path: Path | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "task_id": self.task_id,
+            "status": self.status,
+            "exit_code": self.exit_code,
+        }
+        if self.error is not None:
+            data["error"] = self.error
+        if self.result_path is not None:
+            data["result_path"] = str(self.result_path)
+        return data
+
+
+def validate_batch(
+    tasks: list[Task],
+    repo_resolver,
+    *,
+    results_root: Path,
+    harbor_root: Path = Path("harbor-tasks"),
+    jobs_root: Path = Path("harbor-jobs"),
+    environment: str = DEFAULT_VALIDATION_ENVIRONMENT,
+    concurrency: int | None = None,
+    rebuild: bool = True,
+    log_dir: Path | None = None,
+) -> list[BatchValidationOutcome]:
+    """Validate many tasks concurrently, preserving per-task results and logs.
+
+    ``repo_resolver`` maps a task to the local repository path that contains
+    ``base_commit``. It is a callable ``(task: Task) -> Path`` so callers keep
+    control of the task-to-repo mapping (an operational concern, not a
+    selfbench one).
+
+    The default ``environment`` is Modal so the whole public set can fan out
+    without contending for a single local Docker daemon; pass ``docker`` (or
+    any Harbor environment) to debug locally. Modal authentication and
+    per-task errors are surfaced, never hidden.
+
+    ``concurrency`` defaults to ``len(tasks)`` so every task runs at once on
+    Modal; pass a smaller number to throttle. Idempotent: tasks that already
+    have a current, valid result are skipped.
+    """
+    import concurrent.futures as cf
+
+    if concurrency is None:
+        concurrency = max(1, len(tasks))
+    else:
+        concurrency = max(1, int(concurrency))
+    if log_dir is not None:
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+    outcomes: list[BatchValidationOutcome] = []
+
+    def _log(log_file: Path | None, message: str) -> None:
+        if log_file is None:
+            return
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        with log_file.open("a") as handle:
+            handle.write(message + "\n")
+
+    def _one(task: Task) -> BatchValidationOutcome:
+        log_file = (log_dir / f"{task.task_id}.log") if log_dir is not None else None
+        _log(log_file, f"=== validate {task.task_id} start env={environment} {datetime.now(UTC).isoformat()} ===")
+        if is_currently_valid(task, results_root):
+            _log(log_file, f"=== validate {task.task_id} skipped (already valid) ===")
+            return BatchValidationOutcome(
+                task_id=task.task_id,
+                status="skipped",
+                result_path=results_root / task.task_id / "validation" / "result.json",
+            )
+        try:
+            result = validate_task(
+                task,
+                repo_resolver(task),
+                harbor_root=harbor_root,
+                jobs_root=jobs_root,
+                environment=environment,
+                rebuild=rebuild,
+                verbose=False,
+                log_path=log_file,
+            )
+            path = save_result(result, results_root, "validation")
+            status = "valid" if result.get("valid") else "invalid"
+            _log(log_file, f"=== validate {task.task_id} {status} ===")
+            return BatchValidationOutcome(
+                task_id=task.task_id,
+                status=status,
+                exit_code=0 if result.get("valid") else 1,
+                result_path=path,
+            )
+        except Exception as exc:  # noqa: BLE001 - surface in the outcome, do not hide
+            _log(log_file, f"=== validate {task.task_id} ERROR: {type(exc).__name__}: {exc} ===")
+            return BatchValidationOutcome(
+                task_id=task.task_id,
+                status="error",
+                exit_code=2,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    with cf.ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = {pool.submit(_one, task): task for task in tasks}
+        for future in cf.as_completed(futures):
+            outcomes.append(future.result())
+
+    outcomes.sort(key=lambda o: o.task_id)
+    return outcomes
 
 
 def run_task(
@@ -67,7 +216,7 @@ def run_task(
     agent: str = "pi",
     harbor_root: Path = Path("harbor-tasks"),
     jobs_root: Path = Path("harbor-jobs"),
-    environment: str = "docker",
+    environment: str = DEFAULT_ROLLOUT_ENVIRONMENT,
     rebuild: bool = False,
     verbose: bool = True,
 ) -> dict:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,265 @@
+"""CLI-level tests for default execution environments and batch argument handling."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from selfbench.cli import _positive_int, build_parser, cmd_run, cmd_validate, cmd_validate_batch
+
+
+def _valid_result(task_id: str, run_id: str, *, valid: bool = True) -> dict:
+    return {
+        "result_schema_version": "harbor-1",
+        "run_id": run_id,
+        "run_kind": "validation",
+        "task_id": task_id,
+        "valid": valid,
+        "checks": {},
+        "duration_s": 1.0,
+        "resolved": valid,
+        "failure_reasons": [],
+        "fail_to_pass_passed": valid,
+        "pass_to_pass_passed": valid,
+        "agent_exit_ok": True,
+        "agent_patch_applied": valid,
+        "agent_patch": "",
+        "task_fingerprints": {},
+    }
+
+
+class CliEnvironmentDefaultTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.task_dir = self.root / "task"
+        self.task_dir.mkdir()
+        (self.task_dir / "prompt.md").write_text("Fix the observable behavior.")
+        (self.task_dir / "test.patch").write_text("test patch")
+        (self.task_dir / "gold.patch").write_text("gold patch")
+        (self.task_dir / "task.json").write_text(
+            json.dumps(
+                {
+                    "task_id": "example-task",
+                    "repo": "example/repo",
+                    "base_commit": "abc123",
+                    "workdir": ".",
+                    "setup_cmd": "setup",
+                    "test_cmd": "run {tests}",
+                    "fail_to_pass": ["f2p"],
+                    "pass_to_pass": ["p2p"],
+                    "test_paths": ["tests"],
+                }
+            )
+        )
+        self.repo = self.root / "repo"
+        self.repo.mkdir()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _validate_args(self, env: str | None) -> SimpleNamespace:
+        return SimpleNamespace(
+            task_dir=str(self.task_dir),
+            repo=str(self.repo),
+            results=str(self.root / "results"),
+            harbor_tasks=str(self.root / "harbor-tasks"),
+            jobs=str(self.root / "harbor-jobs"),
+            env=env,
+            rebuild=False,
+            quiet=True,
+        )
+
+    @patch("selfbench.cli.validate_task")
+    def test_validate_without_env_defaults_to_modal(self, validate) -> None:
+        validate.return_value = _valid_result("example-task", "run-1")
+
+        rc = cmd_validate(self._validate_args(env=None))
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(validate.call_args.kwargs["environment"], "modal")
+
+    @patch("selfbench.cli.validate_task")
+    def test_validate_explicit_docker_override_is_forwarded(self, validate) -> None:
+        validate.return_value = _valid_result("example-task", "run-1")
+
+        rc = cmd_validate(self._validate_args(env="docker"))
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(validate.call_args.kwargs["environment"], "docker")
+
+    @patch("selfbench.cli.run_task")
+    def test_run_without_env_keeps_docker_default(self, run) -> None:
+        result = _valid_result("example-task", "run-2")
+        result.update({"thinking": None, "provider": "openai", "model": "gpt-test"})
+        run.return_value = result
+
+        args = SimpleNamespace(
+            task_dir=str(self.task_dir),
+            repo=str(self.repo),
+            results=str(self.root / "results"),
+            harbor_tasks=str(self.root / "harbor-tasks"),
+            jobs=str(self.root / "harbor-jobs"),
+            env=None,
+            rebuild=False,
+            quiet=True,
+            provider="openai",
+            model="gpt-test",
+            thinking=None,
+            agent="pi",
+        )
+        rc = cmd_run(args)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(run.call_args.kwargs["environment"], "docker")
+
+    def test_parser_validate_env_flag_accepts_docker(self) -> None:
+        parser = build_parser()
+        ns = parser.parse_args(["validate", str(self.task_dir), "--repo", str(self.repo), "--env", "docker"])
+        self.assertEqual(ns.env, "docker")
+
+
+class CliBatchEnvironmentTest(unittest.TestCase):
+    def test_validate_batch_env_defaults_to_modal(self) -> None:
+        parser = build_parser()
+        ns = parser.parse_args(["validate-batch", "tasks"])
+        self.assertEqual(ns.env, "modal")
+
+    def test_validate_batch_env_override(self) -> None:
+        parser = build_parser()
+        ns = parser.parse_args(["validate-batch", "tasks", "--env", "docker"])
+        self.assertEqual(ns.env, "docker")
+
+    def test_validate_batch_env_var_default(self) -> None:
+        with patch.dict(os.environ, {"SELFBENCH_VALIDATION_ENV": "docker"}):
+            parser = build_parser()
+            ns = parser.parse_args(["validate-batch", "tasks"])
+        self.assertEqual(ns.env, "docker")
+
+    def test_validate_batch_concurrency_defaults_to_none_and_env_can_throttle(self) -> None:
+        parser = build_parser()
+        ns = parser.parse_args(["validate-batch", "tasks"])
+        self.assertIsNone(ns.concurrency)
+
+        with patch.dict(os.environ, {"SELFBENCH_VALIDATION_CONCURRENCY": "4"}):
+            parser = build_parser()
+            ns = parser.parse_args(["validate-batch", "tasks"])
+        self.assertEqual(ns.concurrency, 4)
+
+    def test_validate_batch_rejects_invalid_concurrency(self) -> None:
+        with patch.dict(os.environ, {"SELFBENCH_VALIDATION_CONCURRENCY": "not-a-number"}):
+            parser = build_parser()
+            with self.assertRaises(SystemExit):
+                parser.parse_args(["validate-batch", "tasks"])
+
+    def test_positive_int_rejects_zero_and_negative(self) -> None:
+        for bad in ("0", "-1", "x"):
+            with self.assertRaises(Exception):
+                _positive_int(bad)
+        self.assertEqual(_positive_int("7"), 7)
+
+
+class CliBatchRunTest(unittest.TestCase):
+    def test_cmd_validate_batch_reports_no_tasks(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            args = SimpleNamespace(
+                task_dirs=[str(root)],
+                results=str(root / "results"),
+                harbor_tasks=str(root / "harbor-tasks"),
+                jobs=str(root / "harbor-jobs"),
+                logs=str(root / "logs"),
+                env="modal",
+                concurrency=None,
+                repo_map=None,
+                repos_root=None,
+            )
+            self.assertEqual(cmd_validate_batch(args), 1)
+
+    def test_cmd_validate_batch_without_repos_fails_with_clear_message(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            task_dir = root / "task"
+            task_dir.mkdir()
+            (task_dir / "prompt.md").write_text("Fix the observable behavior.")
+            (task_dir / "test.patch").write_text("test patch")
+            (task_dir / "gold.patch").write_text("gold patch")
+            (task_dir / "task.json").write_text(
+                json.dumps(
+                    {
+                        "task_id": "example-task",
+                        "repo": "example/repo",
+                        "base_commit": "abc123",
+                        "workdir": ".",
+                        "setup_cmd": "setup",
+                        "test_cmd": "run {tests}",
+                        "fail_to_pass": ["f2p"],
+                        "pass_to_pass": ["p2p"],
+                        "test_paths": ["tests"],
+                    }
+                )
+            )
+            args = SimpleNamespace(
+                task_dirs=[str(task_dir)],
+                results=str(root / "results"),
+                harbor_tasks=str(root / "harbor-tasks"),
+                jobs=str(root / "harbor-jobs"),
+                logs=str(root / "logs"),
+                env="modal",
+                concurrency=None,
+                repo_map=None,
+                repos_root=None,
+            )
+            self.assertEqual(cmd_validate_batch(args), 1)
+
+    @patch("selfbench.cli.validate_batch")
+    def test_cmd_validate_batch_defaults_concurrency_to_task_count(self, validate_batch) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            task_dir = root / "task"
+            task_dir.mkdir()
+            (task_dir / "prompt.md").write_text("Fix the observable behavior.")
+            (task_dir / "test.patch").write_text("test patch")
+            (task_dir / "gold.patch").write_text("gold patch")
+            (task_dir / "task.json").write_text(
+                json.dumps(
+                    {
+                        "task_id": "example-task",
+                        "repo": "example/repo",
+                        "base_commit": "abc123",
+                        "workdir": ".",
+                        "setup_cmd": "setup",
+                        "test_cmd": "run {tests}",
+                        "fail_to_pass": ["f2p"],
+                        "pass_to_pass": ["p2p"],
+                        "test_paths": ["tests"],
+                    }
+                )
+            )
+            validate_batch.return_value = [
+                SimpleNamespace(status="valid", task_id="example-task", exit_code=0, error=None, result_path=None, as_dict=lambda: {"status": "valid"})
+            ]
+            args = SimpleNamespace(
+                task_dirs=[str(task_dir)],
+                results=str(root / "results"),
+                harbor_tasks=str(root / "harbor-tasks"),
+                jobs=str(root / "harbor-jobs"),
+                logs=str(root / "logs"),
+                env="modal",
+                concurrency=None,
+                repo_map=["example/repo=" + str(root / "repo")],
+                repos_root=None,
+            )
+            (root / "repo").mkdir()
+            self.assertEqual(cmd_validate_batch(args), 0)
+            self.assertEqual(validate_batch.call_args.kwargs["concurrency"], 1)
+            self.assertEqual(validate_batch.call_args.kwargs["environment"], "modal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,7 +10,16 @@ from unittest.mock import patch
 from selfbench.cli import _model_slug
 from selfbench.harbor import HarborRun, build_harbor_task
 from selfbench.harbor_pi import PI_VERSION, _provider_error
-from selfbench.runner import run_task, save_result, validate_task
+from selfbench.runner import (
+    DEFAULT_ROLLOUT_ENVIRONMENT,
+    DEFAULT_VALIDATION_ENVIRONMENT,
+    BatchValidationOutcome,
+    is_currently_valid,
+    run_task,
+    save_result,
+    validate_batch,
+    validate_task,
+)
 from selfbench.task import Task
 
 AGENT_PATCH = """\
@@ -184,6 +193,371 @@ class HarborRunnerTest(unittest.TestCase):
             run.call_args.kwargs["model"],
             "openrouter/deepseek/deepseek-v4-flash",
         )
+
+
+class EnvironmentDefaultTest(unittest.TestCase):
+    """Validation defaults to Modal; rollouts keep the Docker default."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        task_dir = self.root / "task"
+        task_dir.mkdir()
+        (task_dir / "prompt.md").write_text("Fix the observable behavior with a focused change.")
+        (task_dir / "test.patch").write_text("test patch")
+        (task_dir / "gold.patch").write_text("gold patch")
+        self.task = Task(
+            task_id="example-task",
+            repo="example/repo",
+            base_commit="abc123",
+            workdir=".",
+            setup_cmd="setup",
+            test_cmd="run {tests}",
+            fail_to_pass=["f2p"],
+            pass_to_pass=["p2p"],
+            test_paths=["tests"],
+            dir=task_dir,
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    @patch("selfbench.runner.build_harbor_task", return_value=Path("/tmp/task"))
+    @patch("selfbench.runner.run_harbor_task")
+    def test_validation_defaults_to_modal(self, run, _build) -> None:
+        run.side_effect = [
+            _fake_run(self.root / "base", {"reward": 0, "fail_to_pass": 0, "pass_to_pass": 1}),
+            _fake_run(
+                self.root / "oracle",
+                {"reward": 1, "patch_applied": 1, "fail_to_pass": 1, "pass_to_pass": 1, "deterministic": 1},
+            ),
+        ]
+
+        result = validate_task(self.task, self.root, verbose=False)
+
+        self.assertEqual(DEFAULT_VALIDATION_ENVIRONMENT, "modal")
+        self.assertEqual(
+            [call.kwargs["environment"] for call in run.call_args_list],
+            ["modal", "modal"],
+        )
+        self.assertTrue(result["valid"])
+
+    @patch("selfbench.runner.build_harbor_task", return_value=Path("/tmp/task"))
+    @patch("selfbench.runner.run_harbor_task")
+    def test_validation_docker_override_passes_docker(self, run, _build) -> None:
+        run.side_effect = [
+            _fake_run(self.root / "base", {"reward": 0, "fail_to_pass": 0, "pass_to_pass": 1}),
+            _fake_run(
+                self.root / "oracle",
+                {"reward": 1, "patch_applied": 1, "fail_to_pass": 1, "pass_to_pass": 1, "deterministic": 1},
+            ),
+        ]
+
+        validate_task(self.task, self.root, environment="docker", verbose=False)
+
+        self.assertEqual(
+            [call.kwargs["environment"] for call in run.call_args_list],
+            ["docker", "docker"],
+        )
+
+    @patch("selfbench.runner.build_harbor_task", return_value=Path("/tmp/task"))
+    @patch("selfbench.runner.run_harbor_task")
+    def test_rollout_keeps_docker_default(self, run, _build) -> None:
+        run.return_value = _fake_run(
+            self.root / "rollout",
+            {"reward": 1, "patch_applied": 1, "fail_to_pass": 1, "pass_to_pass": 1, "deterministic": 1},
+        )
+
+        run_task(self.task, self.root, provider="openai", model="gpt-test", agent="pi", verbose=False)
+
+        self.assertEqual(DEFAULT_ROLLOUT_ENVIRONMENT, "docker")
+        self.assertEqual(run.call_args.kwargs["environment"], "docker")
+
+
+class ValidationSkipTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        task_dir = self.root / "task"
+        task_dir.mkdir()
+        (task_dir / "prompt.md").write_text("Fix the observable behavior.")
+        (task_dir / "test.patch").write_text("test patch")
+        (task_dir / "gold.patch").write_text("gold patch")
+        self.task = Task(
+            task_id="example-task",
+            repo="example/repo",
+            base_commit="abc123",
+            workdir=".",
+            setup_cmd="setup",
+            test_cmd="run {tests}",
+            fail_to_pass=["f2p"],
+            pass_to_pass=["p2p"],
+            test_paths=["tests"],
+            dir=task_dir,
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _write_validation(self, *, valid: bool, schema_ok: bool = True, fingerprints_ok: bool = True) -> None:
+        out = self.root / "results" / self.task.task_id / "validation"
+        out.mkdir(parents=True, exist_ok=True)
+        data = {
+            "result_schema_version": "harbor-1" if schema_ok else "legacy",
+            "task_fingerprints": self.task.evaluation_fingerprints if fingerprints_ok else {"definition_sha256": "stale"},
+            "valid": valid,
+        }
+        (out / "result.json").write_text(json.dumps(data))
+
+    def test_missing_result_is_not_current(self) -> None:
+        self.assertFalse(is_currently_valid(self.task, self.root / "results"))
+
+    def test_current_valid_result_is_skippable(self) -> None:
+        self._write_validation(valid=True)
+        self.assertTrue(is_currently_valid(self.task, self.root / "results"))
+
+    def test_invalid_result_is_not_skippable(self) -> None:
+        self._write_validation(valid=False)
+        self.assertFalse(is_currently_valid(self.task, self.root / "results"))
+
+    def test_stale_schema_or_fingerprints_are_not_skippable(self) -> None:
+        self._write_validation(valid=True, schema_ok=False)
+        self.assertFalse(is_currently_valid(self.task, self.root / "results"))
+        self._write_validation(valid=True, fingerprints_ok=False)
+        self.assertFalse(is_currently_valid(self.task, self.root / "results"))
+
+
+class BatchValidationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.tasks: list[Task] = []
+        for index in range(3):
+            task_dir = self.root / "tasks" / f"task-{index}"
+            task_dir.mkdir(parents=True)
+            (task_dir / "prompt.md").write_text(f"Fix task {index}.")
+            (task_dir / "test.patch").write_text("test patch")
+            (task_dir / "gold.patch").write_text("gold patch")
+            self.tasks.append(
+                Task(
+                    task_id=f"task-{index}",
+                    repo=f"example/repo{index}",
+                    base_commit="abc123",
+                    workdir=".",
+                    setup_cmd="setup",
+                    test_cmd="run {tests}",
+                    fail_to_pass=["f2p"],
+                    pass_to_pass=["p2p"],
+                    test_paths=["tests"],
+                    dir=task_dir,
+                )
+            )
+        self.repos = {task.repo: self.root / f"repo{index}" for index, task in enumerate(self.tasks)}
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    @patch("selfbench.runner.validate_task")
+    def test_batch_runs_all_tasks_on_modal_and_saves_results(self, validate) -> None:
+        validate.side_effect = [
+            {
+                "result_schema_version": "harbor-1",
+                "run_id": f"run-{index}",
+                "run_kind": "validation",
+                "task_id": task.task_id,
+                "valid": True,
+                "checks": {},
+                "task_fingerprints": task.evaluation_fingerprints,
+                "duration_s": 1.0,
+            }
+            for index, task in enumerate(self.tasks)
+        ]
+
+        outcomes = validate_batch(
+            self.tasks,
+            lambda task: self.repos[task.repo],
+            results_root=self.root / "results",
+            environment="modal",
+            concurrency=2,
+        )
+
+        self.assertEqual(sorted(o.status for o in outcomes), ["valid", "valid", "valid"])
+        self.assertEqual(validate.call_count, 3)
+        for call in validate.call_args_list:
+            self.assertEqual(call.kwargs["environment"], "modal")
+        for task in self.tasks:
+            result_path = self.root / "results" / task.task_id / "validation" / "result.json"
+            self.assertTrue(result_path.is_file())
+            self.assertTrue(json.loads(result_path.read_text())["valid"])
+
+    @patch("selfbench.runner.validate_task")
+    def test_docker_override_is_forwarded(self, validate) -> None:
+        validate.return_value = {
+            "result_schema_version": "harbor-1",
+            "run_id": "run",
+            "run_kind": "validation",
+            "task_id": self.tasks[0].task_id,
+            "valid": True,
+            "checks": {},
+            "task_fingerprints": self.tasks[0].evaluation_fingerprints,
+            "duration_s": 1.0,
+        }
+
+        validate_batch(
+            self.tasks[:1],
+            lambda task: self.repos[task.repo],
+            results_root=self.root / "results",
+            environment="docker",
+        )
+
+        self.assertEqual(validate.call_args.kwargs["environment"], "docker")
+
+    @patch("selfbench.runner.validate_task")
+    def test_batch_skips_currently_valid_tasks(self, validate) -> None:
+        valid_result = {
+            "result_schema_version": "harbor-1",
+            "run_id": "earlier",
+            "run_kind": "validation",
+            "task_id": self.tasks[0].task_id,
+            "valid": True,
+            "checks": {},
+            "task_fingerprints": self.tasks[0].evaluation_fingerprints,
+            "duration_s": 1.0,
+        }
+        save_result(valid_result, self.root / "results", "validation")
+
+        validate.return_value = valid_result
+        outcomes = validate_batch(
+            self.tasks,
+            lambda task: self.repos[task.repo],
+            results_root=self.root / "results",
+        )
+
+        self.assertIn("skipped", [o.status for o in outcomes])
+        self.assertEqual(validate.call_count, 2)
+
+    @patch("selfbench.runner.validate_task")
+    def test_batch_surfaces_per_task_errors(self, validate) -> None:
+        def _boom(task, local_repo, **kwargs):  # noqa: ARG001 - mock forwards all kwargs
+            if task.task_id == self.tasks[0].task_id:
+                raise RuntimeError("Modal authentication failed")
+            return {
+                "result_schema_version": "harbor-1",
+                "run_id": f"run-{task.task_id}",
+                "run_kind": "validation",
+                "task_id": task.task_id,
+                "valid": True,
+                "checks": {},
+                "task_fingerprints": task.evaluation_fingerprints,
+                "duration_s": 1.0,
+            }
+
+        validate.side_effect = _boom
+        outcomes = validate_batch(
+            self.tasks,
+            lambda task: self.repos[task.repo],
+            results_root=self.root / "results",
+        )
+
+        error = next(o for o in outcomes if o.status == "error")
+        self.assertEqual(error.exit_code, 2)
+        self.assertIn("Modal authentication failed", error.error)
+        self.assertIn("valid", [o.status for o in outcomes])
+
+        # Saves are still written for the successes.
+        self.assertTrue((self.root / "results" / self.tasks[1].task_id / "validation" / "result.json").is_file())
+
+    @patch("selfbench.runner.validate_task")
+    def test_batch_writes_per_task_logs(self, validate) -> None:
+        validate.side_effect = [
+            {
+                "result_schema_version": "harbor-1",
+                "run_id": f"run-{task.task_id}",
+                "run_kind": "validation",
+                "task_id": task.task_id,
+                "valid": True,
+                "checks": {},
+                "task_fingerprints": task.evaluation_fingerprints,
+                "duration_s": 1.0,
+            }
+            for task in self.tasks
+        ]
+
+        log_dir = self.root / "logs"
+        validate_batch(
+            self.tasks,
+            lambda task: self.repos[task.repo],
+            results_root=self.root / "results",
+            log_dir=log_dir,
+        )
+
+        self.assertTrue(log_dir.is_dir())
+        for task in self.tasks:
+            self.assertTrue((log_dir / f"{task.task_id}.log").is_file())
+
+
+class HarborCommandTest(unittest.TestCase):
+    """The modal default must reach the harbor CLI as `--env modal`."""
+
+    @patch("selfbench.harbor.load_harbor_run")
+    @patch("selfbench.harbor.subprocess.run")
+    @patch("selfbench.harbor._require_harbor")
+    def test_run_harbor_task_passes_env_modal_flag(self, _load, run, require) -> None:
+        from pathlib import Path as P
+
+        require.return_value = P("/usr/local/bin/harbor")
+        run.return_value.returncode = 0
+
+        from selfbench.harbor import run_harbor_task
+
+        with tempfile.TemporaryDirectory() as raw:
+            task_dir = Path(raw) / "harbor-tasks" / "task"
+            task_dir.mkdir(parents=True)
+            jobs = Path(raw) / "jobs"
+            run_harbor_task(task_dir, jobs, agent="nop", environment="modal", quiet=True)
+
+        argv = run.call_args.args[0]
+        self.assertIn("--env", argv)
+        self.assertEqual(argv[argv.index("--env") + 1], "modal")
+
+    @patch("selfbench.harbor.load_harbor_run")
+    @patch("selfbench.harbor.subprocess.run")
+    @patch("selfbench.harbor._require_harbor")
+    def test_run_harbor_task_passes_env_docker_flag(self, _load, run, require) -> None:
+        from pathlib import Path as P
+
+        require.return_value = P("/usr/local/bin/harbor")
+        run.return_value.returncode = 0
+
+        from selfbench.harbor import run_harbor_task
+
+        with tempfile.TemporaryDirectory() as raw:
+            task_dir = Path(raw) / "harbor-tasks" / "task"
+            task_dir.mkdir(parents=True)
+            jobs = Path(raw) / "jobs"
+            run_harbor_task(task_dir, jobs, agent="nop", environment="docker", quiet=True)
+
+        argv = run.call_args.args[0]
+        self.assertEqual(argv[argv.index("--env") + 1], "docker")
+
+    @patch("selfbench.harbor.load_harbor_run")
+    @patch("selfbench.harbor.subprocess.run")
+    @patch("selfbench.harbor._require_harbor")
+    def test_run_harbor_task_writes_log_when_requested(self, _load, run, require) -> None:
+        from pathlib import Path as P
+
+        require.return_value = P("/usr/local/bin/harbor")
+        run.return_value.returncode = 0
+
+        from selfbench.harbor import run_harbor_task
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            task_dir = root / "harbor-tasks" / "task"
+            task_dir.mkdir(parents=True)
+            log_path = root / "logs" / "task.log"
+            run_harbor_task(task_dir, root / "jobs", agent="nop", environment="modal", quiet=True, log_path=log_path)
+            self.assertTrue(log_path.is_file())
 
 
 class HarborPiTest(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,46 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/14/b02446bacfe44351b1689c04937ade007588f44570431880a6937e525e6c/cbor2-6.1.4.tar.gz", hash = "sha256:01ecc79a28f33d17331943ce508fc1e21f4b06553c73f874f4c77120d72b2ef9", size = 90840, upload-time = "2026-08-01T20:41:39.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/76/fb64293c19cafb860060310c57b768fd9cfb7cf592449660b756538cc116/cbor2-6.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1fc15061553e4494dc10883237501e3402c645fe509248dd698e1faf2460d68b", size = 404608, upload-time = "2026-08-01T20:40:50.219Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ac/f58b3bafce7c86ada2ad8eaf189453136d2cf5bae526ea0540e1b9bc9d06/cbor2-6.1.4-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d9ada5a6ccfbb8ea7a3aa2aeb028421b52d8e0cd9323f0a2aeaa9c09d25fbce2", size = 449851, upload-time = "2026-08-01T20:40:51.725Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a5/10c6c126d59b07f2bd005094dd12a20afa46146f7e2673ed6f61a57641a7/cbor2-6.1.4-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:310f3dfb296ba48fe9b63c5cf26e691e3548a1eae6901d2f0c18e941d151f220", size = 461193, upload-time = "2026-08-01T20:40:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e4/4445e6237088d1cca3b8536daeb90d6b4e23776de5609c9fa46773874757/cbor2-6.1.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e6c76004d674ad1c620660cb0bc5a8a0b72a5d8c7b70926d8e09e6d7e87332f", size = 516937, upload-time = "2026-08-01T20:40:54.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/87/9c0959510f7a402e5995c81ccfd82cb9f314140dc0cce88c12836e5b93f1/cbor2-6.1.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32a4663425fbca4a4a7aa918eb5789d844c406439e58424cf34511f79f559242", size = 529229, upload-time = "2026-08-01T20:40:56.365Z" },
+    { url = "https://files.pythonhosted.org/packages/91/8e/6811e4ee84203ac657f6f461a37c7c9ba0287bde80eb83c7971e9b3fe156/cbor2-6.1.4-cp312-cp312-win32.whl", hash = "sha256:2310f07db3f9ba26f2a623774ff9f3dc7185af54f732ea119785a6b1bf7e1e7e", size = 278810, upload-time = "2026-08-01T20:40:57.76Z" },
+    { url = "https://files.pythonhosted.org/packages/da/27/87440788fc0d9513534c3c699238e2a9ca6010f8cb72e9c203b7af20a9f6/cbor2-6.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:cc8cd300e236e9797b2e1ce306109dc481fcccf78bfa2682bf36d99e6eab1ec6", size = 299971, upload-time = "2026-08-01T20:40:59.256Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f9/77981e6e63092de19d7306a09a12b0eb3fd2907dc22c10dd5d389eb27faf/cbor2-6.1.4-cp312-cp312-win_arm64.whl", hash = "sha256:553a46bda7d09552631a714e22b91e6ff2c867ecd91511596ce290d8879b8d5b", size = 290662, upload-time = "2026-08-01T20:41:00.89Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/17/0b20c88e76942ede86c98cdce138681690f95908c540c264fff847729cd4/cbor2-6.1.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c48a7c938fc5fa5300ff82b5df09068dcb4838685ae8556b5ee8279d74f97ab4", size = 403677, upload-time = "2026-08-01T20:41:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3d/93eed770864540c5c9ea0841008208e9db686b7335f42520705b7d6dc6b2/cbor2-6.1.4-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:4bd29f21529e279d50fc14f1a811f7b05b4d8e66a7969163cce98983b6817245", size = 449762, upload-time = "2026-08-01T20:41:04.094Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/21/69e4d37f00319b3d37322355aedc83154b4d8b75dc9e9789c06e1fbd8a92/cbor2-6.1.4-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:36ae16d64b1f7b620c1af748e7b6947e20069ef80eee56871c5fbb84cc635905", size = 460420, upload-time = "2026-08-01T20:41:05.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/26/2cfdd5ee826205a88a826bb38b7a572c676ec3efa29574be5cdbd04b4859/cbor2-6.1.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:69978901302ecbc8cda57b520487c5c5240ed217de783eb7728fceb258311d76", size = 516490, upload-time = "2026-08-01T20:41:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d687cd1c2c9f9a986e8552ad1fdbd22411cc86389b5705dba6ec6f7e3226/cbor2-6.1.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad4efa23fee6447e56a269191044e06eb39e809458bcd674e164fe9445feafd0", size = 528810, upload-time = "2026-08-01T20:41:09.144Z" },
+    { url = "https://files.pythonhosted.org/packages/40/08/88cecf20b8825bdd991c47b317415c08ef9e7d5f05a1def9acd346edabde/cbor2-6.1.4-cp313-cp313-win32.whl", hash = "sha256:d2560c2ba6a95904ba2a0ca257af878c4344409d9b46d8e646d8ebb617b1e0dd", size = 278058, upload-time = "2026-08-01T20:41:10.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/67/ba140234a6415c16dcfbe0585ce12f905157b70e9cb1bb63a2b6d5721e70/cbor2-6.1.4-cp313-cp313-win_amd64.whl", hash = "sha256:c08b9c7d2ea013e24a0cb819b872b0119dde404f64a1182c0b24095b7bba781f", size = 299315, upload-time = "2026-08-01T20:41:12.067Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/35d53ff4252a5a85656480d3a81d5a5af823979ccd0c5cac95196a7548a6/cbor2-6.1.4-cp313-cp313-win_arm64.whl", hash = "sha256:598710183daae69cbdeb177a870ec64aa601de8138a61491fd256826d15a860f", size = 289976, upload-time = "2026-08-01T20:41:13.63Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5d/c5374c76471ab41dff4420a276569a56352e83166374fba6f40fd0bde7ad/cbor2-6.1.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24da0a481294ac416e1e369e2d204b2b1d993cbd082d0d99fa3d6f5f27ae5e69", size = 407497, upload-time = "2026-08-01T20:41:15.189Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f9/b9f12a5e24d5ae355e4c0f6d37330a2bbedad3331247a223a51c4cd39d5e/cbor2-6.1.4-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0859a0837e6e2d4fe5f5b849f6475797e4db545da98c19db4b1d3487bd47aa22", size = 452191, upload-time = "2026-08-01T20:41:16.705Z" },
+    { url = "https://files.pythonhosted.org/packages/67/22/8224b01f95a6fe07b1a64082aea34d9f49068392b3de93f5f3a10c73c62e/cbor2-6.1.4-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c0f5f2d6d3b58e44146860c049f3c082207a4005588b8926d51bf937ab66773c", size = 462383, upload-time = "2026-08-01T20:41:18.17Z" },
+    { url = "https://files.pythonhosted.org/packages/92/52/437e4aa4f5df1fb41020d64b3d99a8239f0f99a3a75eb6ffa5cb66004b7f/cbor2-6.1.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:239db0f92d537fd29eaec4e40195fc3b2b48bc34a5887059658162489a9eb6ae", size = 518700, upload-time = "2026-08-01T20:41:19.592Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/2f5ea5bfe0fd800b3739c7df8679bdffa9f7def6b2f2fee064ada1c63e85/cbor2-6.1.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3f4a434c36bb0d33aeb48ddae8e8b673ca7e1f14545ee7cf4a4c7c39380ea9a2", size = 531243, upload-time = "2026-08-01T20:41:21.21Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c6/0beac64cb74cd3217f295f9bb0d64675e1809c683a31ea2a49ac9d4d1504/cbor2-6.1.4-cp314-cp314-win32.whl", hash = "sha256:6abcf072b8c0fdc8ad7902ee26a906cafbf3427d026b662ff21166a253f85e18", size = 285248, upload-time = "2026-08-01T20:41:22.658Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7d/4afa096ddc94049f5a514690891b02a18319e146ceb14465ce30c8340a8b/cbor2-6.1.4-cp314-cp314-win_amd64.whl", hash = "sha256:855764e02dc60ab9413acd044e997c3170000fdea6155d6c43a923a1d966dbe6", size = 313044, upload-time = "2026-08-01T20:41:24.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b5/e614cee861772f6b5c4d926b066d2e7dbc11e220b50ba716ba91e430fb0f/cbor2-6.1.4-cp314-cp314-win_arm64.whl", hash = "sha256:c6b28b928c5f2dbf47dffa12dce9c8e36fe6ac1c1358bc326499c0736263b66f", size = 304088, upload-time = "2026-08-01T20:41:25.431Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/41/3b28184154f6cbf7e47c1b7fb4a7a291c54f27a6f3a0a2f64b078c6a13e1/cbor2-6.1.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7336ff4cb7d161ec43b65eef43bf3e9bcab44bd152efb54dd637b7afe711254f", size = 401042, upload-time = "2026-08-01T20:41:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1a/a8624023b84b41c43a150a89517c104aed0e467bd258866f13be4c3ac0c6/cbor2-6.1.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:8f1019494b0ec81a3df3ebb01b6acb446d5b946fe35845b1726379abd66a71da", size = 445301, upload-time = "2026-08-01T20:41:28.35Z" },
+    { url = "https://files.pythonhosted.org/packages/60/39/07dd0ea957c1f48673d3947f97ee36826efd4a824053dd0ec4df2f0c89d6/cbor2-6.1.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:179a794bf4be1d46ff190695929f65f0b42019c156919846ae539d2a7ec42e54", size = 459816, upload-time = "2026-08-01T20:41:29.839Z" },
+    { url = "https://files.pythonhosted.org/packages/23/8e/2015175132a27c1daed434f671ac6d9c1311461995df47f201307700e0da/cbor2-6.1.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9b904b8d0f4ddac9259197d21d121fae4cb8b555700d65bc12c5d46a2e6c2025", size = 511565, upload-time = "2026-08-01T20:41:31.939Z" },
+    { url = "https://files.pythonhosted.org/packages/82/66/420991095d9473614b205d4c4e40b5d3b9f1ee4410eb3c48c1e902947837/cbor2-6.1.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:71fcf4f237d68bf4445bf45070f36f82b333f2e6a62612aa2c256683b51378a9", size = 527709, upload-time = "2026-08-01T20:41:33.413Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/7c/73057e7a38488a816a0d40ff9e7cd9f418800894582e2e48fb2f47ce66a2/cbor2-6.1.4-cp314-cp314t-win32.whl", hash = "sha256:7deccc50fd0b55c4c7dd265b144c5358a645121e457c0ae3722b5ad59832b257", size = 281462, upload-time = "2026-08-01T20:41:35.127Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/d5db22837cb566de733b9d1c418cdf1912ccb1efc7b179e295430b1d81a2/cbor2-6.1.4-cp314-cp314t-win_amd64.whl", hash = "sha256:f3fc7d15cba4174373df2496070faa4a927fe3ed772130d281808120aec7b61c", size = 309165, upload-time = "2026-08-01T20:41:36.716Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5f/ff2c6da83553a692219a0a62a21b57a27ded4405200e50db758a17fbaf15/cbor2-6.1.4-cp314-cp314t-win_arm64.whl", hash = "sha256:164ca22b509408435b2d8236c80c964e4fc77c085ab034569cd04c40d5cc8883", size = 298386, upload-time = "2026-08-01T20:41:38.392Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -428,6 +468,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.140.7"
 source = { registry = "https://pypi.org/simple" }
@@ -589,6 +638,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
 ]
 
 [[package]]
@@ -981,6 +1043,30 @@ wheels = [
 ]
 
 [[package]]
+name = "modal"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/13/c54908743129b75f9761ebcc767f8de5e5b16e2a0303e171f7ae38d90d4d/modal-1.5.3.tar.gz", hash = "sha256:0551c6fa2386ce78619f1a058eb4dd3ca527a54048952ea870e26704557c76c4", size = 844542, upload-time = "2026-07-23T21:06:49.14Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/5d/834ba7387383077538f28a1d17d2df95d596e225a44a1ea1207ad90977f3/modal-1.5.3-py3-none-any.whl", hash = "sha256:d3fbe1d95321d1e4bdb08140bf42711084d705e7e3de644f7ae55c9b96b6c51d", size = 961068, upload-time = "2026-07-23T21:06:46.866Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1232,6 +1318,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -1672,8 +1773,19 @@ dependencies = [
     { name = "harbor" },
 ]
 
+[package.optional-dependencies]
+modal = [
+    { name = "dockerfile-parse" },
+    { name = "modal" },
+]
+
 [package.metadata]
-requires-dist = [{ name = "harbor", specifier = ">=0.20,<0.21" }]
+requires-dist = [
+    { name = "dockerfile-parse", marker = "extra == 'modal'", specifier = ">=2.0.1" },
+    { name = "harbor", specifier = ">=0.20,<0.21" },
+    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.5.1" },
+]
+provides-extras = ["modal"]
 
 [[package]]
 name = "shellingham"
@@ -1783,6 +1895,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5543f9c270a731320911569202340d15341f72cdba7c/supabase_functions-2.31.0.tar.gz", hash = "sha256:4ad027b3ae3bd28b31233339f4db1da6965affd3546f655b421baf40cee2690f", size = 4683, upload-time = "2026-06-04T13:37:28.878Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/79/1a8162ce7d705381a4f2668c0da68e097b103c1aa701418a31da52905c7b/supabase_functions-2.31.0-py3-none-any.whl", hash = "sha256:3fdc4c4766152bfda63bdd0e286fc8a06f50e1280711fae4a1dfc9b7e9ebabc6", size = 8794, upload-time = "2026-06-04T13:37:28.022Z" },
+]
+
+[[package]]
+name = "synchronicity"
+version = "0.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1c/f51dc54bbd302991026a53f9790735540e0e9e1184e9d5939f02446aa5bc/synchronicity-0.12.5.tar.gz", hash = "sha256:94d96b1d85698e3056b96a793b8c0949af6584e4a7d877fabdeb5385efe230aa", size = 60745, upload-time = "2026-06-18T21:06:23.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/74/ad9b99520f70c0bc3318e582e359d360cfc0f7afd7bf368a7f24013cece7/synchronicity-0.12.5-py3-none-any.whl", hash = "sha256:fdbbb10d437bc08a6b0f814fc66fddd1b58ffed314533d42f1ab555801e781af", size = 41107, upload-time = "2026-06-18T21:06:22.505Z" },
 ]
 
 [[package]]
@@ -1905,6 +2029,24 @@ wheels = [
 ]
 
 [[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1945,6 +2087,92 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Makes Modal the default execution environment for public selfbench validation, with Docker remaining an explicit `--env docker` override for offline/local debugging. Agent rollouts are unchanged (still default to Docker). Adds a repo-owned batch validation launcher so the whole public task set can fan out concurrently on Modal without contending for a single local Docker daemon.

- `selfbench validate` and the new `selfbench validate-batch` default to Modal (`harbor run --env modal`); `--env docker` still works for local debugging.
- Concurrency defaults to the task count (run all tasks at once on Modal) with a `SELFBENCH_VALIDATION_CONCURRENCY` env override to throttle; Modal auth and per-task errors are surfaced, never hidden.

## Design
### Validation default + batch runtime
- `src/selfbench/runner.py` — Added `DEFAULT_VALIDATION_ENVIRONMENT = "modal"` and `DEFAULT_ROLLOUT_ENVIRONMENT = "docker"` (rollouts intentionally unchanged). `validate_task` now defaults to Modal. New `validate_batch()` runs tasks concurrently via a `ThreadPoolExecutor` (default `concurrency = len(tasks)`; smaller number throttles), with idempotent `is_currently_valid()` skip (checks `result_schema_version` + `task_fingerprints` + `valid`), per-task results through the existing `save_result`, per-task logs with start/skip/result/error markers, and `BatchValidationOutcome` that surfaces Modal authentication and per-task errors instead of swallowing them.
- `src/selfbench/harbor.py` — `run_harbor_task` accepts an optional `log_path`; when set, Harbor stdout/stderr is appended to that file and the failure `RuntimeError` points at the full log. Low-level `_docker_run`/cache-mount behavior is left as origin/main (works on both Docker and Modal's DinD).

### CLI + launcher
- `src/selfbench/cli.py` — Per-command `--env` defaults: `validate` resolves to Modal, `run` resolves to Docker (the shared `common` parser default is `None`, so no code path can accidentally pass Docker on the validation path). New `validate-batch` subcommand with `--concurrency`, `--repo-map REPO=PATH`, `--repos-root`, and `SELFBENCH_VALIDATION_ENV`/`SELFBENCH_VALIDATION_CONCURRENCY` env hooks. `main()` split into `build_parser()` + `main()` so arg/env defaults are unit-testable.
- `scripts/validate-batch.sh` — thin pass-through wrapper with the same env-var overrides; an explicit caller `--env` wins over the env-derived default.

### Dependencies + docs
- `pyproject.toml` / `uv.lock` — opt-in `modal` extra (`modal>=1.5.1`, `dockerfile-parse>=2.0.1`). Harbor lazily imports the Modal SDK only when `--env modal` is requested, so the default install stays lean and `--env modal` fails fast with a clear missing-SDK error rather than silently falling back to Docker.
- `README.md` — documents the Modal default, the `--env docker` override, and batch validation.

### Tests
- `tests/test_runner.py` — `EnvironmentDefaultTest` (validate→modal, validate `--env docker`→docker, rollout→docker), `ValidationSkipTest` (missing/invalid/stale-schema/stale-fingerprint), `BatchValidationTest` (modal default + result save, docker override, skip-valid, per-task error surfacing incl. simulated Modal auth failure, per-task logs), `HarborCommandTest` (the `--env modal`/`--env docker` flag reaches the Harbor CLI argv; `log_path` creates the file).
- `tests/test_cli.py` — CLI/parser-level defaults (`validate` env None→resolved modal, `--env docker` override; `run` env None→docker), `validate-batch` default env = modal, env-var override + concurrency default/throttle + invalid-concurrency rejection, `cmd_validate_batch` no-tasks and no-repo failure paths, and concurrency defaulting to the task count.

## Validation
- Clean checkout: `rm -rf .venv && uv sync && uv run python -m unittest discover -s tests` → `Ran 92 tests, OK` (28 new tests added; all 64 pre-existing tests still pass).
- With the modal extra: `uv sync --extra modal && uv run python -m unittest discover -s tests` → `Ran 92 tests, OK`.
- `uv run selfbench validate --help` and `uv run selfbench validate-batch --help` confirm the Modal default and that `--env docker` is accepted.
- Result schema (`harbor-1`) and result paths (`results/<task-id>/validation/...`) are unchanged; `save_result`/`validation_result` are untouched.
- The 81-task public validation run was NOT launched (deferred to a separate operational run per instructions). `/Users/avyay/code/selfbench-tests` task data/results were not modified; its existing `run-validate.sh`/`validate-one.sh` inherit the Modal default automatically because they call `selfbench validate` without `--env`, but were left untouched to keep changes isolated to this repo.
