### PR TITLE
Generate SelfBench tasks in Modal sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ selfbench create --repo ~/code/my-project \
   "Create an eval from PR 123."
 ```
 
+For a larger batch, a local discovery parent can rank provenance-backed candidates and fan each
+assigned pull request out to a fresh Modal Sandbox. See [Modal generation](docs/modal-generation.md).
+
 Creation writes authoring files to `tasks/TASK_ID` under your current directory. Validation generates the runnable Harbor task at `harbor-tasks/TASK_ID`.
 
 ## Validate

--- a/docs/modal-generation.md
+++ b/docs/modal-generation.md
@@ -1,0 +1,141 @@
+# Generate tasks in Modal Sandboxes
+
+Selfbench can keep candidate discovery local—where Pi can inspect existing tasks, rejected
+candidates, and authentic local coding sessions—then author each assigned pull request in a fresh
+Modal Sandbox. A deterministic coordinator owns the Modal credentials and fan-out. Child agents
+never select replacement pull requests or share a task directory.
+
+This workflow generates and retrieves authoring artifacts. It does not run coding-agent solver
+trials. A generated task is not accepted until the normal nop/oracle validation, audit, and coupling
+review pass.
+
+## Execution model
+
+1. A read-only local Pi parent ranks `count + reserve_count` merged pull requests. It verifies an
+   authentic pre-implementation provenance source and emits a schema-validated plan.
+2. The coordinator uploads only the selected provenance files to a private Modal Volume. Paths are
+   restricted to the source repository and known Pi, Claude, Codex, relaymux, and handoff roots.
+   Credential-like files and provenance files larger than 50 MiB are rejected.
+3. The coordinator starts one candidate per Modal Sandbox, up to the configured concurrency. Each
+   Sandbox has an isolated repository clone, Pi session, and output path.
+4. A child either publishes one task or records a structured rejection. Rejections consume the next
+   ranked reserve; infrastructure failures stop the run so the same candidate can be retried.
+5. Before publishing `_SUCCESS`, the child compiles the task through Selfbench's production Harbor
+   environment compiler. That resolves the exact base-snapshot package manager and lockfile hashes
+   and rejects conflicting or mutable setup commands. The child then creates a fresh detached base
+   worktree, activates the resolved manager version, and executes the authored `setup_cmd` with its
+   declared timeout.
+6. The coordinator downloads the completed worker artifacts, verifies every file hash and source PR,
+   rejects duplicates, and idempotently merges exactly the requested number of tasks locally.
+
+The setup command is executed again with the tests in the generated Harbor environments. The child
+setup smoke is deliberately not a substitute for nop/oracle validation: Harbor's history-free image,
+held-out patch application, base failure, and oracle success remain the canonical proof.
+
+## Prepare Modal
+
+Install the optional Modal dependency and authenticate the CLI:
+
+```bash
+uv sync --extra modal
+uv run modal setup
+```
+
+Create a private Modal Secret named `selfbench-generation` using the Modal dashboard. It should hold
+the provider credential used by the child Pi agents and, for private repositories, `GITHUB_TOKEN` or
+`GH_TOKEN`. For example, an OpenAI run needs `OPENAI_API_KEY`.
+
+The default private Volume is `selfbench-generation-artifacts`. Override these names without editing
+the plan:
+
+```bash
+export SELFBENCH_MODAL_SECRET=my-selfbench-secret
+export SELFBENCH_MODAL_VOLUME=my-selfbench-artifacts
+export SELFBENCH_MODAL_MAX_WORKERS=10
+```
+
+## Run discovery and generation
+
+Run from a clean, committed Selfbench checkout. The image records the exact Selfbench commit and the
+coordinator refuses a dirty checkout so a later run can be reproduced.
+
+```bash
+uv run modal run scripts/modal_generate.py::run \
+  --repo ~/code/my-project \
+  --tasks-root ./tasks \
+  --count 10 \
+  --reserve-count 10 \
+  --profile hard \
+  --provider openai \
+  --model gpt-5.6-sol \
+  --thinking xhigh
+```
+
+The parent plan and private JSONL log stay outside the repository under
+`~/.local/share/selfbench/modal-runs/RUN_ID/`. The successful run is downloaded under the adjacent
+`artifacts/` directory and merged into `--tasks-root`.
+
+Every candidate packet pins its source PR, base commit, completed commit, and provenance descriptor.
+The child prompt explicitly forbids candidate substitution, lockfile mutation, or switching package
+managers to make setup pass.
+
+## Resume or retrieve a run
+
+A stopped run can be resumed from its reviewed local plan. Completed workers are skipped, rejected
+candidates stay rejected, and failed workers are retried before reserves are consumed:
+
+```bash
+uv run modal run scripts/modal_generate.py::submit \
+  --manifest ~/.local/share/selfbench/modal-runs/RUN_ID/plan.json \
+  --repo ~/code/my-project
+```
+
+Download and merge a completed run again without regenerating anything:
+
+```bash
+uv run modal run scripts/modal_generate.py::pull \
+  --run-id RUN_ID \
+  --output ./tasks
+```
+
+Reduction is restart-safe. An identical existing task is retained; a different directory with the
+same task ID, a duplicate source PR, a stale completion marker, or a changed artifact hash stops the
+merge.
+
+## Validate the generated batch
+
+Run deterministic validation after generation. The default Modal path builds and executes the exact
+agent and verifier environments; local Docker preflight catches shared setup failures before the
+remote fan-out:
+
+```bash
+selfbench validate-batch ./tasks \
+  --repo-map example/project=~/code/my-project \
+  --env modal \
+  --concurrency 4
+```
+
+Then run the static audit and independent coupling review described in
+[Authoring evals](authoring-evals.md). Do not run solver agents unless that separate spend is
+explicitly requested.
+
+## Private artifact layout
+
+```text
+runs/RUN_ID/
+├── manifest.json
+├── inputs/WORKER_ID/PROVENANCE_SHA.jsonl
+├── statuses/WORKER_ID.json
+├── failures/WORKER_ID/
+└── workers/WORKER_ID/
+    ├── _SUCCESS
+    ├── artifacts.json
+    ├── request.json
+    ├── setup-preflight.json
+    ├── stdout.log
+    ├── stderr.log
+    └── tasks/TASK_ID/
+```
+
+Worker logs and provenance remain private. The coordinator prints only compact status objects, not
+Pi transcripts or source material.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ modal = [
 ]
 
 [tool.uv-build]
-package-data = { "selfbench" = ["skills/selfbench/SKILL.md", "review_dist/**/*"] }
+package-data = { "selfbench" = ["extensions/*.ts", "skills/selfbench/SKILL.md", "review_dist/**/*"] }
 
 [project.scripts]
 selfbench = "selfbench.cli:main"

--- a/scripts/modal_generate.py
+++ b/scripts/modal_generate.py
@@ -1,0 +1,440 @@
+"""Discover candidates locally, then fan them out to isolated Modal Sandboxes."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import subprocess
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+
+import modal
+
+from selfbench.modal_generation import (
+    GenerationManifest,
+    ManifestError,
+    WorkerSpec,
+    load_generation_manifest,
+    merge_worker_artifacts,
+)
+from selfbench.modal_parent import discover_generation_manifest
+
+APP_NAME = "selfbench-generation"
+ARTIFACT_MOUNT = "/artifacts"
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+VOLUME_NAME = os.environ.get("SELFBENCH_MODAL_VOLUME") or "selfbench-generation-artifacts"
+SECRET_NAME = os.environ.get("SELFBENCH_MODAL_SECRET") or "selfbench-generation"
+MAX_WORKERS = int(os.environ.get("SELFBENCH_MODAL_MAX_WORKERS") or "20")
+
+PI_VERSION = "0.83.0"
+GH_VERSION = "2.89.0"
+GH_LINUX_AMD64_SHA256 = "d0422caade520530e76c1c558da47daebaa8e1203d6b7ff10ad7d6faba3490d8"
+UV_VERSION = "0.11.3"
+BUN_VERSION = "1.1.42"
+COREPACK_VERSION = "0.31.0"
+GO_VERSION = "1.25.0"
+RUST_VERSION = "1.90.0"
+MAX_PROVENANCE_BYTES = 50 * 1024 * 1024
+_BLOCKED_PROVENANCE_NAMES = {
+    ".env",
+    "api-keys",
+    "auth.json",
+    "credentials.json",
+    "id_ed25519",
+    "id_rsa",
+}
+
+
+def _local_git_state() -> tuple[str, bool]:
+    commit = os.environ.get("SELFBENCH_BUILD_COMMIT")
+    if commit:
+        return commit, os.environ.get("SELFBENCH_BUILD_DIRTY") == "1"
+    try:
+        commit = subprocess.run(
+            ["git", "-C", str(PROJECT_ROOT), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        dirty = bool(
+            subprocess.run(
+                ["git", "-C", str(PROJECT_ROOT), "status", "--short"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        )
+        return commit, dirty
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown", True
+
+
+BUILD_COMMIT, BUILD_DIRTY = _local_git_state()
+
+image = (
+    modal.Image.from_registry("node:24.11.1-bookworm-slim", add_python="3.12")
+    .apt_install(
+        "bash",
+        "build-essential",
+        "ca-certificates",
+        "curl",
+        "git",
+        "jq",
+        "pkg-config",
+        "procps",
+        "ripgrep",
+        "unzip",
+        "xz-utils",
+    )
+    .run_commands(
+        "set -eu; "
+        f"archive=gh_{GH_VERSION}_linux_amd64.tar.gz; "
+        f"curl -fsSLO https://github.com/cli/cli/releases/download/v{GH_VERSION}/$archive; "
+        f"echo '{GH_LINUX_AMD64_SHA256}  '$archive | sha256sum -c -; "
+        "tar -xzf $archive; "
+        f"install gh_{GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh; "
+        f"rm -rf $archive gh_{GH_VERSION}_linux_amd64"
+    )
+    .run_commands(
+        f"npm install --global --ignore-scripts @earendil-works/pi-coding-agent@{PI_VERSION}",
+        f"npm install --global bun@{BUN_VERSION} corepack@{COREPACK_VERSION}",
+        "corepack enable",
+        f"python -m pip install --no-cache-dir uv=={UV_VERSION}",
+        "uv python install 3.11 3.12 3.13",
+        (
+            'arch="$(dpkg --print-architecture)"; '
+            f'curl -fsSL "https://go.dev/dl/go{GO_VERSION}.linux-${{arch}}.tar.gz" '
+            "| tar -C /usr/local -xz"
+        ),
+        (
+            "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs "
+            f"| env RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo sh -s -- "
+            f"-y --no-modify-path --profile minimal --default-toolchain {RUST_VERSION}"
+        ),
+    )
+    .add_local_dir(
+        PROJECT_ROOT,
+        "/opt/selfbench",
+        copy=True,
+        ignore=[
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "node_modules",
+            "review/node_modules",
+            "tasks",
+            "results",
+            "harbor-jobs",
+            "harbor-tasks",
+        ],
+    )
+    .run_commands("python -m pip install --no-cache-dir /opt/selfbench")
+    .env(
+        {
+            "CARGO_HOME": "/usr/local/cargo",
+            "PATH": "/usr/local/go/bin:/usr/local/cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",
+            "RUSTUP_HOME": "/usr/local/rustup",
+            "SELFBENCH_BUILD_COMMIT": BUILD_COMMIT,
+            "SELFBENCH_BUILD_DIRTY": "1" if BUILD_DIRTY else "0",
+        }
+    )
+)
+
+app = modal.App(APP_NAME)
+artifact_volume = modal.Volume.from_name(VOLUME_NAME, create_if_missing=True)
+provider_secret = modal.Secret.from_name(SECRET_NAME)
+
+
+def _manifest_bytes(manifest: GenerationManifest) -> bytes:
+    return (json.dumps(manifest.as_dict(), indent=2, sort_keys=True) + "\n").encode()
+
+
+def _read_remote(path: str) -> bytes | None:
+    try:
+        return b"".join(artifact_volume.read_file(path))
+    except FileNotFoundError:
+        return None
+
+
+def _default_provenance_roots(repo: Path | None) -> tuple[Path, ...]:
+    home = Path.home()
+    candidates = [
+        home / ".pi" / "agent" / "sessions",
+        home / ".claude" / "projects",
+        home / ".codex" / "sessions",
+        home / ".codex" / "archived_sessions",
+        home / ".relaymux" / "state" / "implementation-notes",
+        Path("/tmp/pi-handoffs"),
+    ]
+    if repo is not None:
+        candidates.insert(0, repo.resolve())
+    return tuple(path.resolve() for path in candidates if path.exists())
+
+
+def _stage_manifest(manifest: GenerationManifest, repo: Path | None) -> GenerationManifest:
+    """Upload allowlisted provenance and return the private remote manifest."""
+    roots = _default_provenance_roots(repo)
+    staged = manifest.as_dict()
+    raw_workers = staged["workers"]
+    assert isinstance(raw_workers, list)
+    uploads: list[tuple[Path, str]] = []
+    for raw_worker in raw_workers:
+        assert isinstance(raw_worker, dict)
+        provenance = raw_worker.get("provenance")
+        if not isinstance(provenance, dict) or provenance.get("kind") != "file":
+            continue
+        raw_path = provenance.get("path")
+        if not isinstance(raw_path, str):
+            raise ManifestError("file provenance path must be a string")
+        source = Path(raw_path).expanduser().resolve()
+        if not source.is_file() or not any(source.is_relative_to(root) for root in roots):
+            allowed = ", ".join(str(root) for root in roots)
+            raise ManifestError(f"provenance path is outside allowed roots: {source}; allowed: {allowed}")
+        if source.name.lower() in _BLOCKED_PROVENANCE_NAMES:
+            raise ManifestError(f"refusing to upload credential-like provenance file: {source.name}")
+        size = source.stat().st_size
+        if size > MAX_PROVENANCE_BYTES:
+            raise ManifestError(
+                f"provenance file exceeds {MAX_PROVENANCE_BYTES} bytes: {source}"
+            )
+        checksum = _sha256_file(source)
+        worker_id = str(raw_worker["worker_id"])
+        suffix = source.suffix if len(source.suffix) <= 12 else ""
+        remote_path = f"runs/{manifest.run_id}/inputs/{worker_id}/{checksum}{suffix}"
+        provenance["path"] = f"{ARTIFACT_MOUNT}/{remote_path}"
+        provenance["sha256"] = checksum
+        if _read_remote(remote_path) is None:
+            uploads.append((source, remote_path))
+
+    remote_manifest = GenerationManifest.from_dict(staged)
+    manifest_path = f"runs/{manifest.run_id}/manifest.json"
+    expected_manifest = _manifest_bytes(remote_manifest)
+    existing_manifest = _read_remote(manifest_path)
+    if existing_manifest is not None and existing_manifest != expected_manifest:
+        raise RuntimeError(
+            f"run_id {manifest.run_id!r} already has a different manifest in {VOLUME_NAME}"
+        )
+    if uploads or existing_manifest is None:
+        with artifact_volume.batch_upload() as batch:
+            for source, remote_path in uploads:
+                batch.put_file(source, remote_path)
+            if existing_manifest is None:
+                batch.put_file(io.BytesIO(expected_manifest), manifest_path)
+    return remote_manifest
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sandbox_name(manifest: GenerationManifest, worker: WorkerSpec) -> str:
+    fingerprint = manifest.worker_fingerprint(worker)
+    attempt = uuid.uuid4().hex[:8]
+    return f"{manifest.run_id[:16]}-{worker.worker_id[:16]}-{fingerprint[:8]}-{attempt}"
+
+
+def _launch_worker(
+    manifest: GenerationManifest,
+    remote_manifest: str,
+    worker: WorkerSpec,
+) -> modal.Sandbox:
+    return modal.Sandbox.create(
+        "python",
+        "-m",
+        "selfbench.modal_worker",
+        "--manifest",
+        remote_manifest,
+        "--worker-id",
+        worker.worker_id,
+        app=app,
+        name=_sandbox_name(manifest, worker),
+        tags={
+            "run_id": manifest.run_id,
+            "worker_id": worker.worker_id,
+            "selfbench_commit": BUILD_COMMIT,
+        },
+        image=image,
+        secrets=[provider_secret],
+        volumes={ARTIFACT_MOUNT: artifact_volume},
+        timeout=6 * 60 * 60,
+        cpu=4,
+        memory=8192,
+        workdir="/work",
+    )
+
+
+def _worker_status(manifest: GenerationManifest, worker: WorkerSpec) -> dict[str, object] | None:
+    raw = _read_remote(f"runs/{manifest.run_id}/statuses/{worker.worker_id}.json")
+    if raw is None:
+        return None
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid remote status for {worker.worker_id}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise TypeError(f"invalid remote status for {worker.worker_id}")
+    if value.get("worker_fingerprint") != manifest.worker_fingerprint(worker):
+        raise RuntimeError(f"stale remote status for {worker.worker_id}")
+    return value
+
+
+def _run_generation(manifest: GenerationManifest) -> None:
+    remote_manifest = f"{ARTIFACT_MOUNT}/runs/{manifest.run_id}/manifest.json"
+    completed: set[str] = set()
+    rejected: set[str] = set()
+    for worker in manifest.workers:
+        status = _worker_status(manifest, worker)
+        if status is not None and status.get("status") == "complete":
+            completed.add(worker.worker_id)
+        elif status is not None and status.get("status") == "rejected":
+            rejected.add(worker.worker_id)
+
+    while len(completed) < manifest.target_count:
+        deficit = manifest.target_count - len(completed)
+        candidates = [
+            worker
+            for worker in manifest.workers
+            if worker.worker_id not in completed and worker.worker_id not in rejected
+        ]
+        wave = candidates[: min(deficit, MAX_WORKERS)]
+        if not wave:
+            raise RuntimeError(
+                f"candidate pool exhausted at {len(completed)}/{manifest.target_count} authored tasks"
+            )
+        print(
+            f"starting {len(wave)} Pi subagents in separate Modal Sandboxes "
+            f"({len(completed)}/{manifest.target_count} complete)"
+        )
+        sandboxes = [
+            (worker, _launch_worker(manifest, remote_manifest, worker))
+            for worker in wave
+        ]
+        infrastructure_failures: list[str] = []
+        for worker, sandbox in sandboxes:
+            sandbox.wait(raise_on_termination=False)
+            output = sandbox.stdout.read().strip()
+            if output:
+                print(output)
+            status = _worker_status(manifest, worker)
+            state = status.get("status") if status is not None else None
+            if state == "complete":
+                completed.add(worker.worker_id)
+            elif state == "rejected":
+                rejected.add(worker.worker_id)
+            else:
+                infrastructure_failures.append(worker.worker_id)
+        if infrastructure_failures:
+            joined = ", ".join(infrastructure_failures)
+            raise RuntimeError(
+                f"sandbox infrastructure/agent failure for {joined}; retry the same run before consuming reserves"
+            )
+
+    print(
+        f"generation complete: {len(completed)} tasks authored, {len(rejected)} candidates rejected"
+    )
+
+
+def _download_and_merge(run_id: str, output: Path, artifacts_dir: Path) -> dict[str, object]:
+    remote_prefix = f"runs/{run_id}"
+    local_run = artifacts_dir / run_id
+    local_run.mkdir(parents=True, exist_ok=True)
+    entries = artifact_volume.listdir(remote_prefix, recursive=True)
+    for entry in entries:
+        if entry.type.name != "FILE":
+            continue
+        relative = PurePosixPath(entry.path).relative_to(PurePosixPath(remote_prefix))
+        destination = local_run.joinpath(*relative.parts)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("wb") as handle:
+            for chunk in artifact_volume.read_file(entry.path):
+                handle.write(chunk)
+    manifest = load_generation_manifest(local_run / "manifest.json")
+    return merge_worker_artifacts(manifest, local_run, output)
+
+
+def _require_clean_build() -> None:
+    if BUILD_COMMIT == "unknown" or BUILD_DIRTY:
+        raise RuntimeError(
+            "refusing to submit from an unknown or dirty SelfBench checkout; commit the app first"
+        )
+
+
+@app.local_entrypoint()
+def run(
+    repo: str,
+    count: int,
+    tasks_root: str = "tasks",
+    profile: str = "hard",
+    provider: str = "openai",
+    model: str = "gpt-5.6-sol",
+    thinking: str = "xhigh",
+    reserve_count: int = 0,
+    run_id: str = "",
+    pi_executable: str = "pi",
+) -> None:
+    """Run local discovery, cloud authoring, and local artifact reduction."""
+    _require_clean_build()
+    source_repo = Path(repo).expanduser().resolve()
+    local_tasks = Path(tasks_root).expanduser().resolve()
+    reserves = count if reserve_count == 0 else reserve_count
+    resolved_run_id = run_id or (
+        datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ") + "-" + uuid.uuid4().hex[:8]
+    )
+    local_state = Path.home() / ".local" / "share" / "selfbench" / "modal-runs"
+    plan_dir = local_state / resolved_run_id
+    manifest = discover_generation_manifest(
+        source_repo,
+        local_tasks,
+        plan_dir / "plan.json",
+        plan_dir / "parent.jsonl",
+        run_id=resolved_run_id,
+        target_count=count,
+        reserve_count=reserves,
+        profile=profile,
+        provider=provider,
+        model=model,
+        thinking=thinking or None,
+        pi_executable=pi_executable,
+    )
+    remote_manifest = _stage_manifest(manifest, source_repo)
+    _run_generation(remote_manifest)
+    report = _download_and_merge(
+        resolved_run_id,
+        local_tasks,
+        local_state / "artifacts",
+    )
+    print(json.dumps(report, indent=2))
+    print("generation artifacts are local; run deterministic validate-batch before accepting them")
+
+
+@app.local_entrypoint()
+def submit(manifest: str, repo: str = "") -> None:
+    """Resume or submit an already-reviewed local parent manifest."""
+    _require_clean_build()
+    generation = load_generation_manifest(Path(manifest))
+    source_repo = Path(repo).expanduser().resolve() if repo else None
+    remote_manifest = _stage_manifest(generation, source_repo)
+    _run_generation(remote_manifest)
+
+
+@app.local_entrypoint()
+def pull(run_id: str, output: str = "tasks", artifacts_dir: str = "") -> None:
+    """Download, verify, and idempotently merge one completed run."""
+    local_artifacts = (
+        Path(artifacts_dir).expanduser().resolve()
+        if artifacts_dir
+        else Path.home() / ".local" / "share" / "selfbench" / "modal-runs" / "artifacts"
+    )
+    report = _download_and_merge(
+        run_id,
+        Path(output).expanduser().resolve(),
+        local_artifacts,
+    )
+    print(json.dumps(report, indent=2))

--- a/src/selfbench/extensions/modal_generation_plan.ts
+++ b/src/selfbench/extensions/modal_generation_plan.ts
@@ -1,0 +1,99 @@
+import { renameSync, writeFileSync } from "node:fs";
+import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+const provenance = Type.Union([
+	Type.Object(
+		{
+			kind: Type.Literal("file"),
+			path: Type.String({ minLength: 1 }),
+			format: Type.Optional(Type.String({ minLength: 1 })),
+			message_index: Type.Optional(Type.Integer({ minimum: 0 })),
+		},
+		{ additionalProperties: false },
+	),
+	Type.Object(
+		{
+			kind: Type.Literal("url"),
+			url: Type.String({ minLength: 1 }),
+		},
+		{ additionalProperties: false },
+	),
+]);
+
+const worker = Type.Object(
+	{
+		worker_id: Type.String({ pattern: "^[A-Za-z0-9][A-Za-z0-9._-]*$" }),
+		candidates: Type.Array(Type.String({ minLength: 1 }), { minItems: 1, maxItems: 1 }),
+		target_count: Type.Literal(1),
+		source_pr: Type.Integer({ minimum: 1 }),
+		base_commit: Type.String({ pattern: "^[0-9a-fA-F]{40}$" }),
+		completed_commit: Type.String({ pattern: "^[0-9a-fA-F]{40}$" }),
+		provenance,
+		request: Type.String({ minLength: 1 }),
+	},
+	{ additionalProperties: false },
+);
+
+const parameters = Type.Object(
+	{
+		schema_version: Type.Literal(1),
+		run_id: Type.String({ pattern: "^[A-Za-z0-9][A-Za-z0-9._-]*$" }),
+		target_count: Type.Integer({ minimum: 1 }),
+		source: Type.Object(
+			{
+				repo_url: Type.String({ minLength: 1 }),
+				commit: Type.String({ pattern: "^[0-9a-fA-F]{40}$" }),
+			},
+			{ additionalProperties: false },
+		),
+		agent: Type.Object(
+			{
+				provider: Type.String({ minLength: 1 }),
+				model: Type.String({ minLength: 1 }),
+				thinking: Type.Optional(Type.String({ minLength: 1 })),
+				profile: Type.Union([Type.Literal("default"), Type.Literal("hard")]),
+				request: Type.Optional(Type.String({ minLength: 1 })),
+			},
+			{ additionalProperties: false },
+		),
+		workers: Type.Array(worker, { minItems: 1 }),
+	},
+	{ additionalProperties: false },
+);
+
+const submitGenerationPlan = defineTool({
+	name: "submit_generation_plan",
+	label: "Submit generation plan",
+	description:
+		"Submit the final ranked SelfBench candidate plan. This validates and saves the machine-readable plan, then ends discovery.",
+	promptSnippet: "Submit the final candidate plan and terminate discovery",
+	promptGuidelines: [
+		"Call submit_generation_plan exactly once after candidate discovery and provenance verification.",
+		"Do not author task directories in this parent session.",
+		"Put workers in descending rank order: active candidates first, then reserves.",
+	],
+	parameters,
+	async execute(_toolCallId, plan) {
+		const outputPath = process.env.SELFBENCH_PLAN_OUTPUT;
+		if (!outputPath) {
+			throw new Error("SELFBENCH_PLAN_OUTPUT is required");
+		}
+		const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+		writeFileSync(temporaryPath, `${JSON.stringify(plan, null, 2)}\n`, { mode: 0o600 });
+		renameSync(temporaryPath, outputPath);
+		return {
+			content: [{ type: "text", text: `Saved ${plan.workers.length} ranked candidates.` }],
+			details: {
+				run_id: plan.run_id,
+				target_count: plan.target_count,
+				candidate_count: plan.workers.length,
+			},
+			terminate: true,
+		};
+	},
+});
+
+export default function (pi: ExtensionAPI) {
+	pi.registerTool(submitGenerationPlan);
+}

--- a/src/selfbench/modal_generation.py
+++ b/src/selfbench/modal_generation.py
@@ -1,0 +1,663 @@
+"""Manifest and artifact helpers for standalone Modal task generation."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from .agent_input import SUPPORTED_FORMATS
+
+SCHEMA_VERSION = 1
+_SAFE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+_PULL_PATH = re.compile(r"^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>[1-9][0-9]*)/?$")
+
+
+class ManifestError(ValueError):
+    """Raised when a generation manifest or artifact set is invalid."""
+
+
+def _require_object(value: object, field: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ManifestError(f"{field} must be an object")
+    return value
+
+
+def _require_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ManifestError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _require_safe_id(value: object, field: str) -> str:
+    parsed = _require_string(value, field)
+    if _SAFE_ID.fullmatch(parsed) is None:
+        raise ManifestError(f"{field} must be a path-safe identifier")
+    return parsed
+
+
+def _optional_string(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _require_string(value, field)
+
+
+def _positive_int(value: object, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ManifestError(f"{field} must be a positive integer")
+    return value
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    provider: str
+    model: str
+    thinking: str | None
+    profile: str
+    request: str | None
+
+    @classmethod
+    def from_dict(cls, raw: object) -> AgentSpec:
+        data = _require_object(raw, "agent")
+        profile = _require_string(data.get("profile", "default"), "agent.profile")
+        if profile not in {"default", "hard"}:
+            raise ManifestError("agent.profile must be 'default' or 'hard'")
+        return cls(
+            provider=_require_string(data.get("provider"), "agent.provider"),
+            model=_require_string(data.get("model"), "agent.model"),
+            thinking=_optional_string(data.get("thinking"), "agent.thinking"),
+            profile=profile,
+            request=_optional_string(data.get("request"), "agent.request"),
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "thinking": self.thinking,
+            "profile": self.profile,
+            "request": self.request,
+        }
+
+
+@dataclass(frozen=True)
+class WorkerSpec:
+    worker_id: str
+    candidates: tuple[str, ...]
+    target_count: int
+    source_pr: int | None
+    base_commit: str | None
+    completed_commit: str | None
+    provenance: dict[str, object] | None
+    request: str | None
+
+    @classmethod
+    def from_dict(cls, raw: object, index: int) -> WorkerSpec:
+        data = _require_object(raw, f"workers[{index}]")
+        worker_id = _require_safe_id(data.get("worker_id"), f"workers[{index}].worker_id")
+        raw_candidates = data.get("candidates")
+        if not isinstance(raw_candidates, list) or not raw_candidates:
+            raise ManifestError(f"workers[{index}].candidates must be a non-empty list")
+        candidates = tuple(
+            _require_string(candidate, f"workers[{index}].candidates[{candidate_index}]")
+            for candidate_index, candidate in enumerate(raw_candidates)
+        )
+        candidate_keys = [normalize_candidate(candidate) for candidate in candidates]
+        if len(candidate_keys) != len(set(candidate_keys)):
+            raise ManifestError(f"workers[{index}].candidates must not contain duplicates")
+        target_count = _positive_int(
+            data.get("target_count", len(candidates)),
+            f"workers[{index}].target_count",
+        )
+        if target_count > len(candidates):
+            raise ManifestError(
+                f"workers[{index}].target_count cannot exceed its candidate count"
+            )
+        source_pr = data.get("source_pr")
+        if source_pr is not None and (
+            not isinstance(source_pr, int) or isinstance(source_pr, bool) or source_pr < 1
+        ):
+            raise ManifestError(f"workers[{index}].source_pr must be a positive integer")
+        base_commit = _optional_commit(data.get("base_commit"), f"workers[{index}].base_commit")
+        completed_commit = _optional_commit(
+            data.get("completed_commit"),
+            f"workers[{index}].completed_commit",
+        )
+        raw_provenance = data.get("provenance")
+        provenance = None
+        if raw_provenance is not None:
+            provenance = _validate_provenance(raw_provenance, f"workers[{index}].provenance")
+        return cls(
+            worker_id=worker_id,
+            candidates=candidates,
+            target_count=target_count,
+            source_pr=source_pr,
+            base_commit=base_commit,
+            completed_commit=completed_commit,
+            provenance=provenance,
+            request=_optional_string(data.get("request"), f"workers[{index}].request"),
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "worker_id": self.worker_id,
+            "candidates": list(self.candidates),
+            "target_count": self.target_count,
+        }
+        if self.source_pr is not None:
+            result["source_pr"] = self.source_pr
+        if self.base_commit is not None:
+            result["base_commit"] = self.base_commit
+        if self.completed_commit is not None:
+            result["completed_commit"] = self.completed_commit
+        if self.provenance is not None:
+            result["provenance"] = self.provenance
+        if self.request is not None:
+            result["request"] = self.request
+        return result
+
+
+@dataclass(frozen=True)
+class GenerationManifest:
+    run_id: str
+    target_count: int
+    source_repo_url: str
+    source_commit: str
+    agent: AgentSpec
+    workers: tuple[WorkerSpec, ...]
+
+    @classmethod
+    def from_dict(cls, raw: object) -> GenerationManifest:
+        data = _require_object(raw, "manifest")
+        version = data.get("schema_version")
+        if version != SCHEMA_VERSION:
+            raise ManifestError(
+                f"schema_version must be {SCHEMA_VERSION}, got {version!r}"
+            )
+        source = _require_object(data.get("source"), "source")
+        raw_workers = data.get("workers")
+        if not isinstance(raw_workers, list) or not raw_workers:
+            raise ManifestError("workers must be a non-empty list")
+        workers = tuple(WorkerSpec.from_dict(worker, index) for index, worker in enumerate(raw_workers))
+        worker_ids = [worker.worker_id for worker in workers]
+        if len(worker_ids) != len(set(worker_ids)):
+            raise ManifestError("worker_id values must be unique")
+        candidate_keys = [
+            normalize_candidate(candidate)
+            for worker in workers
+            for candidate in worker.candidates
+        ]
+        if len(candidate_keys) != len(set(candidate_keys)):
+            raise ManifestError("candidates must be disjoint across workers")
+        target_count = _positive_int(
+            data.get("target_count", sum(worker.target_count for worker in workers)),
+            "target_count",
+        )
+        available_count = sum(worker.target_count for worker in workers)
+        if target_count > available_count:
+            raise ManifestError("target_count cannot exceed the planned worker capacity")
+        return cls(
+            run_id=_require_safe_id(data.get("run_id"), "run_id"),
+            target_count=target_count,
+            source_repo_url=_require_repo_url(source.get("repo_url")),
+            source_commit=_require_commit(source.get("commit")),
+            agent=AgentSpec.from_dict(data.get("agent")),
+            workers=workers,
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "target_count": self.target_count,
+            "source": {
+                "repo_url": self.source_repo_url,
+                "commit": self.source_commit,
+            },
+            "agent": self.agent.as_dict(),
+            "workers": [worker.as_dict() for worker in self.workers],
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        return _json_sha256(self.as_dict())
+
+    def worker_fingerprint(self, worker: WorkerSpec) -> str:
+        return _json_sha256(
+            {
+                "manifest": self.fingerprint,
+                "worker": worker.as_dict(),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class GeneratedTask:
+    task_id: str
+    source_key: str
+    directory: Path
+    tree_sha256: str
+
+
+def load_generation_manifest(path: Path) -> GenerationManifest:
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"could not read generation manifest {path}: {exc}") from exc
+    return GenerationManifest.from_dict(raw)
+
+
+def normalize_candidate(candidate: str, *, repo_url: str | None = None) -> str:
+    """Return a stable key for a PR URL, PR number, or opaque candidate ID."""
+    value = candidate.strip()
+    parsed = urlsplit(value)
+    match = _PULL_PATH.fullmatch(parsed.path) if parsed.scheme and parsed.netloc else None
+    if match is not None:
+        return (
+            f"{parsed.netloc.lower()}/{match.group('owner')}/{match.group('repo')}"
+            f"#{match.group('number')}"
+        ).lower()
+    number_match = re.fullmatch(r"#?([1-9][0-9]*)", value)
+    if number_match is not None and repo_url is not None:
+        return f"{_repo_key(repo_url)}#{number_match.group(1)}".lower()
+    if parsed.scheme and parsed.netloc:
+        normalized = urlunsplit(
+            (parsed.scheme.lower(), parsed.netloc.lower(), parsed.path.rstrip("/"), "", "")
+        )
+        return normalized
+    return value
+
+
+def build_worker_request(manifest: GenerationManifest, worker: WorkerSpec) -> str:
+    candidates = "\n".join(f"- {candidate}" for candidate in worker.candidates)
+    extra = f"\n\nAdditional run request:\n{manifest.agent.request}" if manifest.agent.request else ""
+    worker_request = f"\n\nCandidate-specific notes:\n{worker.request}" if worker.request else ""
+    commit_lines = []
+    if worker.base_commit is not None:
+        commit_lines.append(f"Base commit: {worker.base_commit}")
+    if worker.completed_commit is not None:
+        commit_lines.append(f"Completed commit: {worker.completed_commit}")
+    if worker.provenance is not None:
+        commit_lines.append(
+            "Authentic provenance descriptor: "
+            + json.dumps(worker.provenance, sort_keys=True, separators=(",", ":"))
+        )
+    assignment = "\n".join(commit_lines)
+    assignment_section = f"\n\nPinned assignment metadata:\n{assignment}" if assignment else ""
+    return (
+        f"This is isolated generation shard {worker.worker_id}. Use only the assigned merged "
+        f"change candidates below and create exactly {worker.target_count} complete task "
+        "directories. Do not discover, reserve, or author any candidate outside this list. "
+        "If an assigned candidate is not viable, record the concrete rejection and stop short; "
+        "do not substitute another pull request. Author only in this worker. Do not run Harbor, "
+        "solver trials, or deterministic nop/oracle validation here; centralized validation "
+        "runs after the artifacts are pulled and merged. Before accepting the task, prove its "
+        "repository-native setup command in a clean checkout at the pinned base commit, using the "
+        "snapshot's declared package manager and frozen lockfile exactly as a SWE-bench environment "
+        "would. Never repair setup by changing a lockfile or silently switching package managers.\n\n"
+        "Assigned candidates:\n"
+        f"{candidates}{assignment_section}{worker_request}{extra}"
+    )
+
+
+def write_worker_artifact_manifest(
+    worker_root: Path,
+    tasks_root: Path,
+    manifest: GenerationManifest,
+    worker: WorkerSpec,
+    *,
+    build_commit: str,
+) -> dict[str, object]:
+    tasks = _inspect_tasks(tasks_root, manifest.source_repo_url, worker)
+    if len(tasks) != worker.target_count:
+        raise ManifestError(
+            f"worker {worker.worker_id} produced {len(tasks)} tasks; expected {worker.target_count}"
+        )
+    files = _file_manifest(tasks_root)
+    artifact = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": manifest.run_id,
+        "run_fingerprint": manifest.fingerprint,
+        "worker_id": worker.worker_id,
+        "worker_fingerprint": manifest.worker_fingerprint(worker),
+        "selfbench_commit": build_commit,
+        "candidates": list(worker.candidates),
+        "tasks": [
+            {
+                "task_id": task.task_id,
+                "source_key": task.source_key,
+                "tree_sha256": task.tree_sha256,
+            }
+            for task in tasks
+        ],
+        "files": files,
+    }
+    setup_preflight = worker_root / "setup-preflight.json"
+    if setup_preflight.is_file():
+        artifact["setup_preflight_sha256"] = hashlib.sha256(
+            setup_preflight.read_bytes()
+        ).hexdigest()
+    elif worker.base_commit is not None:
+        raise ManifestError(f"worker {worker.worker_id} is missing setup-preflight.json")
+    _atomic_write_json(worker_root / "artifacts.json", artifact)
+    return artifact
+
+
+def verify_worker_artifacts(
+    worker_root: Path,
+    manifest: GenerationManifest,
+    worker: WorkerSpec,
+) -> list[GeneratedTask]:
+    success_path = worker_root / "_SUCCESS"
+    if not success_path.is_file():
+        raise ManifestError(f"worker {worker.worker_id} has no _SUCCESS marker")
+    if success_path.read_text().strip() != manifest.worker_fingerprint(worker):
+        raise ManifestError(f"worker {worker.worker_id} has a stale completion marker")
+    artifact_path = worker_root / "artifacts.json"
+    try:
+        artifact = json.loads(artifact_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"invalid artifact manifest for {worker.worker_id}: {exc}") from exc
+    if not isinstance(artifact, dict):
+        raise ManifestError(f"artifact manifest for {worker.worker_id} must be an object")
+    expected_fields = {
+        "run_id": manifest.run_id,
+        "run_fingerprint": manifest.fingerprint,
+        "worker_id": worker.worker_id,
+        "worker_fingerprint": manifest.worker_fingerprint(worker),
+    }
+    for field, expected in expected_fields.items():
+        if artifact.get(field) != expected:
+            raise ManifestError(f"worker {worker.worker_id} artifact {field} does not match")
+    setup_preflight = worker_root / "setup-preflight.json"
+    expected_setup_hash = artifact.get("setup_preflight_sha256")
+    if worker.base_commit is not None and not isinstance(expected_setup_hash, str):
+        raise ManifestError(f"worker {worker.worker_id} has no setup preflight hash")
+    if isinstance(expected_setup_hash, str) and (
+        not setup_preflight.is_file()
+        or hashlib.sha256(setup_preflight.read_bytes()).hexdigest() != expected_setup_hash
+    ):
+        raise ManifestError(f"worker {worker.worker_id} setup preflight hash does not match")
+
+    tasks_root = worker_root / "tasks"
+    expected_files = artifact.get("files")
+    if not isinstance(expected_files, list) or expected_files != _file_manifest(tasks_root):
+        raise ManifestError(f"worker {worker.worker_id} task artifact hashes do not match")
+    tasks = _inspect_tasks(tasks_root, manifest.source_repo_url, worker)
+    expected_tasks = artifact.get("tasks")
+    actual_tasks = [
+        {
+            "task_id": task.task_id,
+            "source_key": task.source_key,
+            "tree_sha256": task.tree_sha256,
+        }
+        for task in tasks
+    ]
+    if expected_tasks != actual_tasks:
+        raise ManifestError(f"worker {worker.worker_id} task index does not match")
+    if len(tasks) != worker.target_count:
+        raise ManifestError(
+            f"worker {worker.worker_id} has {len(tasks)} tasks; expected {worker.target_count}"
+        )
+    return tasks
+
+
+def merge_worker_artifacts(
+    manifest: GenerationManifest,
+    artifact_run_root: Path,
+    output_root: Path,
+) -> dict[str, object]:
+    """Verify completed workers and idempotently merge their task directories."""
+    output_root.mkdir(parents=True, exist_ok=True)
+    tasks: list[tuple[str, GeneratedTask]] = []
+    seen_ids: set[str] = set()
+    seen_sources: set[str] = set()
+    for worker in manifest.workers:
+        worker_root = artifact_run_root / "workers" / worker.worker_id
+        if not (worker_root / "_SUCCESS").is_file():
+            continue
+        for task in verify_worker_artifacts(worker_root, manifest, worker):
+            if task.task_id in seen_ids:
+                raise ManifestError(f"duplicate generated task_id: {task.task_id}")
+            if task.source_key in seen_sources:
+                raise ManifestError(f"duplicate generated source candidate: {task.source_key}")
+            seen_ids.add(task.task_id)
+            seen_sources.add(task.source_key)
+            tasks.append((worker.worker_id, task))
+
+    if len(tasks) != manifest.target_count:
+        raise ManifestError(
+            f"run has {len(tasks)} completed tasks; expected exactly {manifest.target_count}"
+        )
+
+    for _, task in tasks:
+        destination = output_root / task.task_id
+        if destination.exists():
+            if not destination.is_dir() or _tree_sha256(destination) != task.tree_sha256:
+                raise ManifestError(f"existing task conflicts with generated task: {task.task_id}")
+            continue
+        staging = output_root / f".{task.task_id}.tmp-{os.getpid()}"
+        if staging.exists():
+            shutil.rmtree(staging)
+        shutil.copytree(task.directory, staging)
+        os.replace(staging, destination)
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": manifest.run_id,
+        "run_fingerprint": manifest.fingerprint,
+        "tasks": [
+            {
+                "task_id": task.task_id,
+                "source_key": task.source_key,
+                "worker_id": worker_id,
+                "tree_sha256": task.tree_sha256,
+            }
+            for worker_id, task in sorted(tasks, key=lambda item: item[1].task_id)
+        ],
+    }
+    _atomic_write_json(output_root / ".selfbench-generation.json", report)
+    return report
+
+
+def _inspect_tasks(
+    tasks_root: Path,
+    repo_url: str,
+    worker: WorkerSpec,
+) -> list[GeneratedTask]:
+    if not tasks_root.is_dir():
+        return []
+    allowed_sources = {
+        normalize_candidate(candidate, repo_url=repo_url) for candidate in worker.candidates
+    }
+    tasks: list[GeneratedTask] = []
+    for task_dir in sorted(tasks_root.iterdir()):
+        if not task_dir.is_dir() or not (task_dir / "task.json").is_file():
+            continue
+        if task_dir.is_symlink():
+            raise ManifestError(f"task directory must not be a symlink: {task_dir.name}")
+        try:
+            task_data = json.loads((task_dir / "task.json").read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ManifestError(f"invalid task.json in {task_dir}: {exc}") from exc
+        if not isinstance(task_data, dict):
+            raise ManifestError(f"task.json in {task_dir} must be an object")
+        task_id = _require_safe_id(task_data.get("task_id"), f"{task_dir.name}.task_id")
+        if task_id != task_dir.name:
+            raise ManifestError(f"task_id {task_id!r} does not match directory {task_dir.name!r}")
+        source_key = _task_source_key(task_data, repo_url)
+        if source_key not in allowed_sources:
+            raise ManifestError(
+                f"task {task_id} provenance {source_key!r} is not assigned to {worker.worker_id}"
+            )
+        if worker.source_pr is not None and task_data.get("source_pr") != worker.source_pr:
+            raise ManifestError(
+                f"task {task_id} source_pr does not match assigned PR {worker.source_pr}"
+            )
+        if worker.base_commit is not None and task_data.get("base_commit") != worker.base_commit:
+            raise ManifestError(
+                f"task {task_id} base_commit does not match its pinned candidate"
+            )
+        tasks.append(
+            GeneratedTask(
+                task_id=task_id,
+                source_key=source_key,
+                directory=task_dir,
+                tree_sha256=_tree_sha256(task_dir),
+            )
+        )
+    source_keys = [task.source_key for task in tasks]
+    if len(source_keys) != len(set(source_keys)):
+        raise ManifestError(f"worker {worker.worker_id} produced duplicate source candidates")
+    return tasks
+
+
+def _task_source_key(task_data: dict[str, Any], repo_url: str) -> str:
+    source_url = task_data.get("source_url")
+    if isinstance(source_url, str) and source_url.strip():
+        return normalize_candidate(source_url, repo_url=repo_url)
+    source_pr = task_data.get("source_pr")
+    if isinstance(source_pr, int) and not isinstance(source_pr, bool) and source_pr > 0:
+        return normalize_candidate(str(source_pr), repo_url=repo_url)
+    raise ManifestError("generated task must include source_url or a positive source_pr")
+
+
+def _repo_key(repo_url: str) -> str:
+    parsed = urlsplit(repo_url)
+    path = parsed.path.rstrip("/").removesuffix(".git")
+    if parsed.netloc and path.count("/") >= 2:
+        return f"{parsed.netloc.lower()}{path}".lower()
+    scp_match = re.fullmatch(r"[^@]+@([^:]+):(.+?)(?:\.git)?", repo_url)
+    if scp_match is not None:
+        return f"{scp_match.group(1)}/{scp_match.group(2)}".lower()
+    return repo_url.rstrip("/").removesuffix(".git").lower()
+
+
+def _require_repo_url(value: object) -> str:
+    repo_url = _require_string(value, "source.repo_url")
+    parsed = urlsplit(repo_url)
+    is_network_url = parsed.scheme in {"https", "ssh"} and bool(parsed.netloc)
+    is_scp_url = re.fullmatch(r"[^@\s]+@[^:\s]+:.+", repo_url) is not None
+    if not is_network_url and not is_scp_url:
+        raise ManifestError("source.repo_url must be an https or SSH Git URL")
+    return repo_url
+
+
+def _require_commit(value: object) -> str:
+    commit = _require_string(value, "source.commit")
+    if re.fullmatch(r"[0-9a-fA-F]{40}", commit) is None:
+        raise ManifestError("source.commit must be a full 40-character commit SHA")
+    return commit.lower()
+
+
+def _optional_commit(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    commit = _require_string(value, field)
+    if re.fullmatch(r"[0-9a-fA-F]{40}", commit) is None:
+        raise ManifestError(f"{field} must be a full 40-character commit SHA")
+    return commit.lower()
+
+
+def _validate_provenance(value: object, field: str) -> dict[str, object]:
+    data = _require_object(value, field)
+    kind = _require_string(data.get("kind"), f"{field}.kind")
+    if kind == "file":
+        path = _require_string(data.get("path"), f"{field}.path")
+        source_format = _require_string(data.get("format", "auto"), f"{field}.format")
+        if source_format not in SUPPORTED_FORMATS:
+            supported = ", ".join(sorted(SUPPORTED_FORMATS))
+            raise ManifestError(f"{field}.format must be one of {supported}")
+        message_index = data.get("message_index", 0)
+        if not isinstance(message_index, int) or isinstance(message_index, bool) or message_index < 0:
+            raise ManifestError(f"{field}.message_index must be a non-negative integer")
+        result: dict[str, object] = {
+            "kind": kind,
+            "path": path,
+            "format": source_format,
+            "message_index": message_index,
+        }
+        sha256 = data.get("sha256")
+        if sha256 is not None:
+            checksum = _require_string(sha256, f"{field}.sha256")
+            if re.fullmatch(r"[0-9a-fA-F]{64}", checksum) is None:
+                raise ManifestError(f"{field}.sha256 must be a SHA-256 hex digest")
+            result["sha256"] = checksum.lower()
+        return result
+    if kind == "url":
+        return {
+            "kind": kind,
+            "url": _require_string(data.get("url"), f"{field}.url"),
+        }
+    raise ManifestError(f"{field}.kind must be 'file' or 'url'")
+
+
+def _file_manifest(root: Path) -> list[dict[str, object]]:
+    if not root.is_dir():
+        return []
+    files: list[dict[str, object]] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise ManifestError(f"artifact symlinks are not allowed: {path.relative_to(root)}")
+        if not path.is_file():
+            continue
+        files.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                "size": path.stat().st_size,
+            }
+        )
+    return files
+
+
+def _tree_sha256(root: Path) -> str:
+    return _json_sha256(_file_manifest(root))
+
+
+def _json_sha256(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _atomic_write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    os.replace(temporary, path)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="verify and merge downloaded Modal generation artifacts")
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument(
+        "--artifacts",
+        type=Path,
+        required=True,
+        help="downloaded run directory containing workers/",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    try:
+        manifest = load_generation_manifest(args.manifest)
+        report = merge_worker_artifacts(manifest, args.artifacts, args.output)
+    except ManifestError as exc:
+        print(f"error: {exc}")
+        return 1
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/selfbench/modal_parent.py
+++ b/src/selfbench/modal_parent.py
@@ -1,0 +1,308 @@
+"""Local discovery parent for Modal generation fan-out."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from contextlib import ExitStack
+from importlib.resources import as_file, files
+from pathlib import Path
+
+from .agent_input import extract_prompt
+from .modal_generation import (
+    GenerationManifest,
+    ManifestError,
+    load_generation_manifest,
+)
+
+
+def discover_generation_manifest(
+    repo: Path,
+    tasks_root: Path,
+    output_path: Path,
+    log_path: Path,
+    *,
+    run_id: str,
+    target_count: int,
+    reserve_count: int,
+    profile: str,
+    provider: str,
+    model: str,
+    thinking: str | None,
+    pi_executable: str = "pi",
+) -> GenerationManifest:
+    """Run a read-only local Pi parent and return its validated candidate plan."""
+    repo = repo.expanduser().resolve()
+    tasks_root = tasks_root.expanduser().resolve()
+    if not repo.is_dir():
+        raise ManifestError(f"source repository does not exist: {repo}")
+    if target_count < 1 or reserve_count < 0:
+        raise ManifestError("target_count must be positive and reserve_count non-negative")
+    repo_url = _git(repo, "remote", "get-url", "origin")
+    source_commit = _remote_head(repo)
+    expected_candidates = target_count + reserve_count
+    prompt = _discovery_prompt(
+        repo=repo,
+        tasks_root=tasks_root,
+        run_id=run_id,
+        target_count=target_count,
+        expected_candidates=expected_candidates,
+        repo_url=repo_url,
+        source_commit=source_commit,
+        profile=profile,
+        provider=provider,
+        model=model,
+        thinking=thinking,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.unlink(missing_ok=True)
+    skill = files("selfbench").joinpath("skills/selfbench/SKILL.md")
+    extension = files("selfbench").joinpath("extensions/modal_generation_plan.ts")
+    with ExitStack() as stack:
+        resolved_skill = stack.enter_context(as_file(skill))
+        resolved_extension = stack.enter_context(as_file(extension))
+        command = [
+            pi_executable,
+            "--skill",
+            str(resolved_skill),
+            "--extension",
+            str(resolved_extension),
+            "--provider",
+            provider,
+            "--model",
+            model,
+            "--mode",
+            "json",
+            "--no-session",
+            "--no-approve",
+            "--tools",
+            "read,bash,grep,find,ls,submit_generation_plan",
+        ]
+        if thinking:
+            command.extend(("--thinking", thinking))
+        command.append(prompt)
+        environment = os.environ.copy()
+        environment["SELFBENCH_PLAN_OUTPUT"] = str(output_path)
+        try:
+            with log_path.open("wb") as log:
+                result = subprocess.run(
+                    command,
+                    cwd=repo,
+                    env=environment,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    check=False,
+                )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Pi executable not found: {pi_executable}") from exc
+    if result.returncode != 0:
+        raise RuntimeError(f"parent discovery exited {result.returncode}; private log: {log_path}")
+    if not output_path.is_file():
+        raise RuntimeError(f"parent discovery did not submit a plan; private log: {log_path}")
+    manifest = load_generation_manifest(output_path)
+    _validate_parent_manifest(
+        manifest,
+        run_id=run_id,
+        target_count=target_count,
+        expected_candidates=expected_candidates,
+        repo_url=repo_url,
+        source_commit=source_commit,
+        profile=profile,
+        provider=provider,
+        model=model,
+        thinking=thinking,
+    )
+    _verify_candidate_commits(repo, manifest)
+    return manifest
+
+
+def _discovery_prompt(
+    *,
+    repo: Path,
+    tasks_root: Path,
+    run_id: str,
+    target_count: int,
+    expected_candidates: int,
+    repo_url: str,
+    source_commit: str,
+    profile: str,
+    provider: str,
+    model: str,
+    thinking: str | None,
+) -> str:
+    thinking_value = f'"thinking": "{thinking}",' if thinking else ""
+    return f"""Act as the local parent for a SelfBench Modal generation run.
+
+Perform only Step 1 candidate discovery from the loaded SelfBench skill. Do not author, validate,
+audit, or modify task directories. You have local access specifically so you can search authentic
+pre-implementation provenance in Pi, Claude Code, Codex, relaymux, issue, and journal sources.
+
+Repository: {repo}
+Existing and rejected task root: {tasks_root}
+Difficulty profile: {profile}
+Validated-task target: {target_count}
+Ranked candidate count requested: {expected_candidates} ({target_count} active plus reserves)
+
+Read every existing task.json and rejection before ranking. Inspect actual diffs and test design.
+For each candidate, verify an authentic provenance source before including it. Prefer an exact local
+session path with format/message index; use a URL only for an authentic pre-implementation issue or
+request. Resolve the exact base commit and completed merge/squash commit. Exclude any candidate whose
+setup, implementation/test separation, provenance, or reproducibility is already clearly non-viable.
+
+Call submit_generation_plan exactly once with this fixed envelope:
+- schema_version: 1
+- run_id: {run_id}
+- target_count: {target_count}
+- source.repo_url: {repo_url}
+- source.commit: {source_commit}
+- agent: {{"provider": "{provider}", "model": "{model}", {thinking_value} "profile": "{profile}"}}
+- workers: exactly {expected_candidates} entries if that many strong provenance-backed candidates exist,
+  otherwise every viable candidate and no filler.
+
+Each worker must target exactly one PR, use target_count 1, and have a stable worker_id such as pr-123.
+Its request must briefly state why the implementation core is suitable and any setup/workdir facts the
+child must verify. Put entries in descending rank order. After the tool call, stop."""
+
+
+def _validate_parent_manifest(
+    manifest: GenerationManifest,
+    *,
+    run_id: str,
+    target_count: int,
+    expected_candidates: int,
+    repo_url: str,
+    source_commit: str,
+    profile: str,
+    provider: str,
+    model: str,
+    thinking: str | None,
+) -> None:
+    expected = {
+        "run_id": run_id,
+        "target_count": target_count,
+        "repo_url": repo_url,
+        "source_commit": source_commit.lower(),
+        "profile": profile,
+        "provider": provider,
+        "model": model,
+        "thinking": thinking,
+    }
+    actual = {
+        "run_id": manifest.run_id,
+        "target_count": manifest.target_count,
+        "repo_url": manifest.source_repo_url,
+        "source_commit": manifest.source_commit,
+        "profile": manifest.agent.profile,
+        "provider": manifest.agent.provider,
+        "model": manifest.agent.model,
+        "thinking": manifest.agent.thinking,
+    }
+    if actual != expected:
+        raise ManifestError("parent changed the fixed run envelope")
+    if len(manifest.workers) > expected_candidates:
+        raise ManifestError("parent returned more candidates than requested")
+    if len(manifest.workers) < target_count:
+        raise ManifestError(
+            f"parent found only {len(manifest.workers)} viable candidates for target {target_count}"
+        )
+    source_prs: set[int] = set()
+    for worker in manifest.workers:
+        if len(worker.candidates) != 1 or worker.target_count != 1:
+            raise ManifestError(f"parent worker {worker.worker_id} must contain exactly one candidate")
+        if worker.source_pr is None or worker.source_pr in source_prs:
+            raise ManifestError("parent workers must have unique positive source_pr values")
+        source_prs.add(worker.source_pr)
+        if worker.base_commit is None or worker.completed_commit is None:
+            raise ManifestError(f"parent worker {worker.worker_id} is missing pinned commits")
+        if worker.base_commit == worker.completed_commit:
+            raise ManifestError(f"parent worker {worker.worker_id} has identical base and completed commits")
+        if worker.provenance is None:
+            raise ManifestError(f"parent worker {worker.worker_id} is missing authentic provenance")
+        expected_pr_suffix = f"/pull/{worker.source_pr}"
+        candidate_url = worker.candidates[0].rstrip("/")
+        if not candidate_url.endswith(expected_pr_suffix):
+            raise ManifestError(
+                f"parent worker {worker.worker_id} candidate URL does not match source_pr"
+            )
+        if worker.provenance.get("kind") == "file":
+            path = Path(str(worker.provenance["path"])).expanduser().resolve()
+            source_format = str(worker.provenance.get("format", "auto"))
+            message_index = int(worker.provenance.get("message_index", 0))
+            try:
+                extract_prompt(path, source_format=source_format, message_index=message_index)
+            except (OSError, ValueError) as exc:
+                raise ManifestError(
+                    f"parent worker {worker.worker_id} provenance is unreadable: {exc}"
+                ) from exc
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _remote_head(repo: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "ls-remote", "origin", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    first_line = result.stdout.splitlines()[0] if result.stdout.splitlines() else ""
+    commit, separator, ref = first_line.partition("\t")
+    if not separator or ref != "HEAD" or len(commit) != 40:
+        raise ManifestError("could not resolve the source repository's remote HEAD")
+    return commit.lower()
+
+
+def _verify_candidate_commits(repo: Path, manifest: GenerationManifest) -> None:
+    commits = {
+        commit
+        for worker in manifest.workers
+        for commit in (worker.base_commit, worker.completed_commit)
+        if commit is not None
+    }
+    for commit in commits:
+        exists = subprocess.run(
+            ["git", "-C", str(repo), "cat-file", "-e", f"{commit}^{{commit}}"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode == 0
+        if not exists:
+            fetched = subprocess.run(
+                ["git", "-C", str(repo), "fetch", "--quiet", "origin", commit],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if fetched.returncode != 0:
+                raise ManifestError(f"candidate commit is not fetchable from origin: {commit}")
+    for worker in manifest.workers:
+        assert worker.base_commit is not None
+        assert worker.completed_commit is not None
+        relationship = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "merge-base",
+                "--is-ancestor",
+                worker.base_commit,
+                worker.completed_commit,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if relationship.returncode != 0:
+            raise ManifestError(
+                f"candidate {worker.worker_id} base commit is not an ancestor of its completed commit"
+            )

--- a/src/selfbench/modal_worker.py
+++ b/src/selfbench/modal_worker.py
@@ -1,0 +1,478 @@
+"""Runtime entrypoint for one SelfBench generation subagent in a Modal Sandbox."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .harbor import GENERATED_MANIFEST, build_harbor_task
+from .modal_generation import (
+    GenerationManifest,
+    ManifestError,
+    WorkerSpec,
+    build_worker_request,
+    load_generation_manifest,
+    write_worker_artifact_manifest,
+)
+from .task import Task, load_task
+
+WORK_ROOT = Path("/work")
+ARTIFACT_ROOT = Path("/artifacts")
+
+
+class CandidateRejected(ManifestError):
+    """The assigned candidate did not produce one publishable task."""
+
+
+class ProvenanceIntegrityError(RuntimeError):
+    """A staged provenance file is missing, escaped its mount, or changed."""
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    os.replace(temporary, path)
+
+
+def _run_logged(
+    command: list[str],
+    *,
+    cwd: Path,
+    stdout,
+    stderr,
+) -> None:
+    subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        stdin=subprocess.DEVNULL,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _clone_source(
+    manifest: GenerationManifest,
+    worker: WorkerSpec,
+    repo_dir: Path,
+    *,
+    stdout,
+    stderr,
+) -> None:
+    if os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"):
+        _run_logged(
+            ["gh", "auth", "setup-git"],
+            cwd=repo_dir.parent,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    _run_logged(
+        [
+            "git",
+            "clone",
+            "--no-checkout",
+            "--filter=blob:none",
+            manifest.source_repo_url,
+            str(repo_dir),
+        ],
+        cwd=repo_dir.parent,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    commits = [manifest.source_commit]
+    if worker.base_commit is not None:
+        commits.append(worker.base_commit)
+    if worker.completed_commit is not None:
+        commits.append(worker.completed_commit)
+    for commit in dict.fromkeys(commits):
+        _run_logged(
+            ["git", "fetch", "origin", commit],
+            cwd=repo_dir,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    _run_logged(
+        ["git", "checkout", "--detach", manifest.source_commit],
+        cwd=repo_dir,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    actual_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if actual_commit != manifest.source_commit:
+        raise RuntimeError(
+            f"source checkout mismatch: expected {manifest.source_commit}, got {actual_commit}"
+        )
+
+
+def _compile_task_environments(
+    tasks_root: Path,
+    repo_dir: Path,
+    output_path: Path,
+    stdout_path: Path,
+    stderr_path: Path,
+) -> None:
+    """Compile every task through the production Harbor setup contract.
+
+    This resolves package-manager and lockfile evidence from the exact base
+    snapshot and rejects conflicting/mutable setup declarations. The later
+    centralized validation still executes both images and the nop/oracle tests.
+    """
+    compiled_root = output_path.parent / "compiled-environments"
+    rows: list[dict[str, object]] = []
+    with stdout_path.open("ab") as stdout, stderr_path.open("ab") as stderr:
+        for task_dir in sorted(tasks_root.iterdir()):
+            if not task_dir.is_dir() or not (task_dir / "task.json").is_file():
+                continue
+            try:
+                task = load_task(task_dir)
+                harbor_task = build_harbor_task(task, repo_dir, compiled_root)
+                generated = json.loads((harbor_task / GENERATED_MANIFEST).read_text())
+                setup_duration = _execute_setup_smoke(
+                    task,
+                    generated.get("package_manager_profile"),
+                    repo_dir,
+                    output_path.parent / "setup-worktrees" / task.task_id,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            except (OSError, ValueError, subprocess.CalledProcessError) as exc:
+                raise CandidateRejected(
+                    f"task {task_dir.name} failed environment setup preflight: {exc}"
+                ) from exc
+            rows.append(
+                {
+                    "task_id": task.task_id,
+                    "base_commit": task.base_commit,
+                    "setup_cmd": task.setup_cmd,
+                    "setup_executed": True,
+                    "setup_duration_s": setup_duration,
+                    "workdir": task.workdir,
+                    "toolchains": task.toolchains,
+                    "package_manager_profile": generated.get("package_manager_profile"),
+                    "environment_compiler_revision": generated.get(
+                        "environment_compiler_revision"
+                    ),
+                }
+            )
+    _write_json(output_path, {"status": "executed", "tasks": rows})
+
+
+def _execute_setup_smoke(
+    task: Task,
+    package_profile: object,
+    repo_dir: Path,
+    checkout: Path,
+    *,
+    stdout,
+    stderr,
+) -> float:
+    if checkout.exists():
+        shutil.rmtree(checkout)
+    checkout.parent.mkdir(parents=True, exist_ok=True)
+    _run_logged(
+        ["git", "worktree", "add", "--force", "--detach", str(checkout), task.base_commit],
+        cwd=repo_dir,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    try:
+        _activate_package_manager(package_profile, checkout, stdout=stdout, stderr=stderr)
+        started = time.monotonic()
+        try:
+            result = subprocess.run(
+                ["bash", "-lc", task.setup_cmd],
+                cwd=checkout / task.workdir,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout,
+                stderr=stderr,
+                timeout=task.timeout_setup,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise CandidateRejected(
+                f"setup command timed out after {task.timeout_setup}s"
+            ) from exc
+        duration = round(time.monotonic() - started, 3)
+        if result.returncode != 0:
+            raise CandidateRejected(f"setup command exited {result.returncode}")
+        return duration
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(checkout)],
+            cwd=repo_dir,
+            stdout=stdout,
+            stderr=stderr,
+            check=False,
+        )
+        if checkout.exists():
+            shutil.rmtree(checkout)
+
+
+def _activate_package_manager(
+    package_profile: object,
+    cwd: Path,
+    *,
+    stdout,
+    stderr,
+) -> None:
+    if package_profile is None:
+        return
+    if not isinstance(package_profile, dict):
+        raise CandidateRejected("compiled package-manager profile is invalid")
+    manager = package_profile.get("manager")
+    version = package_profile.get("version")
+    specifier = package_profile.get("specifier")
+    if not all(isinstance(value, str) and value for value in (manager, version, specifier)):
+        raise CandidateRejected("compiled package-manager profile is incomplete")
+    if manager in {"pnpm", "yarn"}:
+        commands = [
+            ["corepack", "enable"],
+            ["corepack", "install", "--global", specifier],
+        ]
+    elif manager in {"npm", "bun"}:
+        commands = [["npm", "install", "--global", specifier]]
+    else:
+        raise CandidateRejected(f"unsupported package manager in compiled profile: {manager}")
+    for command in commands:
+        _run_logged(command, cwd=cwd, stdout=stdout, stderr=stderr)
+    actual = subprocess.run(
+        [manager, "--version"],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if actual != version:
+        raise CandidateRejected(
+            f"activated {manager} version {actual!r}, expected {version!r}"
+        )
+
+
+def _run_create(
+    manifest: GenerationManifest,
+    worker: WorkerSpec,
+    repo_dir: Path,
+    tasks_root: Path,
+    *,
+    stdout,
+    stderr,
+) -> None:
+    command = [
+        "selfbench",
+        "create",
+        "--repo",
+        str(repo_dir),
+        "--tasks-root",
+        str(tasks_root),
+        "--count",
+        str(worker.target_count),
+        "--profile",
+        manifest.agent.profile,
+        "--provider",
+        manifest.agent.provider,
+        "--model",
+        manifest.agent.model,
+        "--print",
+    ]
+    if manifest.agent.thinking:
+        command.extend(("--thinking", manifest.agent.thinking))
+    command.append(build_worker_request(manifest, worker))
+    _run_logged(command, cwd=repo_dir, stdout=stdout, stderr=stderr)
+
+
+def _verify_provenance(worker: WorkerSpec, artifact_root: Path = ARTIFACT_ROOT) -> None:
+    provenance = worker.provenance
+    if provenance is None or provenance.get("kind") != "file":
+        return
+    path = Path(str(provenance.get("path", ""))).resolve()
+    if not path.is_relative_to(artifact_root.resolve()) or not path.is_file():
+        raise ProvenanceIntegrityError("staged provenance is outside the artifact mount or missing")
+    expected = provenance.get("sha256")
+    if not isinstance(expected, str):
+        raise ProvenanceIntegrityError("staged provenance has no SHA-256 digest")
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    if digest.hexdigest() != expected:
+        raise ProvenanceIntegrityError("staged provenance SHA-256 does not match")
+
+
+def run_worker(manifest: GenerationManifest, worker: WorkerSpec) -> dict[str, object]:
+    build_commit = os.environ.get("SELFBENCH_BUILD_COMMIT") or "unknown"
+    run_root = ARTIFACT_ROOT / "runs" / manifest.run_id
+    final_root = run_root / "workers" / worker.worker_id
+    status_path = run_root / "statuses" / f"{worker.worker_id}.json"
+    failure_root = run_root / "failures" / worker.worker_id
+    expected_fingerprint = manifest.worker_fingerprint(worker)
+    if (final_root / "_SUCCESS").is_file():
+        if (final_root / "_SUCCESS").read_text().strip() != expected_fingerprint:
+            raise ManifestError(
+                f"run {manifest.run_id} already has incompatible artifacts for {worker.worker_id}"
+            )
+        return {"worker_id": worker.worker_id, "status": "skipped", "tasks": worker.target_count}
+
+    work_dir = WORK_ROOT / manifest.run_id / worker.worker_id
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+    work_dir.mkdir(parents=True)
+    repo_dir = work_dir / "repo"
+    tasks_root = work_dir / "tasks"
+    stdout_path = work_dir / "stdout.log"
+    stderr_path = work_dir / "stderr.log"
+    request = build_worker_request(manifest, worker)
+    request_record = {
+        "run_id": manifest.run_id,
+        "run_fingerprint": manifest.fingerprint,
+        "worker": worker.as_dict(),
+        "source": {
+            "repo_url": manifest.source_repo_url,
+            "commit": manifest.source_commit,
+        },
+        "agent": manifest.agent.as_dict(),
+        "request": request,
+        "selfbench_commit": build_commit,
+    }
+    started_at = _utc_now()
+    _write_json(
+        status_path,
+        {
+            "worker_id": worker.worker_id,
+            "status": "running",
+            "started_at": started_at,
+            "worker_fingerprint": expected_fingerprint,
+        },
+    )
+
+    try:
+        with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+            _verify_provenance(worker)
+            _clone_source(manifest, worker, repo_dir, stdout=stdout, stderr=stderr)
+            _run_create(
+                manifest,
+                worker,
+                repo_dir,
+                tasks_root,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        authored_tasks = [
+            path
+            for path in tasks_root.iterdir()
+            if path.is_dir() and (path / "task.json").is_file()
+        ] if tasks_root.is_dir() else []
+        if not authored_tasks:
+            raise CandidateRejected("assigned candidate produced no publishable task directory")
+        _compile_task_environments(
+            tasks_root,
+            repo_dir,
+            work_dir / "setup-preflight.json",
+            stdout_path,
+            stderr_path,
+        )
+
+        staging_root = run_root / ".staging" / f"{worker.worker_id}-{os.getpid()}"
+        if staging_root.exists():
+            shutil.rmtree(staging_root)
+        staging_root.mkdir(parents=True)
+        shutil.copytree(tasks_root, staging_root / "tasks")
+        shutil.copy2(stdout_path, staging_root / "stdout.log")
+        shutil.copy2(stderr_path, staging_root / "stderr.log")
+        shutil.copy2(work_dir / "setup-preflight.json", staging_root / "setup-preflight.json")
+        _write_json(staging_root / "request.json", request_record)
+        write_worker_artifact_manifest(
+            staging_root,
+            staging_root / "tasks",
+            manifest,
+            worker,
+            build_commit=build_commit,
+        )
+        (staging_root / "_SUCCESS").write_text(expected_fingerprint + "\n")
+        final_root.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(staging_root, final_root)
+        if failure_root.exists():
+            shutil.rmtree(failure_root)
+        _write_json(
+            status_path,
+            {
+                "worker_id": worker.worker_id,
+                "status": "complete",
+                "started_at": started_at,
+                "completed_at": _utc_now(),
+                "worker_fingerprint": expected_fingerprint,
+                "tasks": worker.target_count,
+            },
+        )
+        return {"worker_id": worker.worker_id, "status": "complete", "tasks": worker.target_count}
+    except Exception as exc:  # noqa: BLE001 - persist every sandbox failure before exit
+        status = "rejected" if isinstance(exc, ManifestError) else "failed"
+        failure_root.mkdir(parents=True, exist_ok=True)
+        for path in (stdout_path, stderr_path):
+            if path.is_file():
+                shutil.copy2(path, failure_root / path.name)
+        if tasks_root.is_dir():
+            rejected_tasks = failure_root / "tasks"
+            if rejected_tasks.exists():
+                shutil.rmtree(rejected_tasks)
+            shutil.copytree(tasks_root, rejected_tasks)
+        _write_json(failure_root / "request.json", request_record)
+        _write_json(
+            status_path,
+            {
+                "worker_id": worker.worker_id,
+                "status": status,
+                "started_at": started_at,
+                "completed_at": _utc_now(),
+                "worker_fingerprint": expected_fingerprint,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+        return {"worker_id": worker.worker_id, "status": status, "error": type(exc).__name__}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="run one generation worker inside a Modal Sandbox")
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--worker-id", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    manifest = load_generation_manifest(args.manifest)
+    worker = next(
+        (item for item in manifest.workers if item.worker_id == args.worker_id),
+        None,
+    )
+    if worker is None:
+        raise ManifestError(f"worker {args.worker_id!r} is not declared in the manifest")
+    result = run_worker(manifest, worker)
+    print(json.dumps(result, sort_keys=True))
+    if result["status"] == "failed":
+        return 1
+    if result["status"] == "rejected":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_modal_generation.py
+++ b/tests/test_modal_generation.py
@@ -1,0 +1,461 @@
+"""Tests for standalone Modal generation manifests and artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from selfbench.modal_generation import (
+    GenerationManifest,
+    ManifestError,
+    build_worker_request,
+    merge_worker_artifacts,
+    normalize_candidate,
+    verify_worker_artifacts,
+    write_worker_artifact_manifest,
+)
+from selfbench.modal_parent import _validate_parent_manifest, _verify_candidate_commits
+from selfbench.modal_worker import (
+    CandidateRejected,
+    ProvenanceIntegrityError,
+    _execute_setup_smoke,
+    _verify_provenance,
+)
+from selfbench.task import Task
+
+SOURCE_COMMIT = "a" * 40
+REPO_URL = "https://github.com/example/project.git"
+
+
+def manifest_data(*, workers: list[dict[str, object]] | None = None) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "run_id": "example-run",
+        "source": {"repo_url": REPO_URL, "commit": SOURCE_COMMIT},
+        "agent": {
+            "provider": "openai",
+            "model": "gpt-5.6-sol",
+            "thinking": "xhigh",
+            "profile": "hard",
+        },
+        "workers": workers
+        or [
+            {
+                "worker_id": "shard-00",
+                "candidates": ["https://github.com/example/project/pull/101"],
+                "target_count": 1,
+            }
+        ],
+    }
+
+
+def write_task(tasks_root: Path, task_id: str, pull_number: int) -> Path:
+    task_dir = tasks_root / task_id
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.json").write_text(
+        json.dumps(
+            {
+                "task_id": task_id,
+                "repo": "example/project",
+                "source_pr": pull_number,
+            }
+        )
+    )
+    (task_dir / "gold.patch").write_text(f"gold for {task_id}\n")
+    return task_dir
+
+
+def complete_worker(
+    run_root: Path,
+    manifest: GenerationManifest,
+    worker_index: int,
+    *,
+    task_id: str,
+    pull_number: int,
+) -> Path:
+    worker = manifest.workers[worker_index]
+    worker_root = run_root / "workers" / worker.worker_id
+    tasks_root = worker_root / "tasks"
+    write_task(tasks_root, task_id, pull_number)
+    write_worker_artifact_manifest(
+        worker_root,
+        tasks_root,
+        manifest,
+        worker,
+        build_commit="b" * 40,
+    )
+    (worker_root / "_SUCCESS").write_text(manifest.worker_fingerprint(worker) + "\n")
+    return worker_root
+
+
+class ManifestTest(unittest.TestCase):
+    def test_parses_explicit_shards_and_has_stable_fingerprint(self) -> None:
+        first = GenerationManifest.from_dict(manifest_data())
+        second = GenerationManifest.from_dict(first.as_dict())
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.fingerprint, second.fingerprint)
+        self.assertEqual(first.workers[0].target_count, 1)
+
+    def test_requires_a_full_pinned_source_commit(self) -> None:
+        data = manifest_data()
+        data["source"] = {"repo_url": REPO_URL, "commit": "main"}
+
+        with self.assertRaisesRegex(ManifestError, "full 40-character commit SHA"):
+            GenerationManifest.from_dict(data)
+
+    def test_rejects_duplicate_candidates_across_workers(self) -> None:
+        candidate = "https://github.com/example/project/pull/101"
+        data = manifest_data(
+            workers=[
+                {"worker_id": "one", "candidates": [candidate]},
+                {"worker_id": "two", "candidates": [candidate + "/"]},
+            ]
+        )
+
+        with self.assertRaisesRegex(ManifestError, "disjoint"):
+            GenerationManifest.from_dict(data)
+
+    def test_target_count_cannot_exceed_candidate_count(self) -> None:
+        data = manifest_data()
+        workers = data["workers"]
+        assert isinstance(workers, list)
+        workers[0]["target_count"] = 2
+
+        with self.assertRaisesRegex(ManifestError, "cannot exceed"):
+            GenerationManifest.from_dict(data)
+
+    def test_candidate_normalization_matches_url_and_source_pr(self) -> None:
+        url_key = normalize_candidate("https://github.com/example/project/pull/101/")
+        number_key = normalize_candidate("101", repo_url=REPO_URL)
+
+        self.assertEqual(url_key, number_key)
+
+    def test_worker_request_forbids_discovery_and_remote_validation(self) -> None:
+        manifest = GenerationManifest.from_dict(manifest_data())
+        request = build_worker_request(manifest, manifest.workers[0])
+
+        self.assertIn("Use only the assigned", request)
+        self.assertIn("Do not discover", request)
+        self.assertIn("Do not run Harbor", request)
+        self.assertIn("centralized validation", request)
+        self.assertIn("repository-native setup command", request)
+        self.assertIn("frozen lockfile", request)
+
+    def test_parent_manifest_requires_pinned_candidate_metadata(self) -> None:
+        data = manifest_data()
+        workers = data["workers"]
+        assert isinstance(workers, list)
+        workers[0].update(
+            {
+                "source_pr": 101,
+                "base_commit": "b" * 40,
+                "completed_commit": "c" * 40,
+                "provenance": {
+                    "kind": "url",
+                    "url": "https://github.com/example/project/issues/99",
+                },
+                "request": "Behavioral parser change with separable tests.",
+            }
+        )
+        manifest = GenerationManifest.from_dict(data)
+
+        _validate_parent_manifest(
+            manifest,
+            run_id="example-run",
+            target_count=1,
+            expected_candidates=1,
+            repo_url=REPO_URL,
+            source_commit=SOURCE_COMMIT,
+            profile="hard",
+            provider="openai",
+            model="gpt-5.6-sol",
+            thinking="xhigh",
+        )
+
+    def test_parent_manifest_rejects_missing_candidate_commits(self) -> None:
+        data = manifest_data()
+        workers = data["workers"]
+        assert isinstance(workers, list)
+        workers[0]["source_pr"] = 101
+        manifest = GenerationManifest.from_dict(data)
+
+        with self.assertRaisesRegex(ManifestError, "missing pinned commits"):
+            _validate_parent_manifest(
+                manifest,
+                run_id="example-run",
+                target_count=1,
+                expected_candidates=1,
+                repo_url=REPO_URL,
+                source_commit=SOURCE_COMMIT,
+                profile="hard",
+                provider="openai",
+                model="gpt-5.6-sol",
+                thinking="xhigh",
+            )
+
+
+class ArtifactTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_completed_worker_verifies_and_merges_idempotently(self) -> None:
+        manifest = GenerationManifest.from_dict(manifest_data())
+        run_root = self.root / "downloaded-run"
+        worker_root = complete_worker(
+            run_root,
+            manifest,
+            0,
+            task_id="task-101",
+            pull_number=101,
+        )
+
+        verified = verify_worker_artifacts(worker_root, manifest, manifest.workers[0])
+        self.assertEqual([task.task_id for task in verified], ["task-101"])
+
+        output = self.root / "tasks"
+        first = merge_worker_artifacts(manifest, run_root, output)
+        second = merge_worker_artifacts(manifest, run_root, output)
+        self.assertEqual(first, second)
+        self.assertTrue((output / "task-101" / "task.json").is_file())
+        self.assertTrue((output / ".selfbench-generation.json").is_file())
+
+    def test_tampered_task_file_is_rejected(self) -> None:
+        manifest = GenerationManifest.from_dict(manifest_data())
+        run_root = self.root / "downloaded-run"
+        worker_root = complete_worker(
+            run_root,
+            manifest,
+            0,
+            task_id="task-101",
+            pull_number=101,
+        )
+        (worker_root / "tasks" / "task-101" / "gold.patch").write_text("tampered\n")
+
+        with self.assertRaisesRegex(ManifestError, "hashes do not match"):
+            verify_worker_artifacts(worker_root, manifest, manifest.workers[0])
+
+    def test_unassigned_task_provenance_is_rejected_before_completion(self) -> None:
+        manifest = GenerationManifest.from_dict(manifest_data())
+        worker = manifest.workers[0]
+        worker_root = self.root / "worker"
+        tasks_root = worker_root / "tasks"
+        write_task(tasks_root, "task-999", 999)
+
+        with self.assertRaisesRegex(ManifestError, "is not assigned"):
+            write_worker_artifact_manifest(
+                worker_root,
+                tasks_root,
+                manifest,
+                worker,
+                build_commit="b" * 40,
+            )
+
+    def test_duplicate_task_id_across_workers_is_rejected(self) -> None:
+        manifest = GenerationManifest.from_dict(
+            manifest_data(
+                workers=[
+                    {
+                        "worker_id": "one",
+                        "candidates": ["https://github.com/example/project/pull/101"],
+                    },
+                    {
+                        "worker_id": "two",
+                        "candidates": ["https://github.com/example/project/pull/102"],
+                    },
+                ]
+            )
+        )
+        run_root = self.root / "downloaded-run"
+        complete_worker(run_root, manifest, 0, task_id="same-task", pull_number=101)
+        complete_worker(run_root, manifest, 1, task_id="same-task", pull_number=102)
+
+        with self.assertRaisesRegex(ManifestError, "duplicate generated task_id"):
+            merge_worker_artifacts(manifest, run_root, self.root / "tasks")
+
+    def test_existing_different_task_is_not_overwritten(self) -> None:
+        manifest = GenerationManifest.from_dict(manifest_data())
+        run_root = self.root / "downloaded-run"
+        complete_worker(run_root, manifest, 0, task_id="task-101", pull_number=101)
+        output = self.root / "tasks"
+        write_task(output, "task-101", 101)
+        (output / "task-101" / "gold.patch").write_text("local content\n")
+
+        with self.assertRaisesRegex(ManifestError, "existing task conflicts"):
+            merge_worker_artifacts(manifest, run_root, output)
+
+    def test_reserve_worker_is_not_required_after_target_is_met(self) -> None:
+        data = manifest_data(
+            workers=[
+                {
+                    "worker_id": "active",
+                    "candidates": ["https://github.com/example/project/pull/101"],
+                },
+                {
+                    "worker_id": "reserve",
+                    "candidates": ["https://github.com/example/project/pull/102"],
+                },
+            ]
+        )
+        data["target_count"] = 1
+        manifest = GenerationManifest.from_dict(data)
+        run_root = self.root / "downloaded-run"
+        complete_worker(run_root, manifest, 0, task_id="task-101", pull_number=101)
+
+        report = merge_worker_artifacts(manifest, run_root, self.root / "tasks")
+
+        self.assertEqual([task["task_id"] for task in report["tasks"]], ["task-101"])
+
+    def test_merge_fails_when_reserves_do_not_fill_target(self) -> None:
+        manifest = GenerationManifest.from_dict(manifest_data())
+
+        with self.assertRaisesRegex(ManifestError, "0 completed tasks; expected exactly 1"):
+            merge_worker_artifacts(manifest, self.root / "downloaded-run", self.root / "tasks")
+
+    def test_staged_provenance_must_match_its_hash(self) -> None:
+        provenance = self.root / "inputs" / "session.jsonl"
+        provenance.parent.mkdir()
+        provenance.write_text("original\n")
+        checksum = hashlib.sha256(provenance.read_bytes()).hexdigest()
+        data = manifest_data()
+        workers = data["workers"]
+        assert isinstance(workers, list)
+        workers[0]["provenance"] = {
+            "kind": "file",
+            "path": str(provenance),
+            "format": "auto",
+            "message_index": 0,
+            "sha256": checksum,
+        }
+        worker = GenerationManifest.from_dict(data).workers[0]
+
+        _verify_provenance(worker, self.root)
+        provenance.write_text("changed\n")
+        with self.assertRaisesRegex(ProvenanceIntegrityError, "does not match"):
+            _verify_provenance(worker, self.root)
+
+
+class CandidateCommitTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name)
+        subprocess.run(["git", "init", "-q", str(self.repo)], check=True)
+        subprocess.run(
+            ["git", "-C", str(self.repo), "config", "user.email", "test@example.com"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.repo), "config", "user.name", "Test"],
+            check=True,
+        )
+        (self.repo / "file.txt").write_text("base\n")
+        subprocess.run(["git", "-C", str(self.repo), "add", "file.txt"], check=True)
+        subprocess.run(["git", "-C", str(self.repo), "commit", "-qm", "base"], check=True)
+        self.base = self._git("rev-parse", "HEAD")
+        (self.repo / "file.txt").write_text("complete\n")
+        subprocess.run(["git", "-C", str(self.repo), "commit", "-qam", "complete"], check=True)
+        self.completed = self._git("rev-parse", "HEAD")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(self.repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def _manifest(self, base: str, completed: str) -> GenerationManifest:
+        data = manifest_data()
+        workers = data["workers"]
+        assert isinstance(workers, list)
+        workers[0].update(
+            {
+                "source_pr": 101,
+                "base_commit": base,
+                "completed_commit": completed,
+                "provenance": {
+                    "kind": "url",
+                    "url": "https://github.com/example/project/issues/99",
+                },
+            }
+        )
+        return GenerationManifest.from_dict(data)
+
+    def test_accepts_ancestor_base_commit(self) -> None:
+        _verify_candidate_commits(self.repo, self._manifest(self.base, self.completed))
+
+    def test_rejects_non_ancestor_base_commit(self) -> None:
+        with self.assertRaisesRegex(ManifestError, "is not an ancestor"):
+            _verify_candidate_commits(self.repo, self._manifest(self.completed, self.base))
+
+    def test_setup_smoke_runs_in_fresh_base_worktree(self) -> None:
+        task = Task(
+            task_id="setup-smoke",
+            repo="example/project",
+            base_commit=self.base,
+            workdir=".",
+            setup_cmd="test \"$(cat file.txt)\" = base",
+            test_cmd="true {tests}",
+            fail_to_pass=["test"],
+            pass_to_pass=[],
+        )
+        stdout_path = self.repo / "setup-stdout.log"
+        stderr_path = self.repo / "setup-stderr.log"
+        with tempfile.TemporaryDirectory() as setup_root:
+            checkout = Path(setup_root) / "checkout"
+            with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+                duration = _execute_setup_smoke(
+                    task,
+                    None,
+                    self.repo,
+                    checkout,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+
+            self.assertGreaterEqual(duration, 0)
+            self.assertFalse(checkout.exists())
+
+    def test_setup_smoke_rejects_failed_setup(self) -> None:
+        task = Task(
+            task_id="setup-fail",
+            repo="example/project",
+            base_commit=self.base,
+            workdir=".",
+            setup_cmd="exit 23",
+            test_cmd="true {tests}",
+            fail_to_pass=["test"],
+            pass_to_pass=[],
+        )
+        with tempfile.TemporaryDirectory() as setup_root:
+            checkout = Path(setup_root) / "checkout"
+            with (self.repo / "fail-stdout.log").open("wb") as stdout, (
+                self.repo / "fail-stderr.log"
+            ).open("wb") as stderr, self.assertRaisesRegex(
+                CandidateRejected, "setup command exited 23"
+            ):
+                _execute_setup_smoke(
+                    task,
+                    None,
+                    self.repo,
+                    checkout,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+
+            self.assertFalse(checkout.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a restartable cloud-generation workflow where a local parent ranks provenance-backed candidates and fans each assigned PR out to a fresh Modal Sandbox.

- Keeps candidate discovery local so existing tasks, rejections, and private provenance remain available.
- Enforces exact base-snapshot package-manager setup before artifacts can be accepted.
- Pulls hash-verified task artifacts back into the local task tree without running solver rollouts.

## Design

### Parent planning and fan-out

- `src/selfbench/modal_parent.py` runs a read-only local Pi parent and validates the fixed run envelope, candidate commits, and provenance.
- `src/selfbench/extensions/modal_generation_plan.ts` provides the terminating structured-output tool for ranked candidates and reserves.
- `scripts/modal_generate.py` stages allowlisted provenance into a private Volume, launches one fresh Sandbox per candidate, replenishes rejected candidates from reserves, and supports resume/pull operations.

### Sandbox execution and artifacts

- `src/selfbench/modal_worker.py` clones pinned commits, invokes Pi for exactly one PR, compiles the Harbor environment, activates the selected package manager, executes setup in a fresh base worktree, and publishes status and artifacts.
- `src/selfbench/modal_generation.py` owns manifest validation and fingerprints, duplicate/provenance checks, artifact hashing, and atomic local reduction.
- `tests/test_modal_generation.py` covers the parent envelope, commit ancestry, setup smoke checks, artifact integrity, reserves, and reducer conflicts.

### SWE-bench-style setup contract

- `src/selfbench/harbor.py` resolves the package manager and lockfile from the exact base snapshot, pins npm/pnpm/Yarn/Bun, and rejects conflicting or mutable setup.
- `tests/test_runner.py` covers setup profiles, lockfiles, workdirs, stale reuse, and package-manager conflicts.
- `docs/modal-generation.md` documents secrets, Volume setup, run/resume/pull behavior, and validation.

## Validation

- `bun run validate` — passed: 181 Python tests, review TypeScript typecheck, and production build.
- `uv run python -m unittest tests.test_modal_generation -v` — passed: 20 tests.
- `uvx ruff check src/selfbench/modal_generation.py src/selfbench/modal_parent.py src/selfbench/modal_worker.py scripts/modal_generate.py tests/test_modal_generation.py` — passed.
- `git diff --check` — passed.
- Modal 1.5.3 app import and entrypoint parsing, Pi 0.83 extension loading, and wheel package contents were verified offline.
- Not run: a live Modal image build, Sandbox/provider smoke test, or deterministic Modal validation; no paid cloud work was authorized.
