### PR TITLE
Publish selfbench to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  pypi:
+    if: github.repository == 'mupt-ai/selfbench'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/selfbench
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Verify release version
+        run: test "v$(uv version --short)" = "$GITHUB_REF_NAME"
+      - run: uv build
+      - run: uv publish --trusted-publishing always

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # selfbench
 
 [![CI](https://github.com/mupt-ai/selfbench/actions/workflows/ci.yml/badge.svg)](https://github.com/mupt-ai/selfbench/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/mupt-ai/selfbench/blob/main/LICENSE)
 
 Selfbench turns completed repository changes—usually merged pull requests—into reproducible software-engineering evals for [Harbor](https://harborframework.com).
 
@@ -9,35 +9,33 @@ It recovers the original engineering request, separates the implementation from 
 
 ## Quick start
 
-You need Python 3.12+, [uv](https://docs.astral.sh/uv/), an authenticated [GitHub CLI](https://cli.github.com/), and an installed [Pi](https://github.com/earendil-works/pi) CLI. Use Docker for local validation or Modal for remote validation.
+You need Python 3.12+, an authenticated [GitHub CLI](https://cli.github.com/), and an installed [Pi](https://github.com/earendil-works/pi) CLI. Use Docker for local validation or Modal for remote validation.
 
 ```bash
-git clone https://github.com/mupt-ai/selfbench.git
-cd selfbench
-uv sync --locked
+pip install selfbench
 ```
 
-Create one eval from a repository you can clone:
+Create one eval from a local clone whose GitHub remote you can access:
 
 ```bash
-uv run selfbench create --repo ~/code/my-project --count 1 --print
+selfbench create --repo ~/code/my-project --count 1 --print
 ```
 
 Pi inspects merged pull requests, selects a viable change, writes the eval, validates it, and audits its provenance and test design. To target a specific change:
 
 ```bash
-uv run selfbench create --repo ~/code/my-project \
+selfbench create --repo ~/code/my-project \
   "Create an eval from PR 123."
 ```
 
-Creation writes the authoring files to `tasks/TASK_ID`. Validation generates a native Harbor task at `harbor-tasks/TASK_ID`.
+Creation writes authoring files to `tasks/TASK_ID` under your current directory. Validation generates the runnable Harbor task at `harbor-tasks/TASK_ID`.
 
 ## Validate
 
-Validation defaults to Modal. Install its dependencies with `uv sync --locked --extra modal`, or pass `--env docker` to run locally:
+Validation defaults to Modal. Install its dependencies with `pip install "selfbench[modal]"`, or pass `--env docker` to run locally:
 
 ```bash
-uv run selfbench validate tasks/TASK_ID \
+selfbench validate tasks/TASK_ID \
   --repo ~/code/my-project \
   --env docker
 ```
@@ -45,7 +43,7 @@ uv run selfbench validate tasks/TASK_ID \
 You can validate every eval directly below a task root with the same command:
 
 ```bash
-uv run selfbench validate tasks --repo ~/code/my-project --env docker
+selfbench validate tasks --repo ~/code/my-project --env docker
 ```
 
 An eval is valid only when all six checks pass:
@@ -65,7 +63,7 @@ Harbor—not selfbench—owns coding-agent execution and result artifacts:
 
 ```bash
 export OPENAI_API_KEY=...
-uv run harbor run \
+harbor run \
   --path harbor-tasks/TASK_ID \
   --agent pi \
   --model openai/gpt-5.6-sol \
@@ -88,13 +86,13 @@ tasks/<task-id>/
 
 The coding agent receives a history-free snapshot of the base commit and the engineering request. Harbor grades its patch separately with the held-out tests. The agent never receives `gold.patch` or `test.patch`.
 
-See [Authoring evals](docs/authoring-evals.md) for the task schema, manual authoring, provenance rules, and rejection criteria. The bundled [selfbench skill](skill/SKILL.md) contains the complete construction checklist.
+See [Authoring evals](https://github.com/mupt-ai/selfbench/blob/main/docs/authoring-evals.md) for the task schema, manual authoring, provenance rules, and rejection criteria. The bundled [selfbench skill](https://github.com/mupt-ai/selfbench/blob/main/skill/SKILL.md) contains the complete construction checklist.
 
 ## Audit and review
 
 ```bash
-uv run selfbench audit tasks --results results --strict
-uv run selfbench review-coupling tasks/TASK_ID \
+selfbench audit tasks --results results --strict
+selfbench review-coupling tasks/TASK_ID \
   --provider openai --model gpt-5.6-sol
 ```
 
@@ -103,7 +101,7 @@ For provenance and patch review, open the local review console:
 ```bash
 bun install --frozen-lockfile
 bun run build:review
-uv run selfbench review --tasks tasks --results results
+selfbench review --tasks tasks --results results
 ```
 
 ## Data handling
@@ -122,4 +120,4 @@ bun run validate
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
+MIT. See [LICENSE](https://github.com/mupt-ai/selfbench/blob/main/LICENSE).

--- a/docs/authoring-evals.md
+++ b/docs/authoring-evals.md
@@ -108,7 +108,7 @@ Avoid tests coupled to helpers, fields, constants, archive bytes, payload keys, 
 When `trace_source` points to an original coding session, selfbench can generate a redacted user-voice request:
 
 ```bash
-uv run selfbench generate-prompt tasks/example-fix \
+selfbench generate-prompt tasks/example-fix \
   --provider openai \
   --model YOUR_MODEL \
   --confirm-source-upload \
@@ -120,8 +120,8 @@ This sends the redacted source conversation to the selected model provider. It d
 ## Validate and audit
 
 ```bash
-uv run selfbench validate tasks/example-fix --repo ~/code/my-project --env docker
-uv run selfbench audit tasks/example-fix --results results --strict
+selfbench validate tasks/example-fix --repo ~/code/my-project --env docker
+selfbench audit tasks/example-fix --results results --strict
 ```
 
 Validation generates `harbor-tasks/example-fix/` and runs Harbor's `nop` and `oracle` agents in separate environments. The command above runs locally with Docker; omit `--env docker` after installing and authenticating Modal. The static audit checks prompt provenance, patch separation, protected test paths, likely solution leakage, validation freshness, and test coupling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,16 @@ version = "0.2.0"
 description = "Create, validate, and curate private software-engineering evaluations for Harbor"
 readme = "README.md"
 license = "MIT"
+authors = [{ name = "Mupt AI" }]
 requires-python = ">=3.12"
 dependencies = [
     "harbor>=0.20,<0.21",
 ]
+
+[project.urls]
+Homepage = "https://github.com/mupt-ai/selfbench"
+Repository = "https://github.com/mupt-ai/selfbench"
+Issues = "https://github.com/mupt-ai/selfbench/issues"
 
 [project.optional-dependencies]
 # Modal execution environment for public validation that fans out without a

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -212,7 +212,7 @@ Audit is independent of coding-model selection. Fix any blocker about gold-coupl
 Do not run coding models as part of task creation unless the user explicitly requests them. When solver signal is wanted, choose the provider/model set for that evaluation and run it separately:
 
 ```bash
-uv run harbor run \
+harbor run \
   --path harbor-tasks/TASK_ID \
   --agent pi \
   --model openai/gpt-5.6-sol \

--- a/src/selfbench/cli.py
+++ b/src/selfbench/cli.py
@@ -34,8 +34,6 @@ def _positive_int(value: str) -> int:
 def _harbor_run_command(task_dir: Path) -> str:
     return shlex.join(
         [
-            "uv",
-            "run",
             "harbor",
             "run",
             "--path",

--- a/src/selfbench/skills/selfbench/SKILL.md
+++ b/src/selfbench/skills/selfbench/SKILL.md
@@ -212,7 +212,7 @@ Audit is independent of coding-model selection. Fix any blocker about gold-coupl
 Do not run coding models as part of task creation unless the user explicitly requests them. When solver signal is wanted, choose the provider/model set for that evaluation and run it separately:
 
 ```bash
-uv run harbor run \
+harbor run \
   --path harbor-tasks/TASK_ID \
   --agent pi \
   --model openai/gpt-5.6-sol \

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -574,6 +574,8 @@ class HarborCommandTest(unittest.TestCase):
         self.assertIn("thinking=xhigh", command)
         self.assertIn("api.openai.com", command)
         self.assertIn("'harbor-tasks/example task'", command)
+        self.assertTrue(command.startswith("harbor run "))
+        self.assertNotIn("uv run harbor", command)
         self.assertNotIn("selfbench run", command)
 
     def test_discovers_one_task_or_every_direct_child(self) -> None:


### PR DESCRIPTION
## Summary

Publish selfbench as a normal Python package so users can install it without cloning the repository.

- make `pip install selfbench` the primary setup path
- publish GitHub Releases to PyPI through short-lived OIDC credentials
- emit Harbor commands that work outside a uv project checkout

## Design

### Packaging and release

- `pyproject.toml` — add verified Mupt AI ownership and canonical project links to the existing `selfbench` 0.2.0 package metadata
- `.github/workflows/release.yml` — build and publish matching `vX.Y.Z` GitHub Releases through the protected `pypi` environment and PyPI trusted publishing

### Installed CLI experience

- `README.md` — replace clone-first setup and `uv run` examples with the installed `selfbench` and `harbor` executables
- `src/selfbench/cli.py` — print Harbor-native commands that do not depend on a repository-local uv environment
- `tests/test_runner.py` — lock the standalone Harbor command behavior

## Validation

- `UV_PYTHON=3.12 bun run validate` — 141 Python tests passed; review UI typecheck and production build passed
- `uv lock --check` — passed
- `uv build` — built `selfbench-0.2.0` wheel and source distribution
- `uv publish --dry-run` — package files and metadata validated; upload authentication intentionally deferred to GitHub OIDC
- clean Python 3.12 virtual environment — wheel installed and `selfbench --help` reported version 0.2.0
- `git diff --check` and bundled skill-copy comparison — passed
