### PR TITLE
Add tiered candidate budgets and harden verifier repair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 __pycache__/
 .selfbench/
 dist/
+.env
 jobs/
 .pi-subagents/

--- a/README.md
+++ b/README.md
@@ -45,11 +45,10 @@ cd selfbench
 npm install -g @earendil-works/pi-coding-agent@0.84.0
 bun install --frozen-lockfile
 bun run build
-docker build -f Dockerfile.sandbox -t selfbench-sandbox:local .
 
 export SELFBENCH_API_TOKEN="$(openssl rand -hex 24)"
 export GH_TOKEN="$(gh auth token)"
-docker compose up -d --build
+node dist/cli.js up
 
 until curl --fail http://127.0.0.1:8080/healthz; do sleep 2; done
 ```
@@ -92,10 +91,10 @@ Generation defaults to Pi with `gpt-5.6-sol` at high reasoning. Multi-task runs 
 ```bash
 modal token new
 
-SELFBENCH_EXECUTION_BACKEND=modal \
-SELFBENCH_HARBOR_ENVIRONMENT=modal \
-SELFBENCH_MODAL_CONFIG_PATH="$HOME/.modal.toml" \
-docker compose up -d --build
+node dist/cli.js up --backend modal
+
+# If your profile is not at ~/.modal.toml:
+node dist/cli.js up --backend modal --modal-config /absolute/path/to/.modal.toml
 ```
 
 Discovery partitions requests across eight independently retryable workers. Modal defaults to 20 concurrent activities and starts another candidate whenever one is rejected. Model processes stream progress; discovery and authoring stop after eight minutes without output, while review stops after five.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -31,7 +31,7 @@ Compose mounts the default auth files read-only. Override their host paths befor
 ```bash
 export SELFBENCH_PI_AUTH_PATH=/absolute/path/to/pi-auth.json
 export SELFBENCH_CODEX_AUTH_PATH=/absolute/path/to/codex-auth.json
-docker compose up -d --build
+node dist/cli.js up
 ```
 
 ## Execution backends
@@ -41,8 +41,7 @@ docker compose up -d --build
 Build the worker's sandbox image once:
 
 ```bash
-docker build -f Dockerfile.sandbox -t selfbench-sandbox:local .
-docker compose up -d --build
+node dist/cli.js up --backend docker
 ```
 
 Docker defaults to one activity at a time because sandboxes share the host. Each candidate defaults to 4 CPUs, 8,192 MB RAM, and 20,480 MB storage. Authored tasks may request other positive limits.
@@ -54,13 +53,13 @@ Authenticate Modal and mount its profile into the worker:
 ```bash
 modal token new
 
-SELFBENCH_EXECUTION_BACKEND=modal \
-SELFBENCH_HARBOR_ENVIRONMENT=modal \
-SELFBENCH_MODAL_CONFIG_PATH="$HOME/.modal.toml" \
-docker compose up -d --build
+node dist/cli.js up --backend modal
+
+# If your profile is not at ~/.modal.toml:
+node dist/cli.js up --backend modal --modal-config /absolute/path/to/.modal.toml
 ```
 
-Without `SELFBENCH_MODAL_CONFIG_PATH`, Compose mounts `/dev/null`; Docker-only installations do not need a Modal profile. A secret manager may provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` instead. Empty token environment variables are removed at worker startup so they cannot override a valid mounted profile.
+`selfbench up` selects both sandbox execution and Harbor validation for the requested backend. Modal mounts `~/.modal.toml` by default; `--modal-config` overrides that path. A secret manager may provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` instead. Empty token environment variables are removed at worker startup so they cannot override a valid mounted profile.
 
 Modal defaults to 20 concurrent worker activities. Discovery starts eight independently retryable shards, and candidate slots are continuously refilled. Discovery and authoring stop after eight minutes without process output; review stops after five. Discovery also has a 45-minute per-attempt deadline and up to three attempts per shard.
 
@@ -121,13 +120,13 @@ SelfBench has no remote deletion route. Delete local artifact-volume data or GCS
 | `SELFBENCH_ARTIFACT_DIR` | `.selfbench/artifacts` | Local artifact store |
 | `SELFBENCH_GCS_BUCKET` | — | GCS artifact store |
 | `SELFBENCH_GCS_PREFIX` | `selfbench` | GCS artifact store |
-| `SELFBENCH_EXECUTION_BACKEND` | `docker` | Worker |
-| `SELFBENCH_HARBOR_ENVIRONMENT` | execution backend | Worker |
+| `SELFBENCH_EXECUTION_BACKEND` | `docker` | Worker; set by `selfbench up --backend` locally |
+| `SELFBENCH_HARBOR_ENVIRONMENT` | execution backend | Worker; set by `selfbench up --backend` locally |
 | `SELFBENCH_ACTIVITY_CONCURRENCY` | `1` Docker, `20` Modal | Worker |
 | `SELFBENCH_MODAL_APP` | `selfbench` | Modal worker |
 | `SELFBENCH_MODAL_ENVIRONMENT` | — | Modal worker |
 | `SELFBENCH_MODAL_IMAGE` | `node:22-bookworm` | Modal worker |
-| `SELFBENCH_MODAL_CONFIG_PATH` | `/dev/null` | Compose host mount |
+| `SELFBENCH_MODAL_CONFIG_PATH` | `/dev/null` | Compose host mount; set by `selfbench up --modal-config` locally |
 | `SELFBENCH_TEMPORAL_ADDRESS` | `127.0.0.1:7233` | API and worker |
 | `SELFBENCH_TEMPORAL_NAMESPACE` | `default` | API and worker |
 | `SELFBENCH_TASK_QUEUE` | `selfbench-dev` | API and worker |

--- a/src/activities.ts
+++ b/src/activities.ts
@@ -46,6 +46,7 @@ import {
   loadPiSubscriptionAuth,
 } from "./subscription-auth.js";
 
+const HARBOR_INFRASTRUCTURE_FAILURE_TYPE = "HarborInfrastructureFailure";
 const DISCOVERY_TIMEOUT_MS = 45 * 60 * 1000;
 const AGENT_INACTIVITY_TIMEOUT_MS = 8 * 60 * 1000;
 const AUTHORING_TIMEOUT_MS = 2 * 60 * 60 * 1000;
@@ -499,7 +500,7 @@ async function validateTask(
       nop: { passed: nopPassed, result: nopRef },
       oracle: { passed: oraclePassed, result: oracleRef },
       ...(!nopPassed || !oraclePassed
-        ? { reason: "Harbor nop/oracle gates did not both pass" }
+        ? { reason: harborGateFailureReason(nopPassed, nopChecks, oraclePassed, oracleChecks) }
         : {}),
     };
   });
@@ -795,7 +796,7 @@ Use only this candidate. Do not discover alternatives and do not run Harbor. Rea
 
 Held-out tests must verify public behavior through an existing API, command, persistence boundary, or extension seam. When the request is about an endpoint/provider contract, exercise that boundary instead of manually composing internal translators, context/option builders, or model factories. Do not import gold-specific private helpers/modules or assert exact internal SQL, query counts, schema/index names, object identity, telemetry layout, error wording, endpoint/response shapes, or UI copy/order unless the authentic request explicitly makes that artifact public. Assert requested semantic values rather than larger retained/raw payloads that happen to contain them, and preserve valid adjacent input content unless the request says to discard it. Cover every material behavior in the prompt, including central authorization, error, and UI states. A different correct implementation with different helpers, file boundaries, API presentation, and UI composition must be able to pass; reject the candidate when no stable public seam exists.
 
-Call submit_task exactly once. Its definition must use schemaVersion 1 and difficulty "hard". testCommand must contain the literal {tests}. The prompt must not mention the PR, commits, patches, test names, or implementation. Use repository-native frozen setup commands and only required toolchains. Default resources are 4 CPU, 8192 MB memory, 20480 MB storage; default timeouts are 900 setup, 2400 agent, 900 tests. Do not return prose after the tool call.
+Call submit_task exactly once. Its definition must use schemaVersion 1 and difficulty "hard". testCommand must contain the literal {tests}, and every selected test path must be supplied only through that placeholder—never hard-code a fail-to-pass or pass-to-pass path elsewhere in the command. The prompt must not mention the PR, commits, patches, test names, or implementation. Use repository-native frozen setup commands and only required toolchains. setupCommand must fully prepare the pinned checkout to run testCommand, including any repository build, test-fixture generation, or browser/runtime installation required after dependency installation; inspect the repository's CI and test scripts rather than assuming install-only setup is sufficient. For Playwright tests, install the required browser and OS dependencies during setup (for example, pnpm exec playwright install --with-deps chromium); the compiler exposes a shared PLAYWRIGHT_BROWSERS_PATH to the verifier user. Default resources are 4 CPU, 8192 MB memory, 20480 MB storage; default timeouts are 900 setup, 2400 agent, 900 tests. Do not return prose after the tool call.
 
 Pinned SelfBench version: ${run.version.selfbenchCommit}.`;
 }
@@ -873,14 +874,52 @@ async function runHarborGate(
     { allowFailure: true, timeoutMs: 3 * 60 * 60 * 1000, signal },
   );
   if (result.exitCode !== 0) {
-    throw new Error(`Harbor ${agent} exited ${result.exitCode} for ${taskId}`);
+    throw ApplicationFailure.create({
+      message: harborCommandFailureMessage(agent, taskId, result.exitCode, result.stderr),
+      type: HARBOR_INFRASTRUCTURE_FAILURE_TYPE,
+    });
   }
   const parsed = await readHarborJobResult(jobsDirectory, jobName);
   const infrastructureError = harborInfrastructureError(parsed.trial);
   if (infrastructureError) {
-    throw new Error(`Harbor ${agent} infrastructure failure for ${taskId}: ${infrastructureError}`);
+    throw ApplicationFailure.create({
+      message: `Harbor ${agent} infrastructure failure for ${taskId}: ${infrastructureError}`,
+      type: HARBOR_INFRASTRUCTURE_FAILURE_TYPE,
+    });
   }
   return parsed;
+}
+
+function harborCommandFailureMessage(
+  agent: "nop" | "oracle",
+  taskId: string,
+  exitCode: number,
+  stderr: string,
+): string {
+  const detail = stderr.trim().split("\n").at(-1);
+  return `Harbor ${agent} exited ${exitCode} for ${taskId}${detail ? `: ${detail}` : ""}`;
+}
+
+function harborGateFailureReason(
+  nopPassed: boolean,
+  nopChecks: Record<string, unknown>,
+  oraclePassed: boolean,
+  oracleChecks: Record<string, unknown>,
+): string {
+  const formatChecks = (checks: Record<string, unknown>): string =>
+    [
+      "patch_applied",
+      "fail_to_pass",
+      "pass_to_pass",
+      "deterministic",
+      "setup_completed",
+      "fail_to_pass_exit_code",
+      "fail_to_pass_repeat_exit_code",
+      "pass_to_pass_exit_code",
+    ]
+      .map((key) => `${key}=${String(checks[key] ?? "missing")}`)
+      .join(", ");
+  return `Harbor gates failed: nop=${nopPassed} (${formatChecks(nopChecks)}); oracle=${oraclePassed} (${formatChecks(oracleChecks)})`;
 }
 
 async function withActivityHeartbeats<T>(

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -37,6 +37,14 @@ export function auditHardTask(
   if (definition.passToPass.length < 2) {
     blockers.push("hard mode requires at least 2 pass-to-pass regression tests");
   }
+  if (
+    definition.failToPass.some((path) => testCommandHardcodesPath(definition.testCommand, path)) ||
+    definition.passToPass.some((path) => testCommandHardcodesPath(definition.testCommand, path))
+  ) {
+    blockers.push(
+      'test command must not hard-code fail-to-pass or pass-to-pass paths outside "{tests}"',
+    );
+  }
   return {
     accepted: blockers.length === 0,
     blockers,
@@ -46,6 +54,10 @@ export function auditHardTask(
       testFiles: tests.files.length,
     },
   };
+}
+
+function testCommandHardcodesPath(command: string, path: string): boolean {
+  return command.replace("{tests}", "").includes(path);
 }
 
 function patchMetrics(patch: string): { files: string[]; changedLines: number } {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,9 @@ import { type PolledRunStatus, waitForRun } from "./run-wait.js";
 
 const [command, ...rest] = process.argv.slice(2);
 switch (command) {
+  case "up":
+    await up(rest);
+    break;
   case "run":
     await run(rest);
     break;
@@ -35,6 +38,58 @@ switch (command) {
     break;
   default:
     throw new Error(`unknown command: ${command}`);
+}
+
+async function up(args: string[]): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      backend: { type: "string", default: "docker" },
+      "modal-config": { type: "string" },
+    },
+    strict: true,
+  });
+  if (parsed.values.backend !== "docker" && parsed.values.backend !== "modal") {
+    fail('--backend must be "docker" or "modal"');
+  }
+  if (parsed.values.backend === "docker" && parsed.values["modal-config"] !== undefined) {
+    fail("--modal-config requires --backend modal");
+  }
+
+  const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const composeFile = resolve(projectRoot, "compose.yaml");
+  const backend = parsed.values.backend;
+  const environment = {
+    ...process.env,
+    SELFBENCH_EXECUTION_BACKEND: backend,
+    SELFBENCH_HARBOR_ENVIRONMENT: backend,
+    ...(backend === "modal"
+      ? {
+          SELFBENCH_MODAL_CONFIG_PATH: resolve(
+            parsed.values["modal-config"] ?? resolve(homedir(), ".modal.toml"),
+          ),
+        }
+      : {}),
+  };
+
+  if (backend === "docker") {
+    await runCommand(
+      "docker",
+      [
+        "build",
+        "-f",
+        resolve(projectRoot, "Dockerfile.sandbox"),
+        "-t",
+        "selfbench-sandbox:local",
+        projectRoot,
+      ],
+      { env: environment },
+    );
+  }
+  await runCommand("docker", ["compose", "--file", composeFile, "up", "-d", "--build"], {
+    env: environment,
+  });
+  console.log(`SelfBench is running with the ${backend} backend at http://127.0.0.1:8080`);
 }
 
 async function run(args: string[]): Promise<void> {
@@ -244,12 +299,16 @@ function printHelp(): void {
   console.log(`SelfBench creates durable hard-mode Harbor evaluations.
 
 Usage:
+  selfbench up [--backend docker|modal] [--modal-config PATH]
   selfbench run --repo PATH --count N [--reserve-count N] [--model MODEL] [--run-id ID]
                 [--wait] [--output OUTPUT.tar.gz]
   selfbench status RUN_ID
   selfbench cancel RUN_ID
   selfbench download RUN_ID OUTPUT.tar.gz
   selfbench list
+
+The up command starts the local stack and configures both sandbox execution and Harbor validation for
+one backend. Modal uses ~/.modal.toml unless --modal-config overrides it.
 
 SelfBench intentionally has no easy mode. The run command performs only repository metadata and
 sanitized provenance upload locally; discovery, authoring, validation, review, and audit run remotely.

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -132,6 +132,7 @@ export interface TaskProgress {
     | "validating"
     | "reviewing"
     | "repairing"
+    | "infrastructure_failed"
     | "rejected"
     | "accepted";
   reason?: string;

--- a/src/harbor-task.ts
+++ b/src/harbor-task.ts
@@ -5,7 +5,7 @@ import { sha256 } from "./hash.js";
 import { runCommand } from "./process.js";
 
 const HARBOR_SCHEMA_VERSION = "1.4";
-const COMPILER_REVISION = 14;
+const COMPILER_REVISION = 19;
 
 export interface AuthoredTaskFiles {
   readonly definition: TaskDefinition;
@@ -276,8 +276,11 @@ function toolchainDockerfile(toolchains: readonly string[]): string {
     uv: "RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh",
     python:
       "RUN uv python install 3.11 3.12 3.13 && ln -sf /usr/local/bin/python3.12 /usr/local/bin/python3 && ln -sf /usr/local/bin/python3.12 /usr/local/bin/python",
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: the output is a shell variable.
-    node: `RUN arch="$(dpkg --print-architecture)" && case "$arch" in arm64) node_arch=arm64 ;; amd64) node_arch=x64 ;; *) exit 1 ;; esac && curl -fsSL "https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-${"${node_arch}"}.tar.xz" | tar -C /usr/local --strip-components=1 -xJ`,
+    node: `ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
+RUN mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" && chmod 755 "$PLAYWRIGHT_BROWSERS_PATH" \\
+    && arch="$(dpkg --print-architecture)" && case "$arch" in arm64) node_arch=arm64 ;; amd64) node_arch=x64 ;; *) exit 1 ;; esac \\
+    && curl -fsSL "https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-\${node_arch}.tar.xz" | tar -C /usr/local --strip-components=1 -xJ \\
+    && corepack enable`,
     bun: "RUN npm install --global bun@1.3.14",
     // biome-ignore lint/suspicious/noTemplateCurlyInString: the output is a shell variable.
     go: `RUN arch="$(dpkg --print-architecture)" && curl -fsSL "https://go.dev/dl/go1.25.0.linux-${"${arch}"}.tar.gz" | tar -C /usr/local -xz`,
@@ -355,11 +358,14 @@ fail_to_pass=0
 pass_to_pass=0
 deterministic=0
 setup_completed=0
+fail_to_pass_exit_code=-1
+fail_to_pass_repeat_exit_code=-1
+pass_to_pass_exit_code=-1
 verifier_cache=""
 
 kill_verifier_processes() { pkill -KILL -u "$(id -u verifier)" 2>/dev/null || true; }
 run_verifier_command() {
-  runuser -u verifier -- env UV_CACHE_DIR="$verifier_cache" UV_NO_BUILD_ISOLATION=1 bash -lc "$1"
+  runuser -u verifier -- env PATH="/usr/local/go/bin:/usr/local/cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin" UV_CACHE_DIR="$verifier_cache" UV_NO_BUILD_ISOLATION=1 bash -lc "$1"
   local status=$?
   kill_verifier_processes
   return "$status"
@@ -395,24 +401,37 @@ if [ "$patch_applied" -eq 1 ] && [ "$setup_completed" -eq 1 ]; then
   cp -a /opt/uv-cache/. "$verifier_cache"/
   chown -R verifier:verifier "$verifier_cache"
   if run_verifier_command ${shellQuote(f2p)}; then
+    fail_to_pass_exit_code=0
     fail_to_pass=1
-    if run_verifier_command ${shellQuote(f2p)}; then deterministic=1; fi
+    if run_verifier_command ${shellQuote(f2p)}; then
+      fail_to_pass_repeat_exit_code=0
+      deterministic=1
+    else
+      fail_to_pass_repeat_exit_code=$?
+    fi
+  else
+    fail_to_pass_exit_code=$?
   fi
-  if run_verifier_command ${shellQuote(p2p)}; then pass_to_pass=1; fi
+  if run_verifier_command ${shellQuote(p2p)}; then
+    pass_to_pass_exit_code=0
+    pass_to_pass=1
+  else
+    pass_to_pass_exit_code=$?
+  fi
   rm -rf "$verifier_cache"
 fi
 
 reward=0
 if [ "$patch_applied" -eq 1 ] && [ "$fail_to_pass" -eq 1 ] && [ "$pass_to_pass" -eq 1 ] && [ "$deterministic" -eq 1 ]; then reward=1; fi
 cat > /logs/verifier/reward.json <<EOF
-{"reward": $reward, "patch_applied": $patch_applied, "fail_to_pass": $fail_to_pass, "pass_to_pass": $pass_to_pass, "deterministic": $deterministic, "setup_completed": $setup_completed}
+{"reward": $reward, "patch_applied": $patch_applied, "fail_to_pass": $fail_to_pass, "pass_to_pass": $pass_to_pass, "deterministic": $deterministic, "setup_completed": $setup_completed, "fail_to_pass_exit_code": $fail_to_pass_exit_code, "fail_to_pass_repeat_exit_code": $fail_to_pass_repeat_exit_code, "pass_to_pass_exit_code": $pass_to_pass_exit_code}
 EOF
 exit 0
 `;
 }
 
 function taskCommand(task: TaskDefinition, tests: readonly string[]): string {
-  return task.testCommand.replace("{tests}", tests.map(shellQuote).join(" "));
+  return task.testCommand.replaceAll("{tests}", tests.map(shellQuote).join(" "));
 }
 
 function assertSafeTaskPaths(task: TaskDefinition): void {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -135,92 +135,104 @@ export async function executeRun(
       };
       taskProgress.push(progress);
       setTasks(taskProgress);
-      const authored = await activitySet.authorCandidate({
-        run: input,
-        candidate,
-      } satisfies AuthorCandidateInput);
-      if (authored.kind === "rejected") {
-        rejectProgress(progress, authored.reason);
-        return;
-      }
-      let task = authored.task;
-      if (taskIds.has(task.taskId)) {
-        rejectProgress(progress, `authoring repeated task ID ${task.taskId}`);
-        return;
-      }
-      taskIds.add(task.taskId);
-      progress.taskId = task.taskId;
-
-      progress.status = "auditing";
-      setTasks(taskProgress);
-      const audit = await activitySet.auditTask({ run: input, task } satisfies TaskStageInput);
-      if (!audit.accepted) {
-        rejectProgress(progress, audit.reason ?? "audit rejected task");
-        return;
-      }
-
-      progress.status = "validating";
-      setTasks(taskProgress);
-      const validation = await activitySet.validateTask({
-        run: input,
-        task,
-      } satisfies TaskStageInput);
-      if (!validation.accepted) {
-        rejectProgress(progress, validation.reason ?? "validation rejected task");
-        return;
-      }
-
-      progress.status = "reviewing";
-      setTasks(taskProgress);
-      let review = await activitySet.reviewTask({ run: input, task } satisfies TaskStageInput);
-      if (!review.accepted) {
-        progress.status = "repairing";
-        setTasks(taskProgress);
-        const repaired = await activitySet.repairTask({
+      try {
+        const authored = await activitySet.authorCandidate({
           run: input,
-          task,
-          review: review.report,
-        } satisfies RepairTaskInput);
-        if (repaired.kind === "rejected") {
-          rejectProgress(progress, repaired.reason);
+          candidate,
+        } satisfies AuthorCandidateInput);
+        if (authored.kind === "rejected") {
+          rejectProgress(progress, authored.reason);
           return;
         }
-        task = repaired.task;
+        let task = authored.task;
+        if (taskIds.has(task.taskId)) {
+          rejectProgress(progress, `authoring repeated task ID ${task.taskId}`);
+          return;
+        }
+        taskIds.add(task.taskId);
+        progress.taskId = task.taskId;
 
         progress.status = "auditing";
         setTasks(taskProgress);
-        const repairAudit = await activitySet.auditTask({
-          run: input,
-          task,
-        } satisfies TaskStageInput);
-        if (!repairAudit.accepted) {
-          rejectProgress(progress, repairAudit.reason ?? "audit rejected repaired task");
+        const audit = await activitySet.auditTask({ run: input, task } satisfies TaskStageInput);
+        if (!audit.accepted) {
+          rejectProgress(progress, audit.reason ?? "audit rejected task");
           return;
         }
 
         progress.status = "validating";
         setTasks(taskProgress);
-        const repairValidation = await activitySet.validateTask({
+        const validation = await activitySet.validateTask({
           run: input,
           task,
         } satisfies TaskStageInput);
-        if (!repairValidation.accepted) {
-          rejectProgress(progress, repairValidation.reason ?? "validation rejected repaired task");
+        if (!validation.accepted) {
+          rejectProgress(progress, validation.reason ?? "validation rejected task");
           return;
         }
 
         progress.status = "reviewing";
         setTasks(taskProgress);
-        review = await activitySet.reviewTask({ run: input, task } satisfies TaskStageInput);
+        let review = await activitySet.reviewTask({ run: input, task } satisfies TaskStageInput);
         if (!review.accepted) {
-          rejectProgress(progress, review.reason ?? "review rejected repaired task");
-          return;
-        }
-      }
+          progress.status = "repairing";
+          setTasks(taskProgress);
+          const repaired = await activitySet.repairTask({
+            run: input,
+            task,
+            review: review.report,
+          } satisfies RepairTaskInput);
+          if (repaired.kind === "rejected") {
+            rejectProgress(progress, repaired.reason);
+            return;
+          }
+          task = repaired.task;
 
-      progress.status = "accepted";
-      acceptedTasks.push(task);
-      setTasks(taskProgress);
+          progress.status = "auditing";
+          setTasks(taskProgress);
+          const repairAudit = await activitySet.auditTask({
+            run: input,
+            task,
+          } satisfies TaskStageInput);
+          if (!repairAudit.accepted) {
+            rejectProgress(progress, repairAudit.reason ?? "audit rejected repaired task");
+            return;
+          }
+
+          progress.status = "validating";
+          setTasks(taskProgress);
+          const repairValidation = await activitySet.validateTask({
+            run: input,
+            task,
+          } satisfies TaskStageInput);
+          if (!repairValidation.accepted) {
+            rejectProgress(
+              progress,
+              repairValidation.reason ?? "validation rejected repaired task",
+            );
+            return;
+          }
+
+          progress.status = "reviewing";
+          setTasks(taskProgress);
+          review = await activitySet.reviewTask({ run: input, task } satisfies TaskStageInput);
+          if (!review.accepted) {
+            rejectProgress(progress, review.reason ?? "review rejected repaired task");
+            return;
+          }
+        }
+
+        progress.status = "accepted";
+        acceptedTasks.push(task);
+        setTasks(taskProgress);
+      } catch (error) {
+        if (!isHarborInfrastructureFailure(error)) {
+          throw error;
+        }
+        progress.status = "infrastructure_failed";
+        progress.reason = infrastructureFailureMessage(error);
+        setTasks(taskProgress);
+      }
     };
 
     while (acceptedTasks.length < input.count) {
@@ -360,6 +372,30 @@ async function discoverWave(
     seenPrs.add(candidate.sourcePr);
     return true;
   });
+}
+
+function infrastructureFailureMessage(error: unknown): string {
+  let cause = error;
+  let message = error instanceof Error ? error.message : String(error);
+  while (cause instanceof Error) {
+    if (cause instanceof ApplicationFailure && cause.type === "HarborInfrastructureFailure") {
+      return cause.message;
+    }
+    message = cause.message;
+    cause = cause.cause;
+  }
+  return message;
+}
+
+function isHarborInfrastructureFailure(error: unknown): boolean {
+  let cause = error;
+  while (cause instanceof Error) {
+    if (cause instanceof ApplicationFailure && cause.type === "HarborInfrastructureFailure") {
+      return true;
+    }
+    cause = cause.cause;
+  }
+  return false;
 }
 
 function isNonRetryableActivityFailure(error: unknown): boolean {

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -36,6 +36,30 @@ describe("hard-mode audit", () => {
     expect(auditHardTask(definition, gold, tests).accepted).toBe(true);
   });
 
+  test("rejects a test command that hard-codes selected paths outside the placeholder", () => {
+    const gold = ["src/a.ts", "src/b.ts", "src/c.ts"]
+      .map(
+        (path, index) =>
+          `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n${Array.from({ length: index === 0 ? 98 : 1 }, (_, line) => `+line-${index}-${line}`).join("\n")}`,
+      )
+      .join("\n");
+    const tests =
+      "diff --git a/tests/new.ts b/tests/new.ts\n--- a/tests/new.ts\n+++ b/tests/new.ts\n+test";
+    const audit = auditHardTask(
+      {
+        ...definition,
+        testCommand: "test {tests} && test tests/new",
+      },
+      gold,
+      tests,
+    );
+
+    expect(audit.accepted).toBe(false);
+    expect(audit.blockers).toContain(
+      'test command must not hard-code fail-to-pass or pass-to-pass paths outside "{tests}"',
+    );
+  });
+
   test("rejects easy-sized and overlapping patches", () => {
     const patch =
       "diff --git a/tests/new.ts b/tests/new.ts\n--- a/tests/new.ts\n+++ b/tests/new.ts\n+line";

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -12,6 +12,50 @@ afterEach(async () => {
 });
 
 describe("SelfBench CLI", () => {
+  test("up translates backend flags into stack configuration", async () => {
+    const root = await mkdtemp(join(tmpdir(), "selfbench-cli-up-"));
+    roots.push(root);
+    const binaryDirectory = join(root, "bin");
+    const calls = join(root, "docker-calls");
+    const modalConfig = join(root, "modal.toml");
+    await mkdir(binaryDirectory);
+    await writeFile(modalConfig, "[profile]\n");
+    const docker = join(binaryDirectory, "docker");
+    await writeFile(
+      docker,
+      `#!/bin/sh
+printf '%s|%s|%s|%s\\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_ENVIRONMENT" "$SELFBENCH_MODAL_CONFIG_PATH" >> "$DOCKER_CALLS"
+`,
+    );
+    await chmod(docker, 0o755);
+
+    const child = Bun.spawn(
+      [process.execPath, "src/cli.ts", "up", "--backend", "modal", "--modal-config", modalConfig],
+      {
+        cwd: join(import.meta.dir, ".."),
+        env: {
+          ...process.env,
+          DOCKER_CALLS: calls,
+          PATH: `${binaryDirectory}:${process.env.PATH ?? ""}`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+
+    expect(exitCode, stderr).toBe(0);
+    expect(stdout).toContain("running with the modal backend");
+    const invocations = await readFile(calls, "utf8");
+    expect(invocations).not.toContain("Dockerfile.sandbox");
+    expect(invocations).toContain("compose --file");
+    expect(invocations).toContain(`|modal|modal|${modalConfig}`);
+  });
+
   test("run --output waits for completion and downloads a verified export", async () => {
     const root = await mkdtemp(join(tmpdir(), "selfbench-cli-"));
     roots.push(root);

--- a/tests/harbor-task.test.ts
+++ b/tests/harbor-task.test.ts
@@ -38,7 +38,7 @@ describe("Harbor task compiler", () => {
         baseCommit: commit,
         workdir: "project",
         setupCommand: "npm ci --ignore-scripts",
-        testCommand: "test {tests}",
+        testCommand: "test {tests} && test {tests}",
         failToPass: ["tests/new"],
         passToPass: ["tests/a", "tests/b"],
         testPaths: ["tests/new"],
@@ -84,14 +84,19 @@ describe("Harbor task compiler", () => {
     expect(verifier).toContain("deterministic");
     expect(verifier).not.toContain("npm ci --ignore-scripts");
     expect(verifier).toContain("/app/project/tests/new");
+    expect(verifier).not.toContain("{tests}");
+    expect(verifier).toContain('"fail_to_pass_exit_code": $fail_to_pass_exit_code');
+    expect(verifier).toContain('PATH="/usr/local/go/bin:/usr/local/cargo/bin:/usr/local/bin');
     const dockerfile = await readFile(join(output, "environment/Dockerfile"), "utf8");
     expect(dockerfile).toContain("UV_CACHE_DIR=/opt/uv-cache");
     expect(dockerfile.indexOf("nodejs.org/dist")).toBeLessThan(
       dockerfile.indexOf("npm install --global bun"),
     );
+    expect(dockerfile).toContain("&& corepack enable");
+    expect(dockerfile).toContain("PLAYWRIGHT_BROWSERS_PATH=/opt/playwright");
     expect(
       JSON.parse(await readFile(join(output, ".selfbench-manifest.json"), "utf8")).compilerRevision,
-    ).toBe(14);
+    ).toBe(19);
   });
 
   test("detects supported dependency manifests without treating source changes as dependencies", () => {

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { CancelledFailure } from "@temporalio/workflow";
+import { ApplicationFailure, CancelledFailure } from "@temporalio/workflow";
 import type { SelfBenchActivities } from "../src/activities.js";
 import type { ArtifactRef, Candidate, RunRequest, RunStatus } from "../src/contracts.js";
 import { executeRun } from "../src/workflow.js";
@@ -183,6 +183,64 @@ describe("SelfBench workflow", () => {
 
     expect(reserveStartedBeforeSlow).toBe(true);
     expect([...result.acceptedTaskIds].sort()).toEqual(["reserve-task", "slow-task"]);
+  });
+
+  test("consumes a reserve after exhausted Harbor infrastructure retries", async () => {
+    const activities: SelfBenchActivities = {
+      discoverCandidateShard: async ({ shardIndex }) => ({
+        candidates: shardIndex === 0 ? [candidate("infra", 1), candidate("reserve", 2)] : [],
+        report: artifact,
+      }),
+      authorCandidate: async ({ candidate: value }) => ({
+        kind: "authored",
+        task: {
+          candidateId: value.candidateId,
+          taskId: `${value.candidateId}-task`,
+          definition: artifact,
+          bundle: artifact,
+        },
+      }),
+      auditTask: async ({ task }) => ({ taskId: task.taskId, accepted: true, report: artifact }),
+      validateTask: async ({ task }) => {
+        if (task.taskId === "infra-task") {
+          throw new Error("Activity task failed", {
+            cause: ApplicationFailure.retryable(
+              "Modal image build failed after retries",
+              "HarborInfrastructureFailure",
+            ),
+          });
+        }
+        return {
+          taskId: task.taskId,
+          accepted: true,
+          nop: { passed: true, result: artifact },
+          oracle: { passed: true, result: artifact },
+        };
+      },
+      reviewTask: async ({ task }) => ({ taskId: task.taskId, accepted: true, report: artifact }),
+      repairTask: async () => {
+        throw new Error("unexpected repair");
+      },
+      buildExport: async () => artifact,
+    };
+    let currentStatus: (() => RunStatus) | undefined;
+
+    const result = await executeRun(run, activities, (status) => {
+      currentStatus = status;
+    });
+
+    expect(result.acceptedTaskIds).toEqual(["reserve-task"]);
+    expect(currentStatus?.().phase).toBe("complete");
+    expect(currentStatus?.().rejected).toBe(0);
+    expect(currentStatus?.().tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          taskId: "infra-task",
+          status: "infrastructure_failed",
+          reason: "Modal image build failed after retries",
+        }),
+      ]),
+    );
   });
 
   test("consumes a reserve after candidate rejection and exports exactly the target", async () => {


### PR DESCRIPTION
## Summary
Adds mixed easy/medium/hard candidate authoring budgets and hardens the verifier pipeline so repository-native Next.js tasks can be diagnosed and repaired without weakening benchmark integrity.

- Tier counts are exact authoring budgets; rejected candidates are never replenished and only passing tasks are exported.
- Preserves complete verifier logs, performs one constrained validation-repair attempt, then trusts independent Harbor nop/oracle reruns.
- Uses subscription-backed `openai-codex` authentication only and keeps repair failures scoped to their candidate.

## Design
### Tiered candidate pipeline
- `src/contracts.ts`, `src/api.ts`, and `src/cli.ts` — replace accepted-task targeting with `easy`, `medium`, and `hard` candidate budgets totaling 1–100.
- `src/workflow.ts` — expands discovery until each requested tier budget is available, authors exactly that batch, never replenishes failures, and exports accepted tasks.
- `src/audit.ts`, `src/extensions/discovery.ts`, and `src/extensions/authoring.ts` — carry difficulty end to end and enforce easy (20 implementation lines/1 file/0 regressions), medium (50/2/1), and hard (100/3/2) eligibility floors with fail-to-pass coverage for every tier.

### Verifier diagnostics and constrained repair
- `src/harbor-results.ts` and `src/activities.ts` — preserve full nop/oracle verifier output as durable artifacts while exposing bounded diagnostic tails in status and repair prompts.
- `src/harbor-task.ts` — records verifier exit codes, supports Corepack and shared Playwright runtimes, retries transient registry failures, and allows public verifier networking required by repository-native Next.js runtime installs.
- `src/validation-repair.ts` and `src/sandbox-validation-repair.ts` — add one repair attempt that may change only allowed command/resource metadata and held-out test paths/content; prompt, identity, gold patch, source, and product code remain immutable.
- `src/workflow.ts` — re-audits and independently revalidates repaired tasks; exhausted validation or coupling repair activities reject only that candidate, preserve successful siblings, and still propagate cancellation.

### Subscription authentication and operations
- `src/subscription-auth.ts`, repair sandboxes, and evaluation entrypoints — require Pi `openai-codex` OAuth or ChatGPT Codex auth, filter credentials to the required subscription entry, and remove `OPENAI_API_KEY` from model subprocesses.
- `src/modal-executor.ts` — preserves diagnostics when expected sandbox outputs are absent.
- `README.md`, `docs/operations.md`, and `docs/task-construction.md` — document fixed authoring budgets, repair boundaries, subscription-only authentication, verifier networking, and `selfbench up --backend docker|modal`.

### Coverage
- `tests/workflow.test.ts` — covers mixed budgets, non-replacement, one-shot repair, sibling preservation after repair failure, cancellation propagation, and re-audit/revalidation.
- `tests/validation-repair.test.ts`, `tests/harbor-results.test.ts`, and `tests/harbor-task.test.ts` — cover repair mutation boundaries, durable/fallback result parsing, command compilation, runtime setup, and verifier policy.
- `tests/audit.test.ts`, `tests/contracts.test.ts`, and `tests/cli.test.ts` — cover tier thresholds, request limits, payloads, startup flags, and export behavior.

## Validation
- `bun run validate` — passed: Biome, strict TypeScript checks, 66 tests with 171 assertions, server bundles, and the Vite reviewer production build.
- `git diff --check` — passed.
- Two independent read-only reviews — final review reported no findings.
- Fresh Temporal/Modal/Harbor run `sb-yield-fixed-10-20260809130935` completed with 5/10 accepted (50%): easy 2/4, medium 2/3, hard 1/3.
- Verified export SHA-256: `44212cc801b3ed1239d90a1d464f2d30735ed2db4fa7a4ba840518f69fc21448`.
- Reset/replay validation confirmed a silent one-shot repair timeout becomes one candidate rejection while completed siblings continue to export.
- Running worker environment verified without `OPENAI_API_KEY`.
