### PR TITLE
Add configurable task toolchains

### DIFF
--- a/docs/authoring-evals.md
+++ b/docs/authoring-evals.md
@@ -2,6 +2,12 @@
 
 Selfbench evals reproduce one completed software change from the repository state before the implementation. Prefer `selfbench create`; author a task manually only when you already know the change, tests, and authentic source request.
 
+```bash
+selfbench create --repo ~/code/my-project --count 1 --print
+```
+
+`--count 1` requests one complete eval. `--print` runs the authoring agent non-interactively; it still writes the task under `tasks/` and may stay quiet until the agent finishes.
+
 ## Choose a suitable change
 
 A good eval has:
@@ -71,6 +77,7 @@ If a source session needs to be reconstructed into a standalone prompt, keep the
 | `timeout_setup` | no | Setup timeout in seconds; default `900`. |
 | `timeout_agent` | no | Agent timeout in seconds; default `2400`. |
 | `timeout_tests` | no | Test timeout in seconds; default `900`. |
+| `toolchains` | no | Image tools selected from `uv`, `bun`, `go`, `node`, `python`, and `rust`; defaults to `uv`, `bun`, `go`, and `node`. |
 | `network_mode` | no | `public`, `no-network`, or `allowlist`; default `public`. |
 | `agent_network_mode` | no | Network policy while the coding agent works; default `allowlist`. |
 | `agent_allowed_hosts` | no | Extra hosts available during the coding-agent phase. |
@@ -80,6 +87,8 @@ If a source session needs to be reconstructed into a standalone prompt, keep the
 | `storage_mb` | no | Container storage in MB; default `20480`. |
 
 `prompt_source` is required unless `prompt.md` exists. Exactly one of them must define the eval prompt.
+
+Set `toolchains` when the default image does not fit the project, for example `"toolchains": ["python"]`. Selfbench includes dependencies such as `uv` automatically. Selecting only what the eval needs reduces image build time.
 
 ## Split the change
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -168,6 +168,8 @@ Use at least three meaningful pass-to-pass entries when possible. Avoid broad su
 
 Whenever a task is rejected or removed at any stage, move its directory into `tasks/rejected/` (keeping `task.json` with its `source_pr`) instead of deleting it, so later sessions do not retry the candidate. Do not start Harbor with a coding agent/model; solver trials are a separate operation that requires an explicit user request.
 
+Task images include `uv`, `bun`, `go`, and `node` by default. Set `toolchains` in `task.json` to select from those tools plus `python` and `rust`, for example `"toolchains": ["python"]`. Selfbench includes toolchain dependencies automatically. Selecting only what the eval needs reduces image build time. Increase `timeout_setup` when a cold compiled build needs more than 900 seconds.
+
 Common command templates include:
 
 | Project | Setup | Test command |

--- a/src/selfbench/harbor.py
+++ b/src/selfbench/harbor.py
@@ -22,13 +22,15 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from .task import Task
+from .task import Task, resolve_toolchains
 
 HARBOR_SCHEMA_VERSION = "1.4"
 HARBOR_VERSION_RANGE = ">=0.20,<0.21"
-ENVIRONMENT_COMPILER_REVISION = 3
+ENVIRONMENT_COMPILER_REVISION = 4
 _BASE_IMAGE = "ubuntu:24.04"
 _GO_VERSION = "1.25.0"
+_RUST_VERSION = "1.90.0"
+_PYTHON_VERSIONS = "3.12 3.11 3.13"
 _NODE_VERSION = "22.14.0"
 GENERATED_MANIFEST = ".selfbench-manifest.json"
 
@@ -350,34 +352,63 @@ def _task_toml(task: Task, task_name: str) -> str:
     return "\n".join(lines)
 
 
-def _toolchain_layers() -> str:
-    """Install one deterministic toolchain shared by the agent and the verifier.
+_TOOLCHAIN_LAYERS = {
+    "uv": (
+        "RUN curl -LsSf https://astral.sh/uv/install.sh \\\n"
+        "    | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh"
+    ),
+    "bun": "RUN curl -fsSL https://bun.sh/install | env BUN_INSTALL=/usr/local bash",
+    "go": (
+        'RUN arch="$(dpkg --print-architecture)" \\\n'
+        f'    && curl -fsSL "https://go.dev/dl/go{_GO_VERSION}.linux-${{arch}}.tar.gz" \\\n'
+        "    | tar -C /usr/local -xz"
+    ),
+    "node": (
+        'RUN arch="$(dpkg --print-architecture)" \\\n'
+        "    && case \"$arch\" in \\\n"
+        "        arm64) node_arch=arm64 ;; \\\n"
+        "        amd64) node_arch=x64 ;; \\\n"
+        '        *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \\\n'
+        "    esac \\\n"
+        f'    && curl -fsSL "https://nodejs.org/dist/v{_NODE_VERSION}/node-v{_NODE_VERSION}-linux-${{node_arch}}.tar.xz" \\\n'
+        "    | tar -C /usr/local --strip-components=1 -xJ"
+    ),
+    "python": (
+        f"RUN uv python install {_PYTHON_VERSIONS} \\\n"
+        "    && ln -sf /usr/local/bin/python3.12 /usr/local/bin/python3 \\\n"
+        "    && ln -sf /usr/local/bin/python3.12 /usr/local/bin/python \\\n"
+        "    && chmod -R a+rX /usr/local/share/uv/python"
+    ),
+    "rust": (
+        "RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \\\n"
+        f"    | env RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo sh -s -- \\\n"
+        f"        -y --no-modify-path --profile minimal --default-toolchain {_RUST_VERSION} \\\n"
+        "    && chmod -R a+w /usr/local/cargo"
+    ),
+}
+
+
+def _toolchain_layers(names: list[str] | None = None) -> str:
+    """Install the deterministic toolchain shared by the agent and the verifier.
 
     ``PATH`` extends the image default instead of replacing it, so system
-    binaries such as ``useradd`` in ``/usr/sbin`` stay reachable. uv and bun go
-    to ``/usr/local/bin`` so the unprivileged agent user can run them too.
+    binaries such as ``useradd`` in ``/usr/sbin`` stay reachable. Toolchains go
+    to ``/usr/local`` so the unprivileged agent user can run them too.
     """
+    layers = "\n".join(_TOOLCHAIN_LAYERS[name] for name in resolve_toolchains(names))
     return f"""FROM {_BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive \\
     UV_LINK_MODE=copy \\
-    PATH=/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
+    UV_PYTHON_INSTALL_DIR=/usr/local/share/uv/python \\
+    UV_PYTHON_BIN_DIR=/usr/local/bin \\
+    RUSTUP_HOME=/usr/local/rustup \\
+    CARGO_HOME=/usr/local/cargo \\
+    PATH=/usr/local/go/bin:/usr/local/cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
 RUN apt-get update && apt-get install -y --no-install-recommends \\
-    bash build-essential ca-certificates curl git jq passwd unzip xz-utils \\
+    bash build-essential ca-certificates curl git jq passwd pkg-config unzip xz-utils \\
     && rm -rf /var/lib/apt/lists/*
-RUN curl -LsSf https://astral.sh/uv/install.sh \\
-    | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh
-RUN curl -fsSL https://bun.sh/install | env BUN_INSTALL=/usr/local bash
-RUN arch="$(dpkg --print-architecture)" \\
-    && curl -fsSL "https://go.dev/dl/go{_GO_VERSION}.linux-${{arch}}.tar.gz" \\
-    | tar -C /usr/local -xz \\
-    && case "$arch" in \\
-        arm64) node_arch=arm64 ;; \\
-        amd64) node_arch=x64 ;; \\
-        *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \\
-    esac \\
-    && curl -fsSL "https://nodejs.org/dist/v{_NODE_VERSION}/node-v{_NODE_VERSION}-linux-${{node_arch}}.tar.xz" \\
-    | tar -C /usr/local --strip-components=1 -xJ
+{layers}
 """
 
 
@@ -401,7 +432,7 @@ def _environment_dockerfile(task: Task) -> str:
     The collect hook diffs against it, so an agent that rewrites ``/app/.git``
     cannot disguise what it actually changed.
     """
-    return f"""{_toolchain_layers()}
+    return f"""{_toolchain_layers(task.toolchains)}
 RUN useradd --create-home --shell /bin/bash agent
 {_repo_layers(task)}
 RUN git -C /app reset --hard -q HEAD \\
@@ -418,7 +449,7 @@ WORKDIR /app
 
 def _verifier_dockerfile(task: Task) -> str:
     """Verifier image: holds the held-out tests the agent never sees."""
-    return f"""{_toolchain_layers()}
+    return f"""{_toolchain_layers(task.toolchains)}
 {_repo_layers(task)}
 RUN mkdir -p /opt/selfbench && chmod 700 /opt/selfbench
 COPY . /tests/

--- a/src/selfbench/skills/selfbench/SKILL.md
+++ b/src/selfbench/skills/selfbench/SKILL.md
@@ -168,6 +168,8 @@ Use at least three meaningful pass-to-pass entries when possible. Avoid broad su
 
 Whenever a task is rejected or removed at any stage, move its directory into `tasks/rejected/` (keeping `task.json` with its `source_pr`) instead of deleting it, so later sessions do not retry the candidate. Do not start Harbor with a coding agent/model; solver trials are a separate operation that requires an explicit user request.
 
+Task images include `uv`, `bun`, `go`, and `node` by default. Set `toolchains` in `task.json` to select from those tools plus `python` and `rust`, for example `"toolchains": ["python"]`. Selfbench includes toolchain dependencies automatically. Selecting only what the eval needs reduces image build time. Increase `timeout_setup` when a cold compiled build needs more than 900 seconds.
+
 Common command templates include:
 
 | Project | Setup | Test command |

--- a/src/selfbench/task.py
+++ b/src/selfbench/task.py
@@ -10,6 +10,33 @@ from pathlib import Path
 
 from .agent_input import SUPPORTED_FORMATS, extract_prompt, extract_trace
 
+SUPPORTED_TOOLCHAINS = ("uv", "bun", "go", "node", "python", "rust")
+DEFAULT_TOOLCHAINS = ("uv", "bun", "go", "node")
+_TOOLCHAIN_DEPENDENCIES = {"python": ("uv",)}
+
+
+def resolve_toolchains(toolchains: list[str] | None) -> tuple[str, ...]:
+    if toolchains is None:
+        return DEFAULT_TOOLCHAINS
+    if not isinstance(toolchains, list) or not toolchains or any(
+        not isinstance(name, str) or not name for name in toolchains
+    ):
+        raise ValueError("toolchains must be a non-empty list of toolchain names")
+
+    unknown = sorted(set(toolchains) - set(SUPPORTED_TOOLCHAINS))
+    if unknown:
+        raise ValueError(
+            f"unknown toolchain(s): {', '.join(unknown)}; "
+            f"available: {', '.join(SUPPORTED_TOOLCHAINS)}"
+        )
+    if len(toolchains) != len(set(toolchains)):
+        raise ValueError("toolchains must not contain duplicates")
+
+    selected = set(toolchains)
+    for name in toolchains:
+        selected.update(_TOOLCHAIN_DEPENDENCIES.get(name, ()))
+    return tuple(name for name in SUPPORTED_TOOLCHAINS if name in selected)
+
 
 @dataclass
 class Task:
@@ -34,6 +61,8 @@ class Task:
     # Environment baseline. The agent container needs egress while Harbor
     # installs the coding agent (node, npm, apt), so this stays public; the
     # agent's own run phase and the verifier are sealed separately below.
+    # None preserves the historical default toolchain for existing tasks.
+    toolchains: list[str] | None = None
     network_mode: str = "public"
     # Network policy while the coding agent actually works the task. Sealed by
     # default: agents otherwise clone the upstream repository or fetch the
@@ -79,6 +108,11 @@ class Task:
             "timeout_setup": self.timeout_setup,
             "timeout_agent": self.timeout_agent,
             "timeout_tests": self.timeout_tests,
+            **(
+                {"toolchains": list(resolve_toolchains(self.toolchains))}
+                if self.toolchains is not None
+                else {}
+            ),
             "network_mode": self.network_mode,
             "agent_network_mode": self.agent_network_mode,
             "agent_allowed_hosts": self.agent_allowed_hosts,
@@ -233,6 +267,10 @@ def load_task(task_dir: str | Path) -> Task:
         timeout = getattr(task, timeout_name)
         if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0:
             problems.append(f"{timeout_name} must be a positive integer")
+    try:
+        resolve_toolchains(task.toolchains)
+    except ValueError as exc:
+        problems.append(str(exc))
     for mode_name in ("network_mode", "agent_network_mode", "verifier_network_mode"):
         if getattr(task, mode_name) not in {"public", "no-network", "allowlist"}:
             problems.append(f"{mode_name} must be public, no-network, or allowlist")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -18,7 +18,7 @@ from selfbench.runner import (
     validate_batch,
     validate_task,
 )
-from selfbench.task import Task
+from selfbench.task import DEFAULT_TOOLCHAINS, Task
 
 AGENT_PATCH = """\
 diff --git a/src/fix.py b/src/fix.py
@@ -682,10 +682,6 @@ def _fake_run(root: Path, rewards: dict[str, float | int]) -> HarborRun:
     return HarborRun(root, trial, {"trial_results": [result]}, result)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class SelfbenchPiAgentConfigTest(unittest.TestCase):
     def test_thinking_enum_matches_pinned_pi_package(self) -> None:
         from selfbench.harbor_pi import SelfbenchPi
@@ -738,4 +734,90 @@ class SealedAgentNetworkTest(unittest.TestCase):
         self.assertIn('network_mode = "allowlist"', toml)
         self.assertIn('"api.example.com"', toml)
         self.assertIn("[verifier]", toml)
-        self.assertIn(chr(39)+chr(39), toml) if False else self.assertIn("[verifier]", toml)
+
+
+class ConfigurableToolchainTest(unittest.TestCase):
+    def _task(self, task_dir: Path, **kw) -> Task:
+        (task_dir / "prompt.md").write_text("Fix it.")
+        (task_dir / "test.patch").write_text("t")
+        (task_dir / "gold.patch").write_text("g")
+        return Task(
+            task_id="tc", repo="e/r", base_commit="abc", workdir=".", setup_cmd="s",
+            test_cmd="r {tests}", fail_to_pass=["a"], pass_to_pass=["b"],
+            test_paths=["tests"], dir=task_dir, **kw,
+        )
+
+    def test_default_installs_historical_set(self) -> None:
+        from selfbench.harbor import _toolchain_layers
+
+        d = _toolchain_layers(None)
+        self.assertEqual(DEFAULT_TOOLCHAINS, ("uv", "bun", "go", "node"))
+        for marker in ("astral.sh/uv", "bun.sh/install", "go.dev/dl", "nodejs.org"):
+            self.assertIn(marker, d)
+        self.assertNotIn("rustup.rs", d)
+
+    def test_subset_omits_unused_toolchains(self) -> None:
+        from selfbench.harbor import _toolchain_layers
+
+        d = _toolchain_layers(["uv", "rust"])
+        self.assertIn("rustup.rs", d)
+        self.assertNotIn("go.dev/dl", d)
+        self.assertNotIn("nodejs.org", d)
+
+    def test_unknown_toolchain_rejected(self) -> None:
+        from selfbench.harbor import _toolchain_layers
+
+        with self.assertRaisesRegex(ValueError, "unknown toolchain"):
+            _toolchain_layers(["cobol"])
+
+    def test_default_task_keeps_its_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            plain = self._task(Path(raw))
+            explicit = self._task(Path(raw), toolchains=["uv", "rust"])
+            self.assertNotIn("toolchains", json.dumps(plain.evaluation_fingerprints))
+            self.assertNotEqual(
+                plain.evaluation_fingerprints["definition_sha256"],
+                explicit.evaluation_fingerprints["definition_sha256"],
+            )
+
+    def test_toolchain_order_does_not_change_the_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            first = self._task(Path(raw), toolchains=["python"])
+            second = self._task(Path(raw), toolchains=["uv", "python"])
+            self.assertEqual(first.evaluation_fingerprints, second.evaluation_fingerprints)
+
+    def test_dockerfiles_use_the_task_selection(self) -> None:
+        from selfbench.harbor import _environment_dockerfile, _verifier_dockerfile
+
+        with tempfile.TemporaryDirectory() as raw:
+            t = self._task(Path(raw), toolchains=["uv", "rust"])
+            for df in (_environment_dockerfile(t), _verifier_dockerfile(t)):
+                self.assertIn("rustup.rs", df)
+                self.assertNotIn("go.dev/dl", df)
+
+
+class PythonToolchainTest(unittest.TestCase):
+    def test_python_toolchain_installs_interpreters(self) -> None:
+        from selfbench.harbor import _toolchain_layers
+
+        d = _toolchain_layers(["uv", "python"])
+        self.assertIn("uv python install", d)
+        self.assertIn("UV_PYTHON_INSTALL_DIR", d)
+        self.assertIn("/usr/local/bin/python3.12 /usr/local/bin/python", d)
+
+    def test_python_includes_uv(self) -> None:
+        from selfbench.harbor import _toolchain_layers
+
+        dockerfile = _toolchain_layers(["python"])
+        self.assertIn("astral.sh/uv/install.sh", dockerfile)
+        self.assertIn("uv python install", dockerfile)
+
+    def test_uv_is_installed_before_python_regardless_of_order(self) -> None:
+        from selfbench.harbor import _toolchain_layers
+
+        d = _toolchain_layers(["python", "uv"])
+        self.assertLess(d.index("astral.sh/uv/install.sh"), d.index("uv python install"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -124,6 +124,20 @@ class TaskPromptSourceTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "does not match prompt_generation"):
             load_task(self.task_dir)
 
+    def test_rejects_invalid_toolchain_configuration(self) -> None:
+        (self.task_dir / "prompt.md").write_text("Standalone eval prompt")
+        invalid = (
+            ("uv", "non-empty list"),
+            ([], "non-empty list"),
+            (["uv", "uv"], "must not contain duplicates"),
+            (["cobol"], "unknown toolchain"),
+        )
+        for toolchains, message in invalid:
+            with self.subTest(toolchains=toolchains):
+                self.write_task(prompt_source=None, toolchains=toolchains)
+                with self.assertRaisesRegex(ValueError, message):
+                    load_task(self.task_dir)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Let eval authors select only the project toolchains their Harbor task needs, with Python and Rust available beyond the existing defaults.

- Keeps omitted `toolchains` backward-compatible with `uv`, `bun`, `go`, and `node`.
- Resolves dependencies automatically, validates configuration early, and canonicalizes fingerprints.
- Keeps usage detail in the authoring guide and bundled skill rather than expanding the README.

## Design
### Task schema and image compilation
- `src/selfbench/task.py` — adds the supported/default toolchain contract, validates invalid or duplicate selections while loading `task.json`, resolves Python's uv dependency, and fingerprints canonical selections.
- `src/selfbench/harbor.py` — composes agent and verifier Dockerfiles from the selected installers, adds uv-managed Python 3.11–3.13 and Rust 1.90, and bumps the environment compiler revision.

### Authoring and coverage
- `docs/authoring-evals.md` — documents the field, defaults, dependency behavior, and the non-interactive `selfbench create --print` behavior.
- `skill/SKILL.md` and the packaged skill copy — teach task authors to choose the smallest suitable toolchain set and adjust cold-build timeouts when needed.
- `tests/test_runner.py` and `tests/test_task.py` — cover backward-compatible defaults, subsets, dependency resolution, stable fingerprints, early validation, and both generated Dockerfiles.

## Validation
- `UV_PYTHON=3.12 bun run validate` — passed: 151 Python tests, TypeScript checking, and the production review build.
- Cold arm64 Docker build of `_toolchain_layers(["python", "rust"])` — passed.
- Unprivileged container smoke test — Python 3.11/3.12/3.13, uv discovery, rustc 1.90.0, and cargo 1.90.0 passed.
- `UV_PYTHON=3.12 uv run python tests/test_runner.py` — passed: 39 tests, including the tests moved below the module entry point.
- `git diff --check` — passed.
