### PR TITLE
chore: harden selfbench quality and packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
       - run: bun run validate
         env:
           UV_PYTHON: "3.12"
+      - run: uv build
+      - name: Verify packaged review console
+        run: uv run python scripts/verify-wheel-review-assets.py dist/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
+      - uses: oven-sh/setup-bun@v2
       - name: Verify release version
         run: test "v$(uv version --short)" = "$GITHUB_REF_NAME"
+      - run: bun install --frozen-lockfile
+      - run: bun run build:review
       - run: uv build
+      - name: Verify packaged review console
+        run: uv run python scripts/verify-wheel-review-assets.py dist/*.whl
       - run: uv publish --trusted-publishing always

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/selfbench/review_dist/
 /harbor-tasks/
 /harbor-jobs/
 logs/
+.pi-subagents/

--- a/docs/authoring-evals.md
+++ b/docs/authoring-evals.md
@@ -81,7 +81,7 @@ If a source session needs to be reconstructed into a standalone prompt, keep the
 | `network_mode` | no | `public`, `no-network`, or `allowlist`; default `public`. |
 | `agent_network_mode` | no | Network policy while the coding agent works; default `allowlist`. |
 | `agent_allowed_hosts` | no | Extra hosts available during the coding-agent phase. |
-| `verifier_network_mode` | no | Network policy for held-out grading; default `public`. |
+| `verifier_network_mode` | no | Network policy for held-out grading; default `no-network`. |
 | `cpus` | no | Container CPU count; default `4`. |
 | `memory_mb` | no | Container memory in MB; default `8192`. |
 | `storage_mb` | no | Container storage in MB; default `20480`. |
@@ -112,7 +112,7 @@ git -C ~/code/my-project diff --binary "$BASE_SHA" "$COMPLETED_SHA" \
   -- src/feature.ts > tasks/example-fix/gold.patch
 ```
 
-Every file owned by `test.patch` must fall below a `test_paths` entry. Before grading, the verifier removes agent edits to those paths and applies the held-out test patch.
+Every file owned by `test.patch` must fall below a `test_paths` entry. Before grading, the verifier terminates processes left by solver-controlled setup, removes agent edits to those paths, applies the held-out test patch, and makes those paths root-owned and non-writable. Tests still execute code under test in the same process/filesystem, so this prevents background persistence and default egress rather than claiming impossible runtime secrecy.
 
 ## Select tests
 

--- a/docs/modal-generation.md
+++ b/docs/modal-generation.md
@@ -13,9 +13,14 @@ review pass.
 
 1. A read-only local Pi parent ranks `count + reserve_count` merged pull requests. It verifies an
    authentic pre-implementation provenance source and emits a schema-validated plan.
-2. The coordinator uploads only the selected provenance files to a private Modal Volume. Paths are
-   restricted to the source repository and known Pi, Claude, Codex, relaymux, and handoff roots.
-   Credential-like files and provenance files larger than 50 MiB are rejected.
+2. The coordinator locally extracts the selected engineer prompt, redacts recognized credential
+   forms (including common bearer, AWS, npm/GitLab, database/password, and private-key forms), and
+   uploads it as a one-message generic JSON artifact to a private Modal Volume. Raw session exports,
+   tool results, assistant responses, and other human turns are never uploaded. This is
+   defense-in-depth pattern filtering, not a guarantee that arbitrary prose contains no sensitive
+   data. Source paths are restricted to the source repository and known Pi, Claude, Codex, relaymux,
+   and handoff roots; credential-like source files and provenance files larger than 50 MiB are
+   rejected.
 3. The coordinator starts one candidate per Modal Sandbox, up to the configured concurrency. Each
    Sandbox has an isolated repository clone, Pi session, and output path.
 4. A child either publishes one task or records a structured rejection. Rejections consume the next

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "test": "uv run python -m unittest discover -s tests -v",
-    "validate": "bun run test && bun run typecheck:review && bun run build:review",
+    "test:review": "bun test review/src/detail-loader.test.ts",
+    "validate": "bun run test && bun run test:review && bun run typecheck:review && bun run build:review",
     "dev:review": "vite --config review/vite.config.ts",
     "build:review": "vite build --config review/vite.config.ts",
     "typecheck:review": "tsc --noEmit -p review/tsconfig.json"

--- a/review/src/App.tsx
+++ b/review/src/App.tsx
@@ -2,6 +2,7 @@ import { parsePatchFiles } from '@pierre/diffs';
 import { FileDiff } from '@pierre/diffs/react';
 import React from 'react';
 
+import { loadGuardedTaskDetail } from './detail-loader';
 import type { PromptOrigin, ReviewStatus, RunDetail, SourceTrace, Summaries, TaskDetail, TaskSummary, Verdict } from './types';
 
 type Tab = 'prompt' | 'source' | 'task' | 'test' | 'gold' | 'validation' | 'runs';
@@ -32,6 +33,11 @@ export function App() {
     return value && tabs.includes(value) ? value : 'prompt';
   });
   const [error, setError] = React.useState<string | null>(null);
+  const selectedRef = React.useRef(selected);
+  selectedRef.current = selected;
+
+  const fetchDetail = React.useCallback((taskId: string, signal: AbortSignal) =>
+    getJson<TaskDetail>(`/api/tasks/${encodeURIComponent(taskId)}`, { signal }), []);
 
   const refreshSummaries = React.useCallback(async () => {
     const next = await getJson<Summaries>('/api/tasks');
@@ -51,10 +57,19 @@ export function App() {
       setDetail(null);
       return;
     }
-    getJson<TaskDetail>(`/api/tasks/${encodeURIComponent(selected)}`)
-      .then(setDetail)
-      .catch((nextError: unknown) => setError(String(nextError)));
-  }, [selected]);
+    const controller = new AbortController();
+    setDetail(null);
+    loadGuardedTaskDetail(
+      selected,
+      controller.signal,
+      (taskId) => selectedRef.current === taskId,
+      fetchDetail,
+      setDetail,
+    ).catch((nextError: unknown) => {
+      if (!controller.signal.aborted) setError(String(nextError));
+    });
+    return () => controller.abort();
+  }, [fetchDetail, selected]);
 
   React.useEffect(() => {
     const url = new URL(window.location.href);
@@ -86,9 +101,23 @@ export function App() {
 
   const refresh = React.useCallback(async () => {
     setError(null);
-    await refreshSummaries();
-    if (selected) setDetail(await getJson<TaskDetail>(`/api/tasks/${encodeURIComponent(selected)}`));
-  }, [refreshSummaries, selected]);
+    const controller = new AbortController();
+    const taskId = selectedRef.current;
+    try {
+      await refreshSummaries();
+      if (taskId && selectedRef.current === taskId) {
+        await loadGuardedTaskDetail(
+          taskId,
+          controller.signal,
+          (candidate) => selectedRef.current === candidate,
+          fetchDetail,
+          setDetail,
+        );
+      }
+    } finally {
+      controller.abort();
+    }
+  }, [fetchDetail, refreshSummaries]);
 
   if (error) return <ErrorState error={error} onRetry={() => void refresh()} />;
   if (!summaries) return <div className="page-state">Loading tasks…</div>;
@@ -127,7 +156,12 @@ export function App() {
           nextTask={nextTask}
           onNavigate={setSelected}
           onTab={setTab}
-          onSaved={(nextDetail) => { setDetail(nextDetail); void refreshSummaries(); }}
+          onSaved={(nextDetail) => {
+            // A completed save may outlive its panel after navigation. Replace
+            // detail only when it still represents the same selected task.
+            setDetail((current) => current?.summary.task_id === nextDetail.summary.task_id ? nextDetail : current);
+            void refreshSummaries();
+          }}
         />
       </main>
     </div>
@@ -152,8 +186,8 @@ function Sidebar({ summaries, tasks, selected, filter, search, onFilter, onSearc
           <Count label="In Review" value={summaries.review_counts.in_review ?? 0} />
           <Count label="Approved" value={summaries.review_counts.approved ?? 0} />
         </div>
-        <input value={search} onChange={(event) => onSearch(event.target.value)} placeholder="Search task, workdir, PR" />
-        <select value={filter} onChange={(event) => onFilter(event.target.value as Filter)}>
+        <input aria-label="Search tasks" value={search} onChange={(event) => onSearch(event.target.value)} placeholder="Search task, workdir, PR" />
+        <select aria-label="Filter tasks" value={filter} onChange={(event) => onFilter(event.target.value as Filter)}>
           <option value="all">All Tasks</option>
           <optgroup label="Review Status">
             {reviewStatuses.map((status) => <option key={status} value={`review:${status}`}>{humanize(status)} ({summaries.review_counts[status] ?? 0})</option>)}
@@ -205,21 +239,36 @@ function Detail({ detail, tab, previousTask, nextTask, onNavigate, onTab, onSave
         <ReviewPanel key={detail.summary.task_id} detail={detail} onSaved={onSaved} />
         <section className="panel tab-panel">
           <div className="tabs" role="tablist" aria-label="Task detail">
-            {tabs.map((value) => (
+            {tabs.map((value, index) => (
               <button
                 key={value}
+                id={`task-tab-${value}`}
                 className="tab"
                 data-active={tab === value}
                 type="button"
                 role="tab"
                 aria-selected={tab === value}
+                aria-controls="task-tabpanel"
+                tabIndex={tab === value ? 0 : -1}
                 onClick={() => onTab(value)}
+                onKeyDown={(event) => {
+                  let nextIndex: number | null = null;
+                  if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+                  if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+                  if (event.key === 'Home') nextIndex = 0;
+                  if (event.key === 'End') nextIndex = tabs.length - 1;
+                  if (nextIndex === null) return;
+                  event.preventDefault();
+                  const next = tabs[nextIndex];
+                  onTab(next);
+                  document.getElementById(`task-tab-${next}`)?.focus();
+                }}
               >
                 {tabLabel(value)}
               </button>
             ))}
           </div>
-          <div className="panel-body tab-content"><TabContent tab={tab} detail={detail} /></div>
+          <div id="task-tabpanel" className="panel-body tab-content" role="tabpanel" aria-labelledby={`task-tab-${tab}`}><TabContent tab={tab} detail={detail} /></div>
         </section>
       </div>
     </section>
@@ -254,9 +303,11 @@ function ReviewPanel({ detail, onSaved }: { detail: TaskDetail; onSaved: (detail
   const [reviewed, setReviewed] = React.useState(() => new Set(detail.summary.quality.reviewed_warnings ?? []));
   const [status, setStatus] = React.useState<ReviewStatus>(detail.summary.review_status);
   const [saving, setSaving] = React.useState(false);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
 
   async function save() {
     setSaving(true);
+    setSaveError(null);
     try {
       const next = await getJson<TaskDetail>(`/api/tasks/${encodeURIComponent(detail.summary.task_id)}/quality`, {
         method: 'POST',
@@ -264,6 +315,8 @@ function ReviewPanel({ detail, onSaved }: { detail: TaskDetail; onSaved: (detail
         body: JSON.stringify({ review_notes: notes, reviewed_warnings: [...reviewed], review_status: status }),
       });
       onSaved(next);
+    } catch (nextError: unknown) {
+      setSaveError(String(nextError));
     } finally {
       setSaving(false);
     }
@@ -275,6 +328,7 @@ function ReviewPanel({ detail, onSaved }: { detail: TaskDetail; onSaved: (detail
         <div><div className="panel-title">Review Notes</div><div className="panel-hint">Writes to task.json quality metadata.</div></div>
         <button className="primary-button" type="button" disabled={saving} onClick={() => void save()}>{saving ? 'Saving…' : 'Save Review'}</button>
       </div>
+      {saveError && <div className="warning blocker" role="alert">Review was not saved: {saveError}</div>}
       <div className="panel-body review-grid">
         <div className="review-field">
           <label className="label" htmlFor="review-status">Review Status</label>
@@ -287,7 +341,9 @@ function ReviewPanel({ detail, onSaved }: { detail: TaskDetail; onSaved: (detail
             <label className="check-row" key={warning}>
               <input type="checkbox" checked={[...reviewed].some((token) => warning.includes(token))} onChange={(event) => setReviewed((current) => {
                 const next = new Set(current);
-                if (event.target.checked) next.add(warning); else next.delete(warning);
+                if (event.target.checked) next.add(warning); else {
+                  for (const token of next) if (warning.includes(token)) next.delete(token);
+                }
                 return next;
               })} />
               <span>{warning}</span>

--- a/review/src/detail-loader.test.ts
+++ b/review/src/detail-loader.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'bun:test';
+
+import { loadGuardedTaskDetail } from './detail-loader';
+import type { TaskDetail } from './types';
+
+test('a refresh detail response cannot overwrite a task selected while it was pending', async () => {
+  let selected = 'old-task';
+  let resolveDetail!: (detail: TaskDetail) => void;
+  const pending = new Promise<TaskDetail>((resolve) => { resolveDetail = resolve; });
+  const committed: TaskDetail[] = [];
+  const controller = new AbortController();
+
+  const loading = loadGuardedTaskDetail(
+    'old-task',
+    controller.signal,
+    (taskId) => selected === taskId,
+    () => pending,
+    (detail) => committed.push(detail),
+  );
+  selected = 'new-task';
+  resolveDetail({ summary: { task_id: 'old-task' } } as TaskDetail);
+  await loading;
+
+  expect(committed).toEqual([]);
+});

--- a/review/src/detail-loader.ts
+++ b/review/src/detail-loader.ts
@@ -1,0 +1,12 @@
+import type { TaskDetail } from './types';
+
+export async function loadGuardedTaskDetail(
+  taskId: string,
+  signal: AbortSignal,
+  isSelected: (taskId: string) => boolean,
+  load: (taskId: string, signal: AbortSignal) => Promise<TaskDetail>,
+  commit: (detail: TaskDetail) => void,
+): Promise<void> {
+  const detail = await load(taskId, signal);
+  if (!signal.aborted && isSelected(taskId)) commit(detail);
+}

--- a/review/tsconfig.json
+++ b/review/tsconfig.json
@@ -17,5 +17,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/scripts/modal_generate.py
+++ b/scripts/modal_generate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import io
 import json
 import os
@@ -13,6 +12,7 @@ from pathlib import Path, PurePosixPath
 
 import modal
 
+from selfbench.agent_input import build_provenance_staging
 from selfbench.modal_generation import (
     GenerationManifest,
     ManifestError,
@@ -180,7 +180,7 @@ def _stage_manifest(manifest: GenerationManifest, repo: Path | None) -> Generati
     staged = manifest.as_dict()
     raw_workers = staged["workers"]
     assert isinstance(raw_workers, list)
-    uploads: list[tuple[Path, str]] = []
+    uploads: list[tuple[io.BytesIO, str]] = []
     for raw_worker in raw_workers:
         assert isinstance(raw_worker, dict)
         provenance = raw_worker.get("provenance")
@@ -200,14 +200,24 @@ def _stage_manifest(manifest: GenerationManifest, repo: Path | None) -> Generati
             raise ManifestError(
                 f"provenance file exceeds {MAX_PROVENANCE_BYTES} bytes: {source}"
             )
-        checksum = _sha256_file(source)
-        worker_id = str(raw_worker["worker_id"])
-        suffix = source.suffix if len(source.suffix) <= 12 else ""
-        remote_path = f"runs/{manifest.run_id}/inputs/{worker_id}/{checksum}{suffix}"
-        provenance["path"] = f"{ARTIFACT_MOUNT}/{remote_path}"
-        provenance["sha256"] = checksum
+        source_format = str(provenance.get("format", "auto"))
+        message_index = int(provenance.get("message_index", 0))
+        try:
+            sanitized, remote_path, rewritten = build_provenance_staging(
+                source,
+                run_id=manifest.run_id,
+                worker_id=str(raw_worker["worker_id"]),
+                artifact_mount=ARTIFACT_MOUNT,
+                source_format=source_format,
+                message_index=message_index,
+            )
+        except (OSError, ValueError) as exc:
+            raise ManifestError(f"cannot sanitize provenance {source}: {exc}") from exc
+        # The staged artifact is one generic user message containing only the
+        # selected, redacted prompt. No other source-session records upload.
+        provenance.update(rewritten)
         if _read_remote(remote_path) is None:
-            uploads.append((source, remote_path))
+            uploads.append((io.BytesIO(sanitized), remote_path))
 
     remote_manifest = GenerationManifest.from_dict(staged)
     manifest_path = f"runs/{manifest.run_id}/manifest.json"
@@ -219,19 +229,11 @@ def _stage_manifest(manifest: GenerationManifest, repo: Path | None) -> Generati
         )
     if uploads or existing_manifest is None:
         with artifact_volume.batch_upload() as batch:
-            for source, remote_path in uploads:
-                batch.put_file(source, remote_path)
+            for sanitized, remote_path in uploads:
+                batch.put_file(sanitized, remote_path)
             if existing_manifest is None:
                 batch.put_file(io.BytesIO(expected_manifest), manifest_path)
     return remote_manifest
-
-
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
 
 
 def _sandbox_name(manifest: GenerationManifest, worker: WorkerSpec) -> str:

--- a/scripts/verify-wheel-review-assets.py
+++ b/scripts/verify-wheel-review-assets.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Verify a wheel contains the review HTML and every local asset it references."""
+
+from __future__ import annotations
+
+import re
+import sys
+import zipfile
+from pathlib import PurePosixPath
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: verify-wheel-review-assets.py DIST.whl")
+    with zipfile.ZipFile(sys.argv[1]) as wheel:
+        names = set(wheel.namelist())
+        index_path = "selfbench/review_dist/index.html"
+        if index_path not in names:
+            raise SystemExit(f"missing {index_path}")
+        html = wheel.read(index_path).decode("utf-8")
+        references = re.findall(r'''(?:src|href)=["']([^"']+)["']''', html)
+        missing = []
+        for reference in references:
+            if reference.startswith(("http://", "https://", "data:", "#")):
+                continue
+            relative = reference.lstrip("/")
+            packaged = str(PurePosixPath("selfbench/review_dist") / relative)
+            if packaged not in names:
+                missing.append(packaged)
+        if missing:
+            raise SystemExit("missing referenced review asset(s): " + ", ".join(sorted(missing)))
+    print(f"verified packaged review assets in {sys.argv[1]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/selfbench/agent_input.py
+++ b/src/selfbench/agent_input.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -26,11 +27,63 @@ def extract_prompt(path: Path, *, source_format: str = "auto", message_index: in
         ) from exc
 
 
+def extract_provenance_artifact(
+    path: Path,
+    *,
+    source_format: str = "auto",
+    message_index: int = 0,
+) -> dict[str, object]:
+    """Return a generic one-message trace containing only the selected prompt."""
+    prompt = extract_prompt(path, source_format=source_format, message_index=message_index)
+    return {"messages": [{"role": "user", "content": prompt}]}
+
+
+def build_provenance_payload(
+    path: Path,
+    *,
+    source_format: str = "auto",
+    message_index: int = 0,
+) -> bytes:
+    """Build the exact deterministic JSON bytes safe to stage for a worker."""
+    artifact = extract_provenance_artifact(
+        path,
+        source_format=source_format,
+        message_index=message_index,
+    )
+    return json.dumps(artifact, sort_keys=True, separators=(",", ":")).encode()
+
+
+def build_provenance_staging(
+    path: Path,
+    *,
+    run_id: str,
+    worker_id: str,
+    artifact_mount: str,
+    source_format: str = "auto",
+    message_index: int = 0,
+) -> tuple[bytes, str, dict[str, object]]:
+    """Return exact upload bytes, volume path, and rewritten descriptor fields."""
+    payload = build_provenance_payload(
+        path,
+        source_format=source_format,
+        message_index=message_index,
+    )
+    checksum = hashlib.sha256(payload).hexdigest()
+    remote_path = f"runs/{run_id}/inputs/{worker_id}/{checksum}.json"
+    return payload, remote_path, {
+        "path": f"{artifact_mount}/{remote_path}",
+        "format": "generic",
+        "message_index": 0,
+        "sha256": checksum,
+    }
+
+
 def extract_trace(path: Path, *, source_format: str = "auto") -> dict[str, object]:
     """Return human and assistant text from a source coding session.
 
     Tool results, injected instructions, and non-text blocks are intentionally omitted.
-    The trace is for prompt provenance review and is never sent to an eval agent.
+    The trace is for local provenance review only and is never included in a compiled
+    solver environment.
     """
     resolved_format, messages = _extract_messages(path, source_format)
     trace_messages: list[dict[str, object]] = []
@@ -236,10 +289,19 @@ def _looks_injected(prompt: str) -> bool:
 
 def _redact_secrets(value: str) -> str:
     patterns = (
+        (r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----", "[REDACTED PRIVATE KEY]"),
+        (r"(?i)\bAuthorization\s*:\s*Bearer\s+[^\s,;]+", "Authorization: Bearer [REDACTED]"),
+        (r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", "AWS_ACCESS_KEY_ID=[REDACTED]"),
+        (r"(?i)\bAWS_SECRET_ACCESS_KEY\s*[:=]\s*[^\s,;]+", "AWS_SECRET_ACCESS_KEY=[REDACTED]"),
+        (r"\bnpm_[A-Za-z0-9]{16,}\b", "npm_[REDACTED]"),
+        (r"\bglpat-[A-Za-z0-9_-]{16,}\b", "glpat-[REDACTED]"),
+        (r"(?i)\b(?:password|passwd|pwd)\s*[:=]\s*[^\s,;]+", "password=[REDACTED]"),
+        (r"(?i)\b(?:database_url|db_url)\s*[:=]\s*[^\s]+", "DATABASE_URL=[REDACTED]"),
+        (r"(?i)\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis)://[^\s]+", "[REDACTED DATABASE URL]"),
         (r"\bdari_[A-Za-z0-9_-]{16,}", "dari_[REDACTED]"),
         (r"\bsk-[A-Za-z0-9_-]{16,}", "sk-[REDACTED]"),
         (r"\b(?:ghp|github_pat)_[A-Za-z0-9_-]{16,}", "github_[REDACTED]"),
     )
     for pattern, replacement in patterns:
-        value = re.sub(pattern, replacement, value)
+        value = re.sub(pattern, replacement, value, flags=re.DOTALL if "PRIVATE KEY" in pattern else 0)
     return value

--- a/src/selfbench/extensions/modal_generation_plan.ts
+++ b/src/selfbench/extensions/modal_generation_plan.ts
@@ -62,6 +62,43 @@ const parameters = Type.Object(
 	{ additionalProperties: false },
 );
 
+// TypeBox is supplied by the host extension runtime rather than this package's
+// local dependencies, so Static<typeof parameters> cannot be imported reliably
+// during extension loading. Keep this narrow runtime-facing type in sync with
+// the schema above until the host exposes a supported Static type export.
+type GenerationPlan = {
+	target_count: number;
+	workers: Array<{
+		worker_id: string;
+		target_count: number;
+		candidates: string[];
+		base_commit: string;
+		completed_commit: string;
+	}>;
+};
+
+function validatePlan(plan: GenerationPlan): void {
+	const workerIds = new Set<string>();
+	const candidates = new Set<string>();
+	let capacity = 0;
+	for (const worker of plan.workers) {
+		if (workerIds.has(worker.worker_id)) throw new Error(`duplicate worker_id: ${worker.worker_id}`);
+		workerIds.add(worker.worker_id);
+		if (worker.base_commit.toLowerCase() === worker.completed_commit.toLowerCase()) {
+			throw new Error(`worker ${worker.worker_id} has identical base and completed commits`);
+		}
+		for (const candidate of worker.candidates) {
+			const normalized = candidate.replace(/\/+$/, "");
+			if (candidates.has(normalized)) throw new Error(`duplicate candidate: ${candidate}`);
+			candidates.add(normalized);
+		}
+		capacity += worker.target_count;
+	}
+	if (capacity < plan.target_count) {
+		throw new Error(`worker capacity ${capacity} is below target_count ${plan.target_count}`);
+	}
+}
+
 const submitGenerationPlan = defineTool({
 	name: "submit_generation_plan",
 	label: "Submit generation plan",
@@ -75,6 +112,7 @@ const submitGenerationPlan = defineTool({
 	],
 	parameters,
 	async execute(_toolCallId, plan) {
+		validatePlan(plan);
 		const outputPath = process.env.SELFBENCH_PLAN_OUTPUT;
 		if (!outputPath) {
 			throw new Error("SELFBENCH_PLAN_OUTPUT is required");

--- a/src/selfbench/harbor.py
+++ b/src/selfbench/harbor.py
@@ -28,7 +28,7 @@ from .task import Task, resolve_toolchains
 
 HARBOR_SCHEMA_VERSION = "1.4"
 HARBOR_VERSION_RANGE = ">=0.20.1.dev202607200228,<0.21"
-ENVIRONMENT_COMPILER_REVISION = 5
+ENVIRONMENT_COMPILER_REVISION = 6
 _BASE_IMAGE = "ubuntu:24.04"
 _GO_VERSION = "1.25.0"
 _RUST_VERSION = "1.90.0"
@@ -487,7 +487,7 @@ ENV DEBIAN_FRONTEND=noninteractive \\
     CARGO_HOME=/usr/local/cargo \\
     PATH=/usr/local/go/bin:/usr/local/cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
 RUN apt-get update && apt-get install -y --no-install-recommends \\
-    bash build-essential ca-certificates curl git jq passwd pkg-config unzip xz-utils \\
+    bash build-essential ca-certificates curl git jq passwd pkg-config procps unzip xz-utils \\
     && rm -rf /var/lib/apt/lists/*
 {layers}
 """
@@ -584,9 +584,12 @@ def _verifier_dockerfile(
     """Verifier image: holds the held-out tests the agent never sees."""
     return f"""{_toolchain_layers(task.toolchains, package_profile)}
 {_repo_layers(task)}
-RUN mkdir -p /opt/selfbench && chmod 700 /opt/selfbench
+RUN useradd --create-home --shell /bin/bash verifier \
+    && chown -R verifier:verifier /app \
+    && mkdir -p /opt/selfbench \
+    && chmod 700 /opt/selfbench
 COPY . /tests/
-RUN chmod +x /tests/test.sh
+RUN chmod 700 /tests && chmod 600 /tests/test.patch && chmod +x /tests/test.sh
 WORKDIR /app
 """
 
@@ -604,6 +607,7 @@ def _test_script(task: Task) -> str:
         for path in task.test_paths
     )
     protected = " ".join(shlex.quote(path) for path in task.test_paths)
+    protected_absolute = " ".join(shlex.quote(f"/app/{path}") for path in task.test_paths)
     workdir = shlex.quote(f"/app/{task.workdir}")
     f2p = _test_command(task, task.fail_to_pass)
     p2p = _test_command(task, task.pass_to_pass) if task.pass_to_pass else "true"
@@ -617,6 +621,33 @@ pass_to_pass=0
 deterministic=0
 setup_completed=0
 
+kill_verifier_processes() {{
+  pkill -KILL -u "$(id -u verifier)" 2>/dev/null || true
+}}
+
+run_verifier_command() {{
+  runuser -u verifier -- bash -lc "$1"
+  local status=$?
+  kill_verifier_processes
+  return "$status"
+}}
+
+protect_held_out_path() {{
+  local path="$1"
+  chown -R root:root -- "$path"
+  chmod -R a-w,go+rX -- "$path"
+  if [ -f "$path" ]; then
+    local parent
+    parent="$(dirname "$path")"
+    while :; do
+      chown root:root -- "$parent"
+      chmod a-w,go+rX -- "$parent"
+      [ "$parent" = /app ] && break
+      parent="$(dirname "$parent")"
+    done
+  fi
+}}
+
 if [ ! -f /opt/selfbench/agent.patch ]; then
   echo "Harbor did not transfer the captured agent patch" >&2
   patch_applied=0
@@ -624,22 +655,34 @@ elif [ -s /opt/selfbench/agent.patch ]; then
   git -C /app apply --binary --whitespace=nowarn {exclusions} /opt/selfbench/agent.patch || patch_applied=0
 fi
 
+# Solver-controlled lifecycle/build hooks run before held-out material is exposed.
 if [ "$patch_applied" -eq 1 ]; then
+  cd {workdir}
+  if runuser -u verifier -- bash -lc {shlex.quote(setup)}; then setup_completed=1; fi
+fi
+
+# Setup is solver-controlled. Kill every remaining process for its UID before
+# held-out material appears; code under test still shares the later test process.
+if [ "$patch_applied" -eq 1 ] && [ "$setup_completed" -eq 1 ]; then
+  kill_verifier_processes
   git -C /app restore --source=HEAD --staged --worktree -- {protected} 2>/dev/null || true
   git -C /app clean -fd -- {protected} >/dev/null 2>&1 || true
   git -C /app apply --binary --whitespace=nowarn /tests/test.patch || patch_applied=0
+  if [ "$patch_applied" -eq 1 ]; then
+    for protected_path in {protected_absolute}; do
+      protect_held_out_path "$protected_path"
+    done
+  fi
+  rm -f /tests/test.patch
 fi
 
-if [ "$patch_applied" -eq 1 ]; then
+if [ "$patch_applied" -eq 1 ] && [ "$setup_completed" -eq 1 ]; then
   cd {workdir}
-  if bash -lc {shlex.quote(setup)}; then
-    setup_completed=1
-    if bash -lc {shlex.quote(f2p)}; then
-      fail_to_pass=1
-      if bash -lc {shlex.quote(f2p)}; then deterministic=1; fi
-    fi
-    if bash -lc {shlex.quote(p2p)}; then pass_to_pass=1; fi
+  if run_verifier_command {shlex.quote(f2p)}; then
+    fail_to_pass=1
+    if run_verifier_command {shlex.quote(f2p)}; then deterministic=1; fi
   fi
+  if run_verifier_command {shlex.quote(p2p)}; then pass_to_pass=1; fi
 fi
 
 reward=0

--- a/src/selfbench/modal_generation.py
+++ b/src/selfbench/modal_generation.py
@@ -14,6 +14,7 @@ from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 from .agent_input import SUPPORTED_FORMATS
+from .task import load_task
 
 SCHEMA_VERSION = 1
 _SAFE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
@@ -489,7 +490,11 @@ def _inspect_tasks(
             raise ManifestError(f"invalid task.json in {task_dir}: {exc}") from exc
         if not isinstance(task_data, dict):
             raise ManifestError(f"task.json in {task_dir} must be an object")
-        task_id = _require_safe_id(task_data.get("task_id"), f"{task_dir.name}.task_id")
+        try:
+            authored_task = load_task(task_dir)
+        except (OSError, TypeError, ValueError) as exc:
+            raise ManifestError(f"invalid authored task in {task_dir}: {exc}") from exc
+        task_id = _require_safe_id(authored_task.task_id, f"{task_dir.name}.task_id")
         if task_id != task_dir.name:
             raise ManifestError(f"task_id {task_id!r} does not match directory {task_dir.name!r}")
         source_key = _task_source_key(task_data, repo_url)

--- a/src/selfbench/review.py
+++ b/src/selfbench/review.py
@@ -20,13 +20,22 @@ from .task import Task, load_task
 
 _REVIEW_BUILD_LOCK = threading.Lock()
 _REVIEW_STATUSES = {"unreviewed", "in_review", "approved", "changes_requested", "rejected"}
+_MAX_JSON_BODY_BYTES = 1024 * 1024
+
+
+def _path_component(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or value in {".", ".."} or Path(value).name != value or "/" in value or "\\" in value:
+        raise ValueError(f"{field} must be a path-safe component")
+    return value
 
 
 class ReviewStore:
     def __init__(self, tasks_root: Path, results_root: Path, model_slugs: list[str]):
         self.tasks_root = tasks_root.resolve()
         self.results_root = results_root.resolve()
-        self.model_slugs = model_slugs
+        self.model_slugs = [_path_component(slug, "model slug") for slug in model_slugs]
+        if len(self.model_slugs) != len(set(self.model_slugs)):
+            raise ValueError("model slugs must not contain duplicates")
 
     def task_dirs(self) -> list[Path]:
         if (self.tasks_root / "task.json").is_file():
@@ -155,6 +164,9 @@ class ReviewStore:
         if patch_kind == "gold":
             return task.gold_patch
         if patch_kind == "agent" and model_slug:
+            model_slug = _path_component(model_slug, "model slug")
+            if model_slug not in self.model_slugs:
+                raise KeyError(f"unknown model slug {model_slug}")
             patch = self._run_detail(task_id, model_slug).get("agent_patch")
             return patch if isinstance(patch, str) else ""
         raise KeyError(f"unknown patch {patch_kind}")
@@ -234,7 +246,7 @@ class ReviewHandler(BaseHTTPRequestHandler):
                     self.review_store.patch_text(task_id, patch_kind, model_slug),
                     "text/plain; charset=utf-8",
                 )
-            except KeyError:
+            except (KeyError, ValueError):
                 self._send_error_json(HTTPStatus.NOT_FOUND, "unknown patch")
             return
         if path.startswith("/api/tasks/"):
@@ -266,11 +278,19 @@ class ReviewHandler(BaseHTTPRequestHandler):
             super().log_message(format, *args)
 
     def _read_json_body(self) -> dict[str, object]:
-        length = int(self.headers.get("content-length", "0"))
-        raw = self.rfile.read(length).decode("utf-8")
+        content_type = self.headers.get_content_type()
+        if content_type != "application/json":
+            raise ValueError("content-type must be application/json")
         try:
+            length = int(self.headers.get("content-length", "0"))
+        except ValueError as exc:
+            raise ValueError("content-length must be an integer") from exc
+        if length < 0 or length > _MAX_JSON_BODY_BYTES:
+            raise ValueError(f"request body must not exceed {_MAX_JSON_BODY_BYTES} bytes")
+        try:
+            raw = self.rfile.read(length).decode("utf-8")
             payload = json.loads(raw or "{}")
-        except json.JSONDecodeError as exc:
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise ValueError("request body must be JSON") from exc
         if not isinstance(payload, dict):
             raise ValueError("request body must be a JSON object")
@@ -341,10 +361,17 @@ def _match_patch_path(path: str) -> tuple[str, str, str | None] | None:
 
 
 def _ensure_review_build() -> Path:
-    repo_root = Path(__file__).resolve().parents[2]
-    source_root = repo_root / "review"
-    dist_root = repo_root / "src" / "selfbench" / "review_dist"
+    package_root = Path(__file__).resolve().parent
+    dist_root = package_root / "review_dist"
     index = dist_root / "index.html"
+    repo_root = package_root.parents[1]
+    source_root = repo_root / "review"
+    source_markers = [repo_root / "package.json", repo_root / "bun.lock", source_root / "src"]
+    if not all(path.exists() for path in source_markers):
+        if index.is_file():
+            return dist_root
+        raise RuntimeError("installed selfbench package does not contain the review frontend")
+
     sources = [repo_root / "package.json", repo_root / "bun.lock", *source_root.rglob("*")]
     latest_source = max(path.stat().st_mtime for path in sources if path.is_file())
     if index.is_file() and index.stat().st_mtime >= latest_source:

--- a/src/selfbench/task.py
+++ b/src/selfbench/task.py
@@ -71,11 +71,10 @@ class Task:
     # model and nothing else.
     agent_network_mode: str = "allowlist"
     agent_allowed_hosts: list[str] = field(default_factory=list)
-    # The verifier re-runs setup_cmd before the held-out tests, so it needs the
-    # package registries its ecosystem installs from. It never receives the
-    # agent's session and cannot leak the reference implementation to a solver,
-    # so it stays on the environment baseline rather than being sealed.
-    verifier_network_mode: str = "public"
+    # Setup dependencies are installed while building the verifier image. The
+    # test phase is offline by default to prevent solver code from exfiltrating
+    # held-out material or making evaluation depend on external services.
+    verifier_network_mode: str = "no-network"
     cpus: int = 4
     memory_mb: int = 8192
     storage_mb: int = 20480
@@ -177,8 +176,8 @@ class Task:
         source_path, source_format = self._trace_source_values(source, field_name="prompt_source")
 
         message_index = source.get("message_index", 0)
-        if not isinstance(message_index, int) or isinstance(message_index, bool):
-            raise ValueError("prompt_source.message_index must be an integer")
+        if not isinstance(message_index, int) or isinstance(message_index, bool) or message_index < 0:
+            raise ValueError("prompt_source.message_index must be a non-negative integer")
         return source_path, source_format, message_index
 
     def _trace_source_values(
@@ -206,21 +205,81 @@ class Task:
 
 def load_task(task_dir: str | Path) -> Task:
     task_dir = Path(task_dir).resolve()
-    cfg = json.loads((task_dir / "task.json").read_text())
-    task = Task(dir=task_dir, **cfg)
+    raw = json.loads((task_dir / "task.json").read_text())
+    if not isinstance(raw, dict):
+        raise ValueError(f"invalid task {task_dir}: task.json must contain an object")
+    cfg: dict[str, object] = raw
+    problems: list[str] = []
 
+    required_strings = ("task_id", "repo", "base_commit", "workdir", "setup_cmd", "test_cmd")
+    for name in required_strings:
+        value = cfg.get(name)
+        if not isinstance(value, str) or not value.strip():
+            problems.append(f"{name} must be a non-empty string")
+
+    list_fields = ("fail_to_pass", "pass_to_pass", "test_paths", "agent_allowed_hosts")
+    for name in list_fields:
+        if name not in cfg and name in {"pass_to_pass", "agent_allowed_hosts"}:
+            continue
+        value = cfg.get(name)
+        if not isinstance(value, list):
+            problems.append(f"{name} must be a list of non-empty strings")
+        elif any(not isinstance(item, str) or not item.strip() for item in value):
+            problems.append(f"{name} entries must be non-empty strings")
+
+    for name in ("prompt_source", "trace_source", "prompt_generation"):
+        value = cfg.get(name)
+        if value is not None and not isinstance(value, dict):
+            problems.append(f"{name} must be an object")
+    if "quality" in cfg and not isinstance(cfg["quality"], dict):
+        problems.append("quality must be an object")
+    source_pr = cfg.get("source_pr")
+    if source_pr is not None and (
+        not isinstance(source_pr, int) or isinstance(source_pr, bool) or source_pr <= 0
+    ):
+        problems.append("source_pr must be a positive integer")
+    source_url = cfg.get("source_url")
+    if source_url is not None and (not isinstance(source_url, str) or not source_url.strip()):
+        problems.append("source_url must be a non-empty string")
+    for name in ("network_mode", "agent_network_mode", "verifier_network_mode"):
+        value = cfg.get(name)
+        if value is not None and not isinstance(value, str):
+            problems.append(f"{name} must be a string")
+    for name in (
+        "timeout_setup",
+        "timeout_agent",
+        "timeout_tests",
+        "cpus",
+        "memory_mb",
+        "storage_mb",
+    ):
+        value = cfg.get(name)
+        if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+            problems.append(f"{name} must be an integer")
+
+    known_fields = {name for name in Task.__dataclass_fields__ if name != "dir"}
+    unknown = sorted(set(cfg) - known_fields)
+    if unknown:
+        problems.append(f"unknown task field(s): {', '.join(unknown)}")
+    missing = [
+        name for name in required_strings + ("fail_to_pass", "pass_to_pass", "test_paths")
+        if name not in cfg
+    ]
+    if missing:
+        problems.append(f"missing required field(s): {', '.join(missing)}")
+    if problems:
+        raise ValueError(f"invalid task {task_dir}: " + "; ".join(problems))
+
+    task = Task(dir=task_dir, **raw)
     problems = []
-    if not isinstance(task.task_id, str) or not re.fullmatch(
+    if not re.fullmatch(
         r"[A-Za-z0-9][A-Za-z0-9._-]*",
         task.task_id,
     ):
         problems.append("task_id must be a path-safe identifier")
-    if not isinstance(task.workdir, str) or not task.workdir:
-        problems.append("workdir must be a non-empty relative path")
-    else:
-        workdir = Path(task.workdir)
-        if workdir.is_absolute() or ".." in workdir.parts:
-            problems.append("workdir must stay inside the repository")
+    workdir = Path(task.workdir)
+    if workdir.is_absolute() or ".." in workdir.parts:
+        problems.append("workdir must stay inside the repository")
     if "{tests}" not in task.test_cmd:
         problems.append('test_cmd must contain the "{tests}" placeholder')
     if not task.fail_to_pass:
@@ -237,18 +296,17 @@ def load_task(task_dir: str | Path) -> Task:
             problems.append(str(exc))
     if task.trace_source is not None:
         try:
-            if not isinstance(task.trace_source, dict):
-                raise ValueError("trace_source must be an object")
             trace_path, _ = task._trace_source_values(task.trace_source)
             if not trace_path.is_file():
                 problems.append(f"trace_source does not exist: {trace_path}")
         except ValueError as exc:
             problems.append(str(exc))
-    if task.prompt_generation is not None:
-        if not isinstance(task.prompt_generation, dict):
-            problems.append("prompt_generation must be an object")
-        elif task.prompt_generation.get("prompt_sha256") != task.prompt_sha256:
-            problems.append("prompt.md does not match prompt_generation.prompt_sha256")
+    if task.prompt_generation is not None and (has_prompt_file or task.prompt_source is not None):
+        try:
+            if task.prompt_generation.get("prompt_sha256") != task.prompt_sha256:
+                problems.append("prompt.md does not match prompt_generation.prompt_sha256")
+        except (OSError, ValueError) as exc:
+            problems.append(str(exc))
     for name in ("test.patch", "gold.patch"):
         if not (task_dir / name).is_file():
             problems.append(f"missing {name}")
@@ -256,16 +314,13 @@ def load_task(task_dir: str | Path) -> Task:
         problems.append("test_paths must list the files/dirs the test patch touches")
     else:
         for test_path in task.test_paths:
-            if not isinstance(test_path, str) or not test_path:
-                problems.append("test_paths entries must be non-empty relative paths")
-                break
             path = Path(test_path)
             if path == Path(".") or path.is_absolute() or ".." in path.parts:
                 problems.append("test_paths entries must stay inside the repository")
                 break
     for timeout_name in ("timeout_setup", "timeout_agent", "timeout_tests"):
         timeout = getattr(task, timeout_name)
-        if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0:
+        if timeout <= 0:
             problems.append(f"{timeout_name} must be a positive integer")
     try:
         resolve_toolchains(task.toolchains)
@@ -276,11 +331,9 @@ def load_task(task_dir: str | Path) -> Task:
             problems.append(f"{mode_name} must be public, no-network, or allowlist")
     if task.agent_allowed_hosts and task.agent_network_mode != "allowlist":
         problems.append("agent_allowed_hosts requires agent_network_mode=allowlist")
-    if any(not isinstance(h, str) or not h for h in task.agent_allowed_hosts):
-        problems.append("agent_allowed_hosts entries must be non-empty hostnames")
     for resource_name in ("cpus", "memory_mb", "storage_mb"):
         value = getattr(task, resource_name)
-        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        if value <= 0:
             problems.append(f"{resource_name} must be a positive integer")
     if problems:
         raise ValueError(f"invalid task {task_dir}: " + "; ".join(problems))

--- a/tests/test_agent_input.py
+++ b/tests/test_agent_input.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from selfbench.agent_input import extract_prompt, extract_trace
+from selfbench.agent_input import build_provenance_payload, build_provenance_staging, extract_prompt, extract_provenance_artifact, extract_trace
 
 
 class AgentInputTest(unittest.TestCase):
@@ -80,6 +80,78 @@ class AgentInputTest(unittest.TestCase):
             {"role": "user", "content": "Make the timeout ten minutes.", "user_message_index": 1},
         ])
         self.assertEqual(extract_prompt(path, message_index=-1), "Make the timeout ten minutes.")
+
+    def test_provenance_artifact_contains_only_selected_redacted_prompt(self) -> None:
+        path = self.write_jsonl(
+            "pi.jsonl",
+            [
+                {"type": "message", "parentId": None, "message": {"role": "user", "content": "Unrelated earlier request"}},
+                {"type": "message", "parentId": None, "message": {"role": "assistant", "content": "Unrelated assistant response"}},
+                {"type": "message", "parentId": None, "message": {"role": "toolResult", "content": "UNRELATED_RAW_SECRET"}},
+                {"type": "message", "parentId": None, "message": {"role": "user", "content": "Fix it with sk-abcdefghijklmnopqrstuvwxyz1234"}},
+            ],
+        )
+
+        artifact = extract_provenance_artifact(path, source_format="pi", message_index=1)
+        encoded = json.dumps(artifact)
+
+        self.assertEqual(artifact, {"messages": [{"role": "user", "content": "Fix it with sk-[REDACTED]"}]})
+        self.assertNotIn("UNRELATED_RAW_SECRET", encoded)
+        self.assertNotIn("Unrelated", encoded)
+        self.assertNotIn("abcdefghijklmnopqrstuvwxyz1234", encoded)
+
+    def test_provenance_payload_is_deterministic_generic_json(self) -> None:
+        path = self.root / "prompt.json"
+        path.write_text(json.dumps({"messages": [{"role": "user", "content": "Ship it"}]}))
+        payload = build_provenance_payload(path)
+        self.assertEqual(payload, b'{"messages":[{"content":"Ship it","role":"user"}]}')
+
+    def test_provenance_staging_contract_rewrites_exact_bytes_hash_and_path(self) -> None:
+        path = self.root / "prompt.json"
+        path.write_text(json.dumps({"messages": [
+            {"role": "user", "content": "Earlier request"},
+            {"role": "user", "content": "Ship it"},
+        ]}))
+        payload, remote_path, rewritten = build_provenance_staging(
+            path,
+            run_id="run-1",
+            worker_id="worker-1",
+            artifact_mount="/artifacts",
+            message_index=1,
+        )
+        checksum = "d124f9b7b0b452864d91f7197653a72c009bccb92b7f310acb118c95290f9068"
+        self.assertEqual(payload, b'{"messages":[{"content":"Ship it","role":"user"}]}')
+        self.assertEqual(remote_path, f"runs/run-1/inputs/worker-1/{checksum}.json")
+        self.assertEqual(rewritten, {
+            "path": f"/artifacts/{remote_path}",
+            "format": "generic",
+            "message_index": 0,
+            "sha256": checksum,
+        })
+
+    def test_redacts_common_credential_families_from_selected_prompt(self) -> None:
+        credentials = "\n".join([
+            "Authorization: Bearer bearer-token-abcdefghijklmnopqrstuvwxyz",
+            "AWS_ACCESS_KEY_ID=AKIAABCDEFGHIJKLMNOP",
+            "AWS_SECRET_ACCESS_KEY=abcdefghijklmnopqrstuvwxyz/1234567890+ABCD",
+            "npm_abcdefghijklmnopqrstuvwxyz123456",
+            "glpat-abcdefghijklmnopqrstuvwxyz123456",
+            "PASSWORD=hunter2-secret",
+            "DATABASE_URL=postgresql://user:secret@db.example/app",
+            "-----BEGIN PRIVATE KEY-----\nprivate-material\n-----END PRIVATE KEY-----",
+        ])
+        path = self.root / "credentials.json"
+        path.write_text(json.dumps({"messages": [{"role": "user", "content": credentials}]}))
+
+        prompt = extract_prompt(path)
+
+        for secret in (
+            "bearer-token", "AKIAABCDEFGHIJKLMNOP", "abcdefghijklmnopqrstuvwxyz/1234567890+ABCD",
+            "npm_abcdefghijklmnopqrstuvwxyz", "glpat-abcdefghijklmnopqrstuvwxyz", "hunter2-secret",
+            "user:secret", "private-material",
+        ):
+            self.assertNotIn(secret, prompt)
+        self.assertIn("[REDACTED PRIVATE KEY]", prompt)
 
     def test_extracts_generic_messages_json(self) -> None:
         path = self.root / "generic.json"

--- a/tests/test_modal_generation.py
+++ b/tests/test_modal_generation.py
@@ -61,10 +61,19 @@ def write_task(tasks_root: Path, task_id: str, pull_number: int) -> Path:
             {
                 "task_id": task_id,
                 "repo": "example/project",
+                "base_commit": "b" * 40,
+                "workdir": ".",
+                "setup_cmd": "true",
+                "test_cmd": "pytest {tests}",
+                "fail_to_pass": ["tests/test_fix.py::test_fix"],
+                "pass_to_pass": ["tests/test_existing.py::test_existing"],
+                "test_paths": ["tests"],
                 "source_pr": pull_number,
             }
         )
     )
+    (task_dir / "prompt.md").write_text("Fix the assigned regression without changing public behavior.\n")
+    (task_dir / "test.patch").write_text("diff --git a/tests/test_fix.py b/tests/test_fix.py\n")
     (task_dir / "gold.patch").write_text(f"gold for {task_id}\n")
     return task_dir
 
@@ -227,6 +236,29 @@ class ArtifactTest(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertTrue((output / "task-101" / "task.json").is_file())
         self.assertTrue((output / ".selfbench-generation.json").is_file())
+
+    def test_hash_consistent_but_invalid_task_is_rejected(self) -> None:
+        manifest = GenerationManifest.from_dict(manifest_data())
+        run_root = self.root / "downloaded-run"
+        worker_root = complete_worker(
+            run_root,
+            manifest,
+            0,
+            task_id="task-101",
+            pull_number=101,
+        )
+        task_dir = worker_root / "tasks" / "task-101"
+        task_data = json.loads((task_dir / "task.json").read_text())
+        task_data.pop("setup_cmd")
+        (task_dir / "task.json").write_text(json.dumps(task_data))
+        with self.assertRaisesRegex(ManifestError, "invalid authored task"):
+            write_worker_artifact_manifest(
+                worker_root,
+                worker_root / "tasks",
+                manifest,
+                manifest.workers[0],
+                build_commit="b" * 40,
+            )
 
     def test_tampered_task_file_is_rejected(self) -> None:
         manifest = GenerationManifest.from_dict(manifest_data())

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import json
 import tempfile
 import unittest
+from email.message import Message
 from pathlib import Path
 
-from selfbench.review import ReviewStore, _review_status
+from selfbench.review import ReviewHandler, ReviewStore, _match_patch_path, _review_status
 from selfbench.task import Task
 
 
@@ -51,6 +53,27 @@ class ReviewStatusTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
+
+    def test_rejects_unsafe_configured_model_slugs(self) -> None:
+        for slug in ("..", "nested/model", "nested\\model", "."):
+            with self.subTest(slug=slug), self.assertRaisesRegex(ValueError, "path-safe component"):
+                ReviewStore(self.root / "tasks", self.results, [slug])
+
+    def test_agent_patch_requires_a_configured_model_slug(self) -> None:
+        with self.assertRaises(KeyError):
+            self.store.patch_text("test-task", "agent", "unconfigured")
+
+    def test_encoded_patch_components_are_decoded_for_confinement(self) -> None:
+        for path, expected in (
+            ("/api/tasks/test-task/patch/agent/%2E%2E", ".."),
+            ("/api/tasks/test-task/patch/agent/nested%2Fmodel", "nested/model"),
+        ):
+            with self.subTest(path=path):
+                match = _match_patch_path(path)
+                self.assertIsNotNone(match)
+                assert match is not None
+                with self.assertRaises((KeyError, ValueError)):
+                    self.store.patch_text(*match)
 
     def test_default_review_status_is_unreviewed(self) -> None:
         summaries = self.store.summaries()
@@ -100,6 +123,31 @@ class ReviewStatusTest(unittest.TestCase):
         summaries = self.store.summaries()
         self.assertEqual(summaries["review_counts"], {"unreviewed": 1})
         self.assertEqual(summaries["tasks"][0]["review_status"], "unreviewed")
+
+
+class ReviewRequestBodyTest(unittest.TestCase):
+    def _handler(self, body: bytes, content_type: str = "application/json") -> ReviewHandler:
+        handler = object.__new__(ReviewHandler)
+        headers = Message()
+        headers["content-type"] = content_type
+        headers["content-length"] = str(len(body))
+        handler.headers = headers
+        handler.rfile = io.BytesIO(body)
+        return handler
+
+    def test_requires_application_json(self) -> None:
+        with self.assertRaisesRegex(ValueError, "content-type"):
+            self._handler(b"{}", "text/plain")._read_json_body()
+
+    def test_rejects_oversized_json_without_reading_it(self) -> None:
+        handler = self._handler(b"")
+        handler.headers.replace_header("content-length", str(1024 * 1024 + 1))
+        with self.assertRaisesRegex(ValueError, "must not exceed"):
+            handler._read_json_body()
+
+    def test_rejects_invalid_utf8_as_invalid_json(self) -> None:
+        with self.assertRaisesRegex(ValueError, "request body must be JSON"):
+            self._handler(b'\xff{"review_status":"approved"}')._read_json_body()
 
 
 class ReviewStatusHelperTest(unittest.TestCase):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import tempfile
 import unittest
@@ -94,6 +95,101 @@ class HarborTaskBuildTest(unittest.TestCase):
         self.assertIn("/tests/test.patch", verifier)
         self.assertIn("--exclude=tests", verifier)
         self.assertIn('"reward": $reward', verifier)
+        self.assertLess(verifier.index("runuser -u verifier -- bash -lc true"), verifier.index("git -C /app apply --binary --whitespace=nowarn /tests/test.patch"))
+        self.assertIn("chmod 700 /tests", (output / "tests" / "Dockerfile").read_text())
+        self.assertLess(verifier.index("git -C /app apply --binary --whitespace=nowarn /tests/test.patch"), verifier.index("rm -f /tests/test.patch"))
+
+    def test_generated_verifier_kills_setup_process_before_exposing_tests(self) -> None:
+        output = build_harbor_task(self.task, self.repo, self.root / "harbor-tasks")
+        sandbox = self.root / "script-sandbox"
+        app = sandbox / "app"
+        tests = sandbox / "tests"
+        opt = sandbox / "opt" / "selfbench"
+        logs = sandbox / "logs"
+        bin_dir = sandbox / "bin"
+        for directory in (app, tests, opt, logs, bin_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+        (opt / "agent.patch").write_text("")
+        (tests / "test.patch").write_text("held out")
+        (app / "tests").mkdir()
+
+        runuser = bin_dir / "runuser"
+        runuser.write_text(f'''#!/bin/bash
+count=$(cat {sandbox / "run-count"} 2>/dev/null || echo 0)
+count=$((count + 1))
+echo "$count" > {sandbox / "run-count"}
+if [ "$count" -eq 1 ]; then
+  sleep 60 & echo $! > {sandbox / "watcher.pid"}
+elif [ "$count" -eq 2 ]; then
+  sleep 60 & echo $! > {sandbox / "watcher.pid"}
+elif [ "$count" -eq 3 ]; then
+  if kill -0 "$(cat {sandbox / "watcher.pid"})" 2>/dev/null; then exit 92; fi
+  touch {sandbox / "second-run-clean"}
+fi
+exit 0
+''')
+        pkill = bin_dir / "pkill"
+        pkill.write_text(f'''#!/bin/bash
+if [ -f {sandbox / "watcher.pid"} ]; then
+  kill -KILL "$(cat {sandbox / "watcher.pid"})" 2>/dev/null || true
+fi
+touch {sandbox / "killed"}
+''')
+        git = bin_dir / "git"
+        git.write_text(f'''#!/bin/bash
+if [[ "$*" == *"{tests / "test.patch"}"* ]]; then
+  test -f {sandbox / "killed"} || exit 91
+  touch {sandbox / "held-out-applied"}
+fi
+exit 0
+''')
+        (bin_dir / "id").write_text("#!/bin/bash\necho 4242\n")
+        for name in ("chown", "chmod"):
+            (bin_dir / name).write_text("#!/bin/bash\nexit 0\n")
+        for executable in bin_dir.iterdir():
+            executable.chmod(0o755)
+
+        script = (output / "tests" / "test.sh").read_text()
+        for source, target in (
+            ("/opt/selfbench", str(opt)), ("/app", str(app)),
+            ("/tests", str(tests)), ("/logs", str(logs)),
+        ):
+            script = script.replace(source, target)
+        script_path = sandbox / "test.sh"
+        script_path.write_text(script)
+        script_path.chmod(0o755)
+        subprocess.run(
+            [str(script_path)],
+            check=True,
+            env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+        )
+        self.assertTrue((sandbox / "held-out-applied").is_file())
+        self.assertTrue((sandbox / "second-run-clean").is_file())
+
+    def test_file_valued_test_path_locks_its_parent_against_replacement(self) -> None:
+        self.task.test_paths = ["tests/test_hidden.py"]
+        output = build_harbor_task(self.task, self.repo, self.root / "harbor-file-task")
+        script = (output / "tests" / "test.sh").read_text()
+
+        self.assertIn('for protected_path in /app/tests/test_hidden.py; do', script)
+        self.assertIn('protect_held_out_path "$protected_path"', script)
+        self.assertIn('parent="$(dirname "$path")"', script)
+        self.assertIn('chmod a-w,go+rX -- "$parent"', script)
+        self.assertIn('[ "$parent" = /app ] && break', script)
+        self.assertNotIn("chmod -R a-w,go+rX -- /app", script)
+
+        with tempfile.TemporaryDirectory() as raw_permission_dir:
+            permission_root = Path(raw_permission_dir)
+            parent = permission_root / "tests"
+            parent.mkdir()
+            hidden = parent / "test_hidden.py"
+            hidden.write_text("held out\n")
+            parent.chmod(0o555)
+            try:
+                with self.assertRaises(PermissionError):
+                    hidden.unlink()
+            finally:
+                parent.chmod(0o755)
 
     def test_reuses_current_build_and_rejects_stale_output(self) -> None:
         output = build_harbor_task(self.task, self.repo, self.root / "harbor-tasks")
@@ -1013,7 +1109,7 @@ class SealedAgentNetworkTest(unittest.TestCase):
             t = self._task(Path(raw))
         self.assertEqual(t.agent_network_mode, "allowlist")
         self.assertEqual(t.agent_allowed_hosts, [])
-        self.assertEqual(t.verifier_network_mode, "public")
+        self.assertEqual(t.verifier_network_mode, "no-network")
 
     def test_task_toml_emits_phase_policies(self) -> None:
         from selfbench.harbor import _task_toml

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -30,7 +30,7 @@ class TaskPromptSourceTest(unittest.TestCase):
             "fail_to_pass": ["tests/x"],
             "pass_to_pass": ["tests/y"],
             "test_paths": ["tests"],
-            "prompt_source": {"path": "inputs/session.json", "format": "generic", "message_index": -1},
+            "prompt_source": {"path": "inputs/session.json", "format": "generic", "message_index": 1},
         }
         config.update(overrides)
         (self.task_dir / "task.json").write_text(json.dumps(config))
@@ -49,7 +49,7 @@ class TaskPromptSourceTest(unittest.TestCase):
             "kind": "agent_json",
             "path": "inputs/session.json",
             "format": "generic",
-            "message_index": -1,
+            "message_index": 1,
         })
 
     def test_loads_trace_source_with_manual_prompt(self) -> None:
@@ -81,6 +81,31 @@ class TaskPromptSourceTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "exactly one"):
             load_task(self.task_dir)
+
+    def test_rejects_negative_prompt_message_index(self) -> None:
+        self.write_task(prompt_source={"path": "inputs/session.json", "message_index": -1})
+
+        with self.assertRaisesRegex(ValueError, "non-negative integer"):
+            load_task(self.task_dir)
+
+    def test_rejects_malformed_public_schema_fields(self) -> None:
+        (self.task_dir / "prompt.md").write_text("Standalone eval prompt")
+        cases = (
+            ({"repo": 3}, "repo must be a non-empty string"),
+            ({"setup_cmd": None}, "setup_cmd must be a non-empty string"),
+            ({"fail_to_pass": "tests/x"}, "fail_to_pass must be a list"),
+            ({"pass_to_pass": ["ok", 3]}, "pass_to_pass entries"),
+            ({"test_paths": "tests"}, "test_paths must be a list"),
+            ({"agent_allowed_hosts": "api.example.com"}, "agent_allowed_hosts must be a list"),
+            ({"quality": []}, "quality must be an object"),
+            ({"quality": None}, "quality must be an object"),
+            ({"source_pr": True}, "source_pr must be a positive integer"),
+        )
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides):
+                self.write_task(prompt_source=None, **overrides)
+                with self.assertRaisesRegex(ValueError, message):
+                    load_task(self.task_dir)
 
     def test_rejects_prompt_source_outside_task_directory(self) -> None:
         self.write_task(prompt_source={"path": "../session.json"})


### PR DESCRIPTION
## Summary
Harden selfbench across task validation, Harbor grading, Modal provenance, review-server safety, frontend loading, and wheel packaging.

- Prevents path traversal, malformed task/artifact data, unsafe verifier behavior, and accidental provenance leakage.
- Fixes stale frontend requests, save failures, warning-token handling, and accessibility issues.
- Adds focused regression coverage and packaged-asset verification.

## Design
### Evaluation and task safety
- `src/selfbench/task.py` — validates task metadata and downloaded artifacts with strict schemas and safe file handling.
- `src/selfbench/harbor.py` — isolates held-out grading, cleans up spawned processes, protects filesystem paths, and disables grading egress.
- `tests/test_task.py`, `tests/test_runner.py` — cover task validation, process cleanup, permissions, and verifier isolation.

### Modal generation and provenance
- `src/selfbench/modal_generation.py` — validates generated artifacts through the canonical task loader.
- `scripts/modal_generate.py` — validates generation plans and stages only the selected redacted prompt as provenance.
- `src/selfbench/extensions/modal_generation_plan.ts`, `tests/test_modal_generation.py` — enforce generation-plan semantics and regression coverage.

### Review UI and server
- `src/selfbench/review.py` — bounds request bodies, validates JSON, and confines review task paths.
- `review/src/App.tsx`, `review/src/detail-loader.ts` — guard asynchronous task-detail commits, improve save/error behavior, and tighten accessibility.
- `review/src/detail-loader.test.ts`, `tests/test_review.py` — cover navigation races and review-server behavior.

### Packaging and CI
- `scripts/verify-wheel-review-assets.py` — verifies the wheel contains the packaged review HTML and all local assets it references.
- `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `package.json` — validate frontend/package assets in CI and builds.

## Validation
- `bun run validate` — passed: 196 Python tests, review regression test, TypeScript typecheck, and production build.
- `uv build` — passed.
- `scripts/verify-wheel-review-assets.py` — passed against the built wheel.
- Extension bundle/load validation — passed.
- `git diff --check` — passed.
- No live Harbor container or Modal end-to-end run was performed.
