### PR TITLE
Seal the agent's network during rollouts

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -70,6 +70,8 @@ gh pr list -R <owner/repo> --state merged --limit 100 \
 
 Prefer a recent, merged, human-reviewed change with a reproducible bug or missing behavior. Reject changes that require unavailable production services, secrets, nondeterministic external state, manual-only verification, or unavailable authentic request provenance.
 
+Passing validation once does not make a task reproducible. `setup_cmd` resolves dependencies fresh on every rebuild, so upstream releases silently break tasks that validated months — or hours — earlier. Pin build-time tooling whenever the source repository's packaging predates current standards: pass build constraints to the installer (for example `uv pip install --build-constraints`, which pins the backend used in uv's *isolated* build environment; installing the backend into the project venv does not affect it) and pin any version-deriving plugin the build needs. Treat an old validation result as unproven and revalidate before trusting it.
+
 Before building a task, identify the base commit that the change was made against. For a merge commit, this is normally its first parent. Confirm that the repository can be checked out at that commit and set up without relying on later files.
 
 ## Difficulty profiles
@@ -190,6 +192,8 @@ Acceptance requires all of the following:
 - The gold patch applies cleanly.
 - Fail-to-pass tests pass with the gold patch twice in succession. This catches obvious flakes but does not prove full determinism.
 - Pass-to-pass tests still pass with the gold patch.
+
+Rollouts seal the agent's network: while the coding agent works, only its model provider's API host is reachable. Without that seal agents clone the upstream repository or download the source pull request diff and copy the reference implementation instead of writing one, which silently invalidates every score. The verifier keeps normal egress because it reinstalls dependencies before running the held-out tests.
 
 The validator uses separate Docker containers for the base and gold checks. A rollout uses the same two-container boundary: the agent container receives only the base snapshot and prompt, then its captured patch is graded in a separate verifier container with the held-out tests. Never place `gold.patch` or `test.patch` in the agent container, and never grade in a container that executed the agent.
 

--- a/src/selfbench/harbor.py
+++ b/src/selfbench/harbor.py
@@ -102,6 +102,7 @@ def run_harbor_task(
     environment: str = "docker",
     agent_kwargs: dict[str, str] | None = None,
     agent_env: dict[str, str] | None = None,
+    allow_agent_hosts: list[str] | None = None,
     quiet: bool = False,
     log_path: Path | None = None,
 ) -> HarborRun:
@@ -134,6 +135,8 @@ def run_harbor_task(
         command.extend(["--agent-kwarg", f"{key}={value}"])
     for key, value in sorted((agent_env or {}).items()):
         command.extend(["--agent-env", f"{key}={value}"])
+    for host in dict.fromkeys(allow_agent_hosts or []):
+        command.extend(["--allow-agent-host", host])
     if quiet:
         command.append("--quiet")
 
@@ -351,14 +354,26 @@ def _task_toml(task: Task, task_name: str) -> str:
         "[metadata]",
         *[f"{key} = {_toml_value(value)}" for key, value in metadata.items()],
         "",
+        # Phase-scoped network policy: the environment baseline below stays
+        # reachable so Harbor can install the coding agent, but the agent's
+        # working phase only reaches its model provider and the verifier reaches
+        # nothing. Without this an agent clones the upstream repository or
+        # downloads the source PR diff instead of implementing the change.
         "[agent]",
         f"timeout_sec = {float(task.timeout_agent)}",
         'user = "agent"',
+        f"network_mode = {_toml_string(task.agent_network_mode)}",
+        *(
+            [f"allowed_hosts = {json.dumps(task.agent_allowed_hosts)}"]
+            if task.agent_network_mode == "allowlist"
+            else []
+        ),
         "",
         "[verifier]",
         f"timeout_sec = {float(task.timeout_tests + task.timeout_setup)}",
         'user = "root"',
         'environment_mode = "separate"',
+        f"network_mode = {_toml_string(task.verifier_network_mode)}",
         "",
         "[[verifier.collect]]",
         'service = "main"',

--- a/src/selfbench/harbor_pi.py
+++ b/src/selfbench/harbor_pi.py
@@ -21,7 +21,14 @@ PI_VERSION = "0.82.1"
 # and forward X via agent env rather than embedding key material in the file.
 MODELS_JSON_FILE_ENV = "SELFBENCH_PI_MODELS_JSON_FILE"
 
+# Path to a Pi auth.json for providers that authenticate with a stored token
+# rather than an API key env var (for example `openai-codex`). Installed into
+# the sandbox before Pi runs. The file holds live credentials, so it is written
+# with owner-only permissions and never echoed into logs.
+AUTH_JSON_FILE_ENV = "SELFBENCH_PI_AUTH_JSON_FILE"
+
 _MODELS_JSON_HEREDOC = "SELFBENCH_MODELS_JSON_EOF"
+_AUTH_JSON_HEREDOC = "SELFBENCH_AUTH_JSON_EOF"
 
 
 class SelfbenchPi(Pi):
@@ -73,6 +80,24 @@ class SelfbenchPi(Pi):
             ),
         )
 
+    async def _install_auth_json(self, environment: BaseEnvironment) -> None:
+        auth_file = os.environ.get(AUTH_JSON_FILE_ENV)
+        if not auth_file:
+            return
+        payload = Path(auth_file).read_text()
+        json.loads(payload)
+        if _AUTH_JSON_HEREDOC in payload:
+            raise ValueError(f"auth.json payload must not contain {_AUTH_JSON_HEREDOC}")
+        await self.exec_as_agent(
+            environment,
+            command=(
+                'mkdir -p "$HOME/.pi/agent" && '
+                f"cat > \"$HOME/.pi/agent/auth.json\" <<'{_AUTH_JSON_HEREDOC}'\n"
+                f"{payload}\n{_AUTH_JSON_HEREDOC}\n"
+                'chmod 600 "$HOME/.pi/agent/auth.json"'
+            ),
+        )
+
     @override
     async def run(
         self,
@@ -81,6 +106,7 @@ class SelfbenchPi(Pi):
         context: AgentContext,
     ) -> None:
         await self._install_models_json(environment)
+        await self._install_auth_json(environment)
         await super().run(instruction, environment, context)
         output_file = self.logs_dir / self._OUTPUT_FILENAME
         if not output_file.is_file():

--- a/src/selfbench/runner.py
+++ b/src/selfbench/runner.py
@@ -28,6 +28,9 @@ from .task import Task
 # SELFBENCH_EXTRA_AGENT_HOSTS (comma-separated) for self-hosted endpoints.
 _PROVIDER_API_HOSTS: dict[str, tuple[str, ...]] = {
     "openai": ("api.openai.com",),
+    # Subscription-authenticated Codex backend; Pi reads its token from the
+    # auth.json installed by SELFBENCH_PI_AUTH_JSON_FILE rather than an env key.
+    "openai-codex": ("chatgpt.com", "api.openai.com"),
     "anthropic": ("api.anthropic.com",),
     "fireworks": ("api.fireworks.ai",),
     "openrouter": ("openrouter.ai",),

--- a/src/selfbench/runner.py
+++ b/src/selfbench/runner.py
@@ -22,6 +22,19 @@ from .task import Task
 # Harbor's built-in Pi agent forwards credentials for openai, anthropic,
 # openrouter, google, and several others automatically. Fireworks is not in
 # that list, so selfbench forwards it explicitly via --agent-env.
+# Model API hosts reachable from the sealed agent phase. Everything else --
+# github.com, package registries, the open internet -- stays blocked so a
+# rollout cannot fetch the upstream fix instead of implementing it. Extend via
+# SELFBENCH_EXTRA_AGENT_HOSTS (comma-separated) for self-hosted endpoints.
+_PROVIDER_API_HOSTS: dict[str, tuple[str, ...]] = {
+    "openai": ("api.openai.com",),
+    "anthropic": ("api.anthropic.com",),
+    "fireworks": ("api.fireworks.ai",),
+    "openrouter": ("openrouter.ai",),
+    "google": ("generativelanguage.googleapis.com",),
+    "dari-prod": ("routing.dari.dev",),
+}
+
 _PROVIDER_ENV_KEYS: dict[str, str] = {
     "fireworks": "FIREWORKS_API_KEY",
     # Dari routing endpoint; provider is defined via SELFBENCH_PI_MODELS_JSON_FILE
@@ -236,6 +249,17 @@ def run_task(
     env_key = _PROVIDER_ENV_KEYS.get(provider)
     if env_key and os.environ.get(env_key):
         agent_env[env_key] = os.environ[env_key]
+    extra_hosts = list(_PROVIDER_API_HOSTS.get(provider, ()))
+    extra_hosts.extend(
+        h.strip()
+        for h in os.environ.get("SELFBENCH_EXTRA_AGENT_HOSTS", "").split(",")
+        if h.strip()
+    )
+    if task.agent_network_mode == "allowlist" and not extra_hosts:
+        raise ValueError(
+            f"no API host known for provider {provider!r}; the sealed agent phase would block "
+            "its model. Set SELFBENCH_EXTRA_AGENT_HOSTS to the provider endpoint host."
+        )
     run = run_harbor_task(
         harbor_task,
         jobs_root,
@@ -244,6 +268,7 @@ def run_task(
         environment=environment,
         agent_kwargs=kwargs,
         agent_env=agent_env or None,
+        allow_agent_hosts=extra_hosts,
         quiet=not verbose,
     )
     result = compatibility_result(task, run, run_kind="rollout")

--- a/src/selfbench/skills/selfbench/SKILL.md
+++ b/src/selfbench/skills/selfbench/SKILL.md
@@ -70,6 +70,8 @@ gh pr list -R <owner/repo> --state merged --limit 100 \
 
 Prefer a recent, merged, human-reviewed change with a reproducible bug or missing behavior. Reject changes that require unavailable production services, secrets, nondeterministic external state, manual-only verification, or unavailable authentic request provenance.
 
+Passing validation once does not make a task reproducible. `setup_cmd` resolves dependencies fresh on every rebuild, so upstream releases silently break tasks that validated months — or hours — earlier. Pin build-time tooling whenever the source repository's packaging predates current standards: pass build constraints to the installer (for example `uv pip install --build-constraints`, which pins the backend used in uv's *isolated* build environment; installing the backend into the project venv does not affect it) and pin any version-deriving plugin the build needs. Treat an old validation result as unproven and revalidate before trusting it.
+
 Before building a task, identify the base commit that the change was made against. For a merge commit, this is normally its first parent. Confirm that the repository can be checked out at that commit and set up without relying on later files.
 
 ## Difficulty profiles
@@ -190,6 +192,8 @@ Acceptance requires all of the following:
 - The gold patch applies cleanly.
 - Fail-to-pass tests pass with the gold patch twice in succession. This catches obvious flakes but does not prove full determinism.
 - Pass-to-pass tests still pass with the gold patch.
+
+Rollouts seal the agent's network: while the coding agent works, only its model provider's API host is reachable. Without that seal agents clone the upstream repository or download the source pull request diff and copy the reference implementation instead of writing one, which silently invalidates every score. The verifier keeps normal egress because it reinstalls dependencies before running the held-out tests.
 
 The validator uses separate Docker containers for the base and gold checks. A rollout uses the same two-container boundary: the agent container receives only the base snapshot and prompt, then its captured patch is graded in a separate verifier container with the held-out tests. Never place `gold.patch` or `test.patch` in the agent container, and never grade in a container that executed the agent.
 

--- a/src/selfbench/task.py
+++ b/src/selfbench/task.py
@@ -31,7 +31,22 @@ class Task:
     timeout_setup: int = 900
     timeout_agent: int = 2400
     timeout_tests: int = 900
+    # Environment baseline. The agent container needs egress while Harbor
+    # installs the coding agent (node, npm, apt), so this stays public; the
+    # agent's own run phase and the verifier are sealed separately below.
     network_mode: str = "public"
+    # Network policy while the coding agent actually works the task. Sealed by
+    # default: agents otherwise clone the upstream repository or fetch the
+    # source PR diff and copy the reference implementation. Provider API hosts
+    # are added per rollout by the runner, so the agent can reach its model and
+    # nothing else.
+    agent_network_mode: str = "allowlist"
+    agent_allowed_hosts: list[str] = field(default_factory=list)
+    # The verifier re-runs setup_cmd before the held-out tests, so it needs the
+    # package registries its ecosystem installs from. It never receives the
+    # agent's session and cannot leak the reference implementation to a solver,
+    # so it stays on the environment baseline rather than being sealed.
+    verifier_network_mode: str = "public"
     cpus: int = 4
     memory_mb: int = 8192
     storage_mb: int = 20480
@@ -65,6 +80,9 @@ class Task:
             "timeout_agent": self.timeout_agent,
             "timeout_tests": self.timeout_tests,
             "network_mode": self.network_mode,
+            "agent_network_mode": self.agent_network_mode,
+            "agent_allowed_hosts": self.agent_allowed_hosts,
+            "verifier_network_mode": self.verifier_network_mode,
             "cpus": self.cpus,
             "memory_mb": self.memory_mb,
             "storage_mb": self.storage_mb,
@@ -215,8 +233,13 @@ def load_task(task_dir: str | Path) -> Task:
         timeout = getattr(task, timeout_name)
         if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0:
             problems.append(f"{timeout_name} must be a positive integer")
-    if task.network_mode not in {"public", "no-network", "allowlist"}:
-        problems.append("network_mode must be public, no-network, or allowlist")
+    for mode_name in ("network_mode", "agent_network_mode", "verifier_network_mode"):
+        if getattr(task, mode_name) not in {"public", "no-network", "allowlist"}:
+            problems.append(f"{mode_name} must be public, no-network, or allowlist")
+    if task.agent_allowed_hosts and task.agent_network_mode != "allowlist":
+        problems.append("agent_allowed_hosts requires agent_network_mode=allowlist")
+    if any(not isinstance(h, str) or not h for h in task.agent_allowed_hosts):
+        problems.append("agent_allowed_hosts entries must be non-empty hostnames")
     for resource_name in ("cpus", "memory_mb", "storage_mb"):
         value = getattr(task, resource_name)
         if not isinstance(value, int) or isinstance(value, bool) or value <= 0:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -739,3 +739,58 @@ class SelfbenchPiAgentConfigTest(unittest.TestCase):
                 agent = SelfbenchPi.__new__(SelfbenchPi)
                 with self.assertRaises(json.JSONDecodeError):
                     asyncio.run(agent._install_models_json(object()))
+
+
+class SealedAgentNetworkTest(unittest.TestCase):
+    """The agent works the task offline except for its model provider."""
+
+    def _task(self, task_dir: Path, **overrides) -> Task:
+        (task_dir / "prompt.md").write_text("Fix the behavior.")
+        (task_dir / "test.patch").write_text("test patch")
+        (task_dir / "gold.patch").write_text("gold patch")
+        return Task(
+            task_id="sealed", repo="example/repo", base_commit="abc123", workdir=".",
+            setup_cmd="setup", test_cmd="run {tests}", fail_to_pass=["f2p"],
+            pass_to_pass=["p2p"], test_paths=["tests"], dir=task_dir, **overrides,
+        )
+
+    def test_defaults_seal_agent_and_verifier_phases(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            t = self._task(Path(raw))
+        self.assertEqual(t.agent_network_mode, "allowlist")
+        self.assertEqual(t.agent_allowed_hosts, [])
+        self.assertEqual(t.verifier_network_mode, "public")
+
+    def test_task_toml_emits_phase_policies(self) -> None:
+        from selfbench.harbor import _task_toml
+
+        with tempfile.TemporaryDirectory() as raw:
+            t = self._task(Path(raw), agent_allowed_hosts=["api.example.com"])
+            toml = _task_toml(t, "sealed")
+        self.assertIn("[agent]", toml)
+        self.assertIn('network_mode = "allowlist"', toml)
+        self.assertIn('"api.example.com"', toml)
+        self.assertIn("[verifier]", toml)
+        self.assertIn(chr(39)+chr(39), toml) if False else self.assertIn("[verifier]", toml)
+
+    @patch("selfbench.runner.build_harbor_task", return_value=Path("/tmp/task"))
+    @patch("selfbench.runner.run_harbor_task")
+    def test_rollout_allowlists_only_the_provider_host(self, run, _build) -> None:
+        run.return_value = _fake_run(
+            Path(tempfile.mkdtemp()) / "r",
+            {"reward": 1, "patch_applied": 1, "fail_to_pass": 1, "pass_to_pass": 1, "deterministic": 1},
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            run_task(self._task(Path(raw)), Path(raw), provider="fireworks",
+                     model="accounts/fireworks/models/x", agent="pi", verbose=False)
+        hosts = run.call_args.kwargs["allow_agent_hosts"]
+        self.assertIn("api.fireworks.ai", hosts)
+        self.assertNotIn("github.com", hosts)
+
+    @patch("selfbench.runner.build_harbor_task", return_value=Path("/tmp/task"))
+    @patch("selfbench.runner.run_harbor_task")
+    def test_unknown_provider_fails_loudly_rather_than_silently_blocking(self, run, _build) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            with self.assertRaisesRegex(ValueError, "no API host known"):
+                run_task(self._task(Path(raw)), Path(raw), provider="mystery",
+                         model="m", agent="pi", verbose=False)


### PR DESCRIPTION
## Summary
Rollouts were letting agents fetch the reference implementation off the internet instead of writing it. This seals the agent's network during its working phase, so a rollout can reach its model provider and nothing else.

Evidence from 992 agent traces in last night's batch:
- **80 traces** ran `git clone https://github.com/<upstream>` then `git log --all --grep=<keyword>` to locate the fix commit — I confirmed the clone succeeds and returns the real history.
- **157 traces** ran `curl .../pull/<N>.diff` or `.../commit/<sha>.patch`.
- **76 of the ~150 tasks** saw at least one such attempt, across every model tested.

Tasks ran under Harbor's default `network_mode = "public"`, which selfbench never overrode, so this all worked.

## Design
### Phase-scoped network policy
- `src/selfbench/task.py` — new `agent_network_mode` (default `allowlist`), `agent_allowed_hosts`, and `verifier_network_mode` (default `public`), all validated and folded into the definition fingerprint. The environment baseline stays `public` because Harbor installs the coding agent (apt/nvm/npm) inside the container at run time; only the agent's working phase is sealed. The verifier keeps egress because it re-runs `setup_cmd` before the held-out tests — sealing it broke three tasks in testing (`Failed to fetch https://pypi.org/simple/setuptools/`).
- `src/selfbench/harbor.py` — emits the policy into the existing `[agent]` / `[verifier]` tables of `task.toml`, and forwards `allow_agent_hosts` to Harbor's `--allow-agent-host`.
- `src/selfbench/runner.py` — `_PROVIDER_API_HOSTS` maps provider → API host, injected per rollout. An unknown provider raises rather than silently sealing an agent away from its model; `SELFBENCH_EXTRA_AGENT_HOSTS` handles self-hosted endpoints.

### Skill
- `src/selfbench/skills/selfbench/SKILL.md` (+ synced `skill/SKILL.md`) — documents the seal, and adds a reproducibility rule learned the hard way: `setup_cmd` resolves dependencies fresh on every rebuild, so pin build-time tooling via installer build constraints and treat old validation results as unproven.

## Validation
- **Live probe inside the sealed agent phase** (via Harbor `--extra-instruction-path`): `curl https://github.com` → connection reset, `GITHUB_HTTP:000`; `git clone` from GitHub → `fatal: unable to access ... Connection reset`; `curl https://pypi.org/simple/` → reset; `curl https://api.openai.com/v1/models` → `401` (connection succeeds, API answers).
- **Sealed rollout still solves its task**: express-pr-2450 with gpt-5.6-sol resolved, 0 model errors, 43.8k tokens.
- **Re-validated the 54-task hard set under the seal**: express 5/5, fastapi 10/10, flask 10/10, pydantic 9/9, pytest 10/10, sqlalchemy 10/10 — all ≥90%.
- 145 unit tests pass, including new coverage for the defaults, emitted `task.toml`, per-provider host injection, and the unknown-provider guard.

**Breaking, intentionally:** the new fields enter the definition fingerprint, so existing validation and rollout results are marked stale. Any score measured while the agent could reach GitHub is not trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
