### PR TITLE
Harden batch validation setup

### DIFF
--- a/src/selfbench/cli.py
+++ b/src/selfbench/cli.py
@@ -16,6 +16,7 @@ from .prompt_generation import generate_prompt, save_generated_prompt
 from .quality import audit_task, format_audit_markdown
 from .review import cmd_review
 from .runner import (
+    DEFAULT_SETUP_FAILURE_THRESHOLD,
     DEFAULT_VALIDATION_ENVIRONMENT,
     save_result,
     validate_batch,
@@ -187,6 +188,12 @@ def cmd_validate_batch(args: argparse.Namespace) -> int:
 
     environment = args.env or DEFAULT_VALIDATION_ENVIRONMENT
     concurrency = args.concurrency or len(tasks)
+    preflight = getattr(args, "preflight", True) and environment == "modal"
+    setup_failure_threshold = getattr(
+        args,
+        "setup_failure_threshold",
+        DEFAULT_SETUP_FAILURE_THRESHOLD,
+    )
     outcomes = validate_batch(
         tasks,
         repo_for,
@@ -197,10 +204,14 @@ def cmd_validate_batch(args: argparse.Namespace) -> int:
         concurrency=concurrency,
         rebuild=True,
         log_dir=Path(args.logs),
+        preflight=preflight,
+        setup_failure_threshold=setup_failure_threshold,
     )
     summary = {
         "environment": environment,
         "concurrency": concurrency,
+        "preflight": preflight,
+        "setup_failure_threshold": setup_failure_threshold,
         "tasks": len(tasks),
         "outcomes": [outcome.as_dict() for outcome in outcomes],
     }
@@ -403,7 +414,25 @@ def build_parser() -> argparse.ArgumentParser:
             "(e.g. --repos-root ~/code/repos resolves fastapi/fastapi to that dir/fastapi)"
         ),
     )
-    p_batch.set_defaults(fn=cmd_validate_batch)
+    p_batch.add_argument(
+        "--no-preflight",
+        dest="preflight",
+        action="store_false",
+        help=(
+            "skip the local Docker image-build preflight for Modal batches (not "
+            "recommended; it avoids spending Modal jobs on broken task setup)"
+        ),
+    )
+    p_batch.add_argument(
+        "--setup-failure-threshold",
+        type=_positive_int,
+        default=DEFAULT_SETUP_FAILURE_THRESHOLD,
+        help=(
+            "block the remaining tasks for a repository after this many canaries have "
+            "the same setup failure (default: %(default)s)"
+        ),
+    )
+    p_batch.set_defaults(fn=cmd_validate_batch, preflight=True)
 
     p_couple = sub.add_parser(
         "review-coupling",

--- a/src/selfbench/harbor.py
+++ b/src/selfbench/harbor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -26,7 +27,7 @@ from .task import Task
 
 HARBOR_SCHEMA_VERSION = "1.4"
 HARBOR_VERSION_RANGE = ">=0.20,<0.21"
-ENVIRONMENT_COMPILER_REVISION = 3
+ENVIRONMENT_COMPILER_REVISION = 4
 _BASE_IMAGE = "ubuntu:24.04"
 _GO_VERSION = "1.25.0"
 _NODE_VERSION = "22.14.0"
@@ -67,6 +68,7 @@ def build_harbor_task(
     output_root = output_root.resolve()
     _check_commit(local_repo, task.base_commit)
     task_name = f"{_harbor_name(org)}/{_harbor_name(task.task_id)}"
+    package_manager = _package_manager_spec(local_repo, task.base_commit)
     destination = output_root / task.task_id
     if destination.exists() and not overwrite:
         manifest = _read_json(destination / GENERATED_MANIFEST)
@@ -83,7 +85,7 @@ def build_harbor_task(
     output_root.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix=f".{task.task_id}-", dir=output_root))
     try:
-        _write_harbor_task(staging, task, local_repo, task_name)
+        _write_harbor_task(staging, task, local_repo, task_name, package_manager)
         if destination.exists():
             shutil.rmtree(destination)
         staging.replace(destination)
@@ -209,6 +211,7 @@ def validation_result(task: Task, base: HarborRun, oracle: HarborRun) -> dict[st
         "gold_patch_applies": float(gold_rewards.get("patch_applied", 0)) >= 1,
     }
     infrastructure_errors = {}
+    setup_failures = {}
     for name, run in (("base", base), ("oracle", oracle)):
         exc = run.exception
         if exc is not None:
@@ -216,6 +219,11 @@ def validation_result(task: Task, base: HarborRun, oracle: HarborRun) -> dict[st
                 f"{exc.get('exception_type', 'Harbor error')}: "
                 f"{exc.get('exception_message', '')}".rstrip()
             )
+        if (
+            float(run.rewards.get("patch_applied", 1)) >= 1
+            and float(run.rewards.get("setup_completed", 1)) == 0
+        ):
+            setup_failures[name] = _setup_failure_signature(run)
     return {
         "result_schema_version": "harbor-1",
         "run_id": f"{base.trial_result.get('id')}+{oracle.trial_result.get('id')}",
@@ -224,6 +232,7 @@ def validation_result(task: Task, base: HarborRun, oracle: HarborRun) -> dict[st
         "valid": all(checks.values()),
         "checks": checks,
         **({"infrastructure_errors": infrastructure_errors} if infrastructure_errors else {}),
+        **({"setup_failures": setup_failures} if setup_failures else {}),
         "task_fingerprints": task.evaluation_fingerprints,
         "harbor": {
             "version_range": HARBOR_VERSION_RANGE,
@@ -242,7 +251,13 @@ def validation_result(task: Task, base: HarborRun, oracle: HarborRun) -> dict[st
     }
 
 
-def _write_harbor_task(root: Path, task: Task, local_repo: Path, task_name: str) -> None:
+def _write_harbor_task(
+    root: Path,
+    task: Task,
+    local_repo: Path,
+    task_name: str,
+    package_manager: str | None,
+) -> None:
     environment = root / "environment"
     solution = root / "solution"
     tests = root / "tests"
@@ -258,8 +273,8 @@ def _write_harbor_task(root: Path, task: Task, local_repo: Path, task_name: str)
     (root / "instruction.md").write_text(task.prompt.rstrip() + "\n")
     (solution / "solve.sh").write_text(_solution_script(task))
     (tests / "test.sh").write_text(_test_script(task))
-    (environment / "Dockerfile").write_text(_environment_dockerfile(task))
-    (tests / "Dockerfile").write_text(_verifier_dockerfile(task))
+    (environment / "Dockerfile").write_text(_environment_dockerfile(task, package_manager))
+    (tests / "Dockerfile").write_text(_verifier_dockerfile(task, package_manager))
     os.chmod(solution / "solve.sh", 0o755)
     os.chmod(tests / "test.sh", 0o755)
     (root / "task.toml").write_text(_task_toml(task, task_name))
@@ -271,6 +286,7 @@ def _write_harbor_task(root: Path, task: Task, local_repo: Path, task_name: str)
                 "harbor_version_range": HARBOR_VERSION_RANGE,
                 "environment_compiler_revision": ENVIRONMENT_COMPILER_REVISION,
                 "task_id": task.task_id,
+                "package_manager": package_manager,
                 "task_fingerprints": task.evaluation_fingerprints,
                 "generated_at": datetime.now(UTC).isoformat(),
             },
@@ -381,6 +397,28 @@ RUN arch="$(dpkg --print-architecture)" \\
 """
 
 
+def _corepack_layer(package_manager: str | None) -> str:
+    """Persist the package manager the base snapshot declares via Corepack.
+
+    Corepack normally downloads a project's manager into ``/root/.cache`` on
+    first use. The setup layer is cache-mounted there, which lets distinct
+    images accidentally reuse that mutable state. Keeping the resolved binary
+    under ``/usr/local/share/corepack`` makes each generated image self-
+    contained and ensures that frozen installs use the lockfile's own manager.
+    """
+    if package_manager is None:
+        return ""
+    name, _, _ = package_manager.partition("@")
+    return f"""ENV COREPACK_HOME=/usr/local/share/corepack \\
+    COREPACK_DEFAULT_TO_LATEST=0
+RUN mkdir -p "$COREPACK_HOME" \\
+    && corepack enable \\
+    && corepack prepare {shlex.quote(package_manager)} --activate \\
+    && corepack {shlex.quote(name)} --version \\
+    && chmod -R a+rX "$COREPACK_HOME"
+"""
+
+
 def _repo_layers(task: Task) -> str:
     """Unpack the history-free snapshot and run the task's own setup command."""
     return f"""COPY repo.tar.gz /tmp/repo.tar.gz
@@ -394,7 +432,7 @@ RUN mkdir -p /app && tar -xzf /tmp/repo.tar.gz -C /app && rm /tmp/repo.tar.gz \\
 """
 
 
-def _environment_dockerfile(task: Task) -> str:
+def _environment_dockerfile(task: Task, package_manager: str | None = None) -> str:
     """Agent-facing image: no gold patch, no held-out tests, no provenance.
 
     ``/opt/selfbench/base.git`` is a root-only copy of the pristine base repo.
@@ -402,7 +440,7 @@ def _environment_dockerfile(task: Task) -> str:
     cannot disguise what it actually changed.
     """
     return f"""{_toolchain_layers()}
-RUN useradd --create-home --shell /bin/bash agent
+{_corepack_layer(package_manager)}RUN useradd --create-home --shell /bin/bash agent
 {_repo_layers(task)}
 RUN git -C /app reset --hard -q HEAD \\
     && git -C /app clean -fdq \\
@@ -416,10 +454,10 @@ WORKDIR /app
 """
 
 
-def _verifier_dockerfile(task: Task) -> str:
+def _verifier_dockerfile(task: Task, package_manager: str | None = None) -> str:
     """Verifier image: holds the held-out tests the agent never sees."""
     return f"""{_toolchain_layers()}
-{_repo_layers(task)}
+{_corepack_layer(package_manager)}{_repo_layers(task)}
 RUN mkdir -p /opt/selfbench && chmod 700 /opt/selfbench
 COPY . /tests/
 RUN chmod +x /tests/test.sh
@@ -451,6 +489,7 @@ patch_applied=1
 fail_to_pass=0
 pass_to_pass=0
 deterministic=0
+setup_completed=0
 
 if [ ! -f /opt/selfbench/agent.patch ]; then
   echo "Harbor did not transfer the captured agent patch" >&2
@@ -468,6 +507,7 @@ fi
 if [ "$patch_applied" -eq 1 ]; then
   cd {workdir}
   if bash -lc {shlex.quote(setup)}; then
+    setup_completed=1
     if bash -lc {shlex.quote(f2p)}; then
       fail_to_pass=1
       if bash -lc {shlex.quote(f2p)}; then deterministic=1; fi
@@ -481,7 +521,7 @@ if [ "$patch_applied" -eq 1 ] && [ "$fail_to_pass" -eq 1 ] && [ "$pass_to_pass" 
   reward=1
 fi
 cat > /logs/verifier/reward.json <<EOF
-{{"reward": $reward, "patch_applied": $patch_applied, "fail_to_pass": $fail_to_pass, "pass_to_pass": $pass_to_pass, "deterministic": $deterministic}}
+{{"reward": $reward, "patch_applied": $patch_applied, "fail_to_pass": $fail_to_pass, "pass_to_pass": $pass_to_pass, "deterministic": $deterministic, "setup_completed": $setup_completed}}
 EOF
 exit 0
 """
@@ -497,6 +537,40 @@ def _docker_run(command: str, workdir: str) -> str:
         "RUN --mount=type=cache,target=/root/.cache "
         f"cd {shlex.quote(workdir)} && bash -lc {shlex.quote(command)}"
     )
+
+
+def _setup_failure_signature(run: HarborRun) -> str:
+    """Return a stable, short signature for a verifier setup failure."""
+    output = run.trial_dir / "verifier" / "test-stdout.txt"
+    if output.is_file():
+        text = output.read_text(errors="replace")
+        if match := re.search(r"\bERR_[A-Z0-9_]+\b", text):
+            return match.group(0)
+    return "setup command failed"
+
+
+def _package_manager_spec(local_repo: Path, commit: str) -> str | None:
+    """Read a Corepack-compatible manager pin from the exact task snapshot."""
+    result = subprocess.run(
+        ["git", "-C", str(local_repo), "show", f"{commit}:package.json"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        package_json = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    value = package_json.get("packageManager") if isinstance(package_json, dict) else None
+    if not isinstance(value, str):
+        return None
+    name, separator, version = value.partition("@")
+    if name not in {"pnpm", "yarn"} or not separator or not version or any(
+        char.isspace() for char in value
+    ):
+        return None
+    return value
 
 
 def _git_archive(local_repo: Path, commit: str) -> bytes:

--- a/src/selfbench/runner.py
+++ b/src/selfbench/runner.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import json
+import re
+import shutil
+import subprocess
+import threading
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -20,6 +24,7 @@ from .task import Task
 # Public validation defaults to Modal so larger task sets can fan out. Docker
 # remains available as an explicit local/offline override.
 DEFAULT_VALIDATION_ENVIRONMENT = "modal"
+DEFAULT_SETUP_FAILURE_THRESHOLD = 2
 
 def validate_task(
     task: Task,
@@ -81,10 +86,11 @@ class BatchValidationOutcome:
     """Per-task outcome for a batch validation run."""
 
     task_id: str
-    status: str  # "skipped", "valid", "invalid", "error"
+    status: str  # "skipped", "valid", "invalid", "error", or "blocked"
     exit_code: int = 0
     error: str | None = None
     result_path: Path | None = None
+    setup_failure_signature: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {
@@ -96,7 +102,36 @@ class BatchValidationOutcome:
             data["error"] = self.error
         if self.result_path is not None:
             data["result_path"] = str(self.result_path)
+        if self.setup_failure_signature is not None:
+            data["setup_failure_signature"] = self.setup_failure_signature
         return data
+
+
+def preflight_harbor_task(harbor_task: Path, *, log_path: Path | None = None) -> None:
+    """Build both generated images locally before spending a remote validation.
+
+    The build executes the task's real ``setup_cmd``. It is deliberately not a
+    replacement for Harbor validation: it only catches dependency, toolchain,
+    and Dockerfile failures before a Modal batch fans them out.
+    """
+    docker = shutil.which("docker")
+    if docker is None:
+        raise RuntimeError("Docker is required for validation preflight; pass --no-preflight to skip it")
+    for name in ("environment", "tests"):
+        context = harbor_task / name
+        command = [docker, "build", "--progress=plain", "--file", str(context / "Dockerfile"), str(context)]
+        result = subprocess.run(command, text=True, capture_output=True, check=False)
+        output = result.stdout + result.stderr
+        if log_path is not None:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("a") as log:
+                log.write(f"=== preflight {name} image ===\n")
+                log.write(output)
+                if output and not output.endswith("\n"):
+                    log.write("\n")
+        if result.returncode != 0:
+            detail = _preflight_failure_detail(output)
+            raise RuntimeError(f"Docker preflight failed for {name} image: {detail}")
 
 
 def validate_batch(
@@ -110,6 +145,8 @@ def validate_batch(
     concurrency: int | None = None,
     rebuild: bool = True,
     log_dir: Path | None = None,
+    preflight: bool = False,
+    setup_failure_threshold: int = DEFAULT_SETUP_FAILURE_THRESHOLD,
 ) -> list[BatchValidationOutcome]:
     """Validate many tasks concurrently, preserving per-task results and logs.
 
@@ -126,17 +163,27 @@ def validate_batch(
     ``concurrency`` defaults to ``len(tasks)`` so every task runs at once on
     Modal; pass a smaller number to throttle. Idempotent: tasks that already
     have a current, valid result are skipped.
+
+    When ``preflight`` is enabled, each local validation builds both generated
+    images. Modal batches preflight only their two canaries per repository;
+    two identical setup failures block the remaining queued
+    tasks for that repository rather than spending the whole batch on one
+    broken environment.
     """
     import concurrent.futures as cf
+    from collections import Counter, deque
 
     if concurrency is None:
         concurrency = max(1, len(tasks))
     else:
         concurrency = max(1, int(concurrency))
+    if setup_failure_threshold < 1:
+        raise ValueError("setup_failure_threshold must be positive")
     if log_dir is not None:
         log_dir.mkdir(parents=True, exist_ok=True)
 
     outcomes: list[BatchValidationOutcome] = []
+    preflight_lock = threading.Lock()
 
     def _log(log_file: Path | None, message: str) -> None:
         if log_file is None:
@@ -145,7 +192,7 @@ def validate_batch(
         with log_file.open("a") as handle:
             handle.write(message + "\n")
 
-    def _one(task: Task) -> BatchValidationOutcome:
+    def _one(task: Task, *, should_preflight: bool) -> BatchValidationOutcome:
         log_file = (log_dir / f"{task.task_id}.log") if log_dir is not None else None
         _log(log_file, f"=== validate {task.task_id} start env={environment} {datetime.now(UTC).isoformat()} ===")
         if is_currently_valid(task, results_root):
@@ -156,41 +203,164 @@ def validate_batch(
                 result_path=results_root / task.task_id / "validation" / "result.json",
             )
         try:
+            local_repo = repo_resolver(task)
+            if should_preflight:
+                harbor_task = build_harbor_task(
+                    task,
+                    local_repo,
+                    harbor_root,
+                    overwrite=rebuild,
+                )
+                # Docker builds are memory-heavy, especially for monorepos. Keep
+                # this local guard serial even when the subsequent Modal trials fan out.
+                with preflight_lock:
+                    preflight_harbor_task(harbor_task, log_path=log_file)
             result = validate_task(
                 task,
-                repo_resolver(task),
+                local_repo,
                 harbor_root=harbor_root,
                 jobs_root=jobs_root,
                 environment=environment,
-                rebuild=rebuild,
+                rebuild=False if should_preflight else rebuild,
                 verbose=False,
                 log_path=log_file,
             )
             path = save_result(result, results_root, "validation")
             status = "valid" if result.get("valid") else "invalid"
+            signature = _result_setup_failure_signature(result)
             _log(log_file, f"=== validate {task.task_id} {status} ===")
             return BatchValidationOutcome(
                 task_id=task.task_id,
                 status=status,
                 exit_code=0 if result.get("valid") else 1,
                 result_path=path,
+                setup_failure_signature=signature,
             )
         except Exception as exc:  # noqa: BLE001 - surface in the outcome, do not hide
-            _log(log_file, f"=== validate {task.task_id} ERROR: {type(exc).__name__}: {exc} ===")
+            error = f"{type(exc).__name__}: {exc}"
+            signature = _error_setup_failure_signature(error)
+            _log(log_file, f"=== validate {task.task_id} ERROR: {error} ===")
             return BatchValidationOutcome(
                 task_id=task.task_id,
                 status="error",
                 exit_code=2,
-                error=f"{type(exc).__name__}: {exc}",
+                error=error,
+                setup_failure_signature=signature,
             )
 
+    if environment != "modal":
+        with cf.ThreadPoolExecutor(max_workers=concurrency) as pool:
+            futures = [pool.submit(_one, task, should_preflight=preflight) for task in tasks]
+            for future in cf.as_completed(futures):
+                outcomes.append(future.result())
+        outcomes.sort(key=lambda o: o.task_id)
+        return outcomes
+
+    by_repo: dict[str, deque[Task]] = {}
+    for task in tasks:
+        by_repo.setdefault(task.repo, deque()).append(task)
+    canary_queue: deque[tuple[str, Task]] = deque()
+    remaining: dict[str, deque[Task]] = {}
+    canaries_planned: dict[str, int] = {}
+    canary_task_ids: dict[str, set[str]] = {}
+    canaries_finished: Counter[str] = Counter()
+    canary_outcomes: dict[str, list[BatchValidationOutcome]] = {}
+    for repo, queued in by_repo.items():
+        count = min(setup_failure_threshold, len(queued))
+        canaries_planned[repo] = count
+        canary_task_ids[repo] = set()
+        for _ in range(count):
+            task = queued.popleft()
+            canary_task_ids[repo].add(task.task_id)
+            canary_queue.append((repo, task))
+        remaining[repo] = queued
+
+    regular_queue: deque[tuple[str, Task]] = deque()
     with cf.ThreadPoolExecutor(max_workers=concurrency) as pool:
-        futures = {pool.submit(_one, task): task for task in tasks}
-        for future in cf.as_completed(futures):
-            outcomes.append(future.result())
+        futures: dict[cf.Future[BatchValidationOutcome], tuple[str, bool]] = {}
+        while canary_queue or regular_queue or futures:
+            while len(futures) < concurrency and (canary_queue or regular_queue):
+                repo, task = canary_queue.popleft() if canary_queue else regular_queue.popleft()
+                is_canary = task.task_id in canary_task_ids[repo]
+                futures[pool.submit(_one, task, should_preflight=preflight and is_canary)] = (repo, is_canary)
+            if not futures:
+                continue
+            finished, _ = cf.wait(futures, return_when=cf.FIRST_COMPLETED)
+            for future in finished:
+                repo, is_canary = futures.pop(future)
+                outcome = future.result()
+                outcomes.append(outcome)
+                if not is_canary:
+                    continue
+                canaries_finished[repo] += 1
+                canary_outcomes.setdefault(repo, []).append(outcome)
+                if canaries_finished[repo] != canaries_planned[repo]:
+                    continue
+                signatures = Counter(
+                    item.setup_failure_signature
+                    for item in canary_outcomes[repo]
+                    if item.setup_failure_signature is not None
+                )
+                repeated = next(
+                    (signature for signature, count in signatures.items() if count >= setup_failure_threshold),
+                    None,
+                )
+                if repeated is None:
+                    regular_queue.extend((repo, task) for task in remaining[repo])
+                    remaining[repo].clear()
+                    continue
+                message = f"batch circuit breaker: repeated setup failure {repeated}"
+                while remaining[repo]:
+                    task = remaining[repo].popleft()
+                    log_file = (log_dir / f"{task.task_id}.log") if log_dir is not None else None
+                    _log(log_file, f"=== validate {task.task_id} BLOCKED: {message} ===")
+                    outcomes.append(
+                        BatchValidationOutcome(
+                            task_id=task.task_id,
+                            status="blocked",
+                            exit_code=2,
+                            error=message,
+                            setup_failure_signature=repeated,
+                        )
+                    )
 
     outcomes.sort(key=lambda o: o.task_id)
     return outcomes
+
+
+def _result_setup_failure_signature(result: dict[str, Any]) -> str | None:
+    failures = result.get("setup_failures")
+    if isinstance(failures, dict):
+        values = [value for value in failures.values() if isinstance(value, str) and value]
+        if values:
+            return sorted(values)[0]
+    infrastructure = result.get("infrastructure_errors")
+    if isinstance(infrastructure, dict):
+        values = [value for value in infrastructure.values() if isinstance(value, str) and value]
+        if values:
+            return _error_setup_failure_signature(sorted(values)[0])
+    return None
+
+
+def _preflight_failure_detail(output: str) -> str:
+    if match := re.search(r"\bERR_[A-Z0-9_]+\b", output):
+        return match.group(0)
+    lines = output.strip().splitlines()
+    return lines[-1] if lines else "no Docker output"
+
+
+def _error_setup_failure_signature(error: str) -> str | None:
+    if match := re.search(r"\bERR_[A-Z0-9_]+\b", error):
+        return match.group(0)
+    if "Docker preflight failed" in error:
+        return "Docker preflight failed"
+    if "Docker is required for validation preflight" in error:
+        return "Docker preflight unavailable"
+    if "Image build" in error:
+        return "image build failed"
+    if "RemoteError" in error:
+        return "RemoteError"
+    return None
 
 
 def save_result(result: dict, results_root: Path, subdir: str) -> Path:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,11 @@ class CliBatchEnvironmentTest(unittest.TestCase):
         ns = parser.parse_args(["validate-batch", "tasks", "--env", "docker"])
         self.assertEqual(ns.env, "docker")
 
+    def test_validate_batch_preflight_defaults_on_and_can_be_disabled(self) -> None:
+        parser = build_parser()
+        self.assertTrue(parser.parse_args(["validate-batch", "tasks"]).preflight)
+        self.assertFalse(parser.parse_args(["validate-batch", "tasks", "--no-preflight"]).preflight)
+
     def test_validate_batch_env_var_default(self) -> None:
         with patch.dict(os.environ, {"SELFBENCH_VALIDATION_ENV": "docker"}):
             parser = build_parser()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -104,6 +104,25 @@ class HarborTaskBuildTest(unittest.TestCase):
         with self.assertRaisesRegex(FileExistsError, "pass --force"):
             build_harbor_task(self.task, self.repo, self.root / "harbor-tasks")
 
+    def test_pins_the_snapshot_corepack_package_manager(self) -> None:
+        (self.repo / "package.json").write_text('{"packageManager":"pnpm@9.6.0"}\n')
+        subprocess.run(["git", "-C", str(self.repo), "add", "package.json"], check=True)
+        subprocess.run(["git", "-C", str(self.repo), "commit", "-qm", "pin pnpm"], check=True)
+        self.task.base_commit = subprocess.run(
+            ["git", "-C", str(self.repo), "rev-parse", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+
+        output = build_harbor_task(self.task, self.repo, self.root / "harbor-tasks")
+
+        dockerfile = (output / "environment" / "Dockerfile").read_text()
+        manifest = json.loads((output / ".selfbench-manifest.json").read_text())
+        self.assertIn("COREPACK_HOME=/usr/local/share/corepack", dockerfile)
+        self.assertIn("corepack prepare pnpm@9.6.0 --activate", dockerfile)
+        self.assertEqual(manifest["package_manager"], "pnpm@9.6.0")
+
 
 class HarborRunnerTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -407,6 +426,65 @@ class BatchValidationTest(unittest.TestCase):
         self.assertTrue((self.root / "results" / self.tasks[1].task_id / "validation" / "result.json").is_file())
 
     @patch("selfbench.runner.validate_task")
+    def test_repeated_setup_failures_block_remaining_repo_tasks(self, validate) -> None:
+        for task in self.tasks:
+            task.repo = "example/shared"
+
+        def setup_failure(task, local_repo, **kwargs):  # noqa: ARG001 - mock forwards all kwargs
+            return {
+                "result_schema_version": "harbor-1",
+                "run_id": f"run-{task.task_id}",
+                "run_kind": "validation",
+                "task_id": task.task_id,
+                "valid": False,
+                "checks": {},
+                "setup_failures": {"oracle": "ERR_PNPM_LOCKFILE_CONFIG_MISMATCH"},
+                "task_fingerprints": task.evaluation_fingerprints,
+                "duration_s": 1.0,
+            }
+
+        validate.side_effect = setup_failure
+        outcomes = validate_batch(
+            self.tasks,
+            lambda task: self.root / "repo",
+            results_root=self.root / "results",
+            environment="modal",
+            concurrency=1,
+        )
+
+        self.assertEqual(validate.call_count, 2)
+        self.assertEqual([outcome.status for outcome in outcomes].count("blocked"), 1)
+        blocked = next(outcome for outcome in outcomes if outcome.status == "blocked")
+        self.assertEqual(blocked.setup_failure_signature, "ERR_PNPM_LOCKFILE_CONFIG_MISMATCH")
+
+    @patch("selfbench.runner.preflight_harbor_task")
+    @patch("selfbench.runner.build_harbor_task", return_value=Path("/tmp/harbor-task"))
+    @patch("selfbench.runner.validate_task")
+    def test_preflight_builds_images_before_remote_validation(self, validate, build, preflight) -> None:
+        validate.return_value = {
+            "result_schema_version": "harbor-1",
+            "run_id": "run",
+            "run_kind": "validation",
+            "task_id": self.tasks[0].task_id,
+            "valid": True,
+            "checks": {},
+            "task_fingerprints": self.tasks[0].evaluation_fingerprints,
+            "duration_s": 1.0,
+        }
+
+        validate_batch(
+            self.tasks[:1],
+            lambda task: self.repos[task.repo],
+            results_root=self.root / "results",
+            environment="modal",
+            preflight=True,
+        )
+
+        build.assert_called_once()
+        preflight.assert_called_once_with(Path("/tmp/harbor-task"), log_path=None)
+        self.assertFalse(validate.call_args.kwargs["rebuild"])
+
+    @patch("selfbench.runner.validate_task")
     def test_batch_writes_per_task_logs(self, validate) -> None:
         validate.side_effect = [
             {
@@ -628,6 +706,38 @@ class InfrastructureErrorSurfacingTest(unittest.TestCase):
         self.assertFalse(result["valid"])
         self.assertEqual(
             result["infrastructure_errors"], {"oracle": "RemoteError: Image build failed"}
+        )
+
+    def test_validation_result_records_setup_failure_signature(self) -> None:
+        from selfbench.harbor import validation_result
+
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            task_dir = root / "task"
+            task_dir.mkdir()
+            (task_dir / "prompt.md").write_text("Fix the behavior.")
+            (task_dir / "test.patch").write_text("test patch")
+            (task_dir / "gold.patch").write_text("gold patch")
+            task = Task(
+                task_id="setup-task", repo="example/repo", base_commit="abc123", workdir=".",
+                setup_cmd="setup", test_cmd="run {tests}", fail_to_pass=["f2p"],
+                pass_to_pass=["p2p"], test_paths=["tests"], dir=task_dir,
+            )
+            base = _fake_run(root / "base", {"patch_applied": 1, "setup_completed": 0})
+            oracle = _fake_run(root / "oracle", {"patch_applied": 1, "setup_completed": 0})
+            for run in (base, oracle):
+                verifier = run.trial_dir / "verifier"
+                verifier.mkdir()
+                (verifier / "test-stdout.txt").write_text("ERR_PNPM_LOCKFILE_CONFIG_MISMATCH\n")
+
+            result = validation_result(task, base, oracle)
+
+        self.assertEqual(
+            result["setup_failures"],
+            {
+                "base": "ERR_PNPM_LOCKFILE_CONFIG_MISMATCH",
+                "oracle": "ERR_PNPM_LOCKFILE_CONFIG_MISMATCH",
+            },
         )
 
     def test_validation_result_omits_key_without_exceptions(self) -> None:


### PR DESCRIPTION
## Summary
Make Modal validation batches reproducible and stop spending remote jobs on shared setup failures.

- Generated Harbor images honor the exact `package.json#packageManager` pin while keeping frozen installs.
- Modal batches preflight per-repository canaries and block remaining tasks after repeated identical setup failures.
- Preflight is enabled by default for Modal and can be disabled with `--no-preflight`.

## Design
### Deterministic generated environments
- `src/selfbench/harbor.py` — read the package-manager pin from the task commit, persist the Corepack installation in the generated images, bump the environment compiler revision, and record setup completion/failure signatures.
- `tests/test_runner.py` — verify generated Dockerfiles and manifests use the snapshot's pinned manager.

### Batch validation safeguards
- `src/selfbench/runner.py` — build local canary images before Modal validation, serialize Docker preflight, classify setup failures, and circuit-break remaining tasks for a repository after repeated matching failures.
- `src/selfbench/cli.py` — expose `--no-preflight` and `--setup-failure-threshold` while preserving frozen-lockfile behavior.
- `tests/test_runner.py`, `tests/test_cli.py` — cover preflight ordering, circuit breaking, setup signatures, and CLI defaults.

## Validation
- `bun run validate` — passed: 146 Python tests, review TypeScript typecheck, and production review build.
- Built a real generated Next.js PR 69230 environment image; `pnpm@9.6.0` was selected and its frozen install completed.
- The corresponding verifier image later hit an OrbStack/Docker daemon disconnect during export, so a complete second-image local validation was not available.
