### PR TITLE
Add npm trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,38 @@
+name: Publish npm package
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - run: bun install --frozen-lockfile
+      - run: bun run validate
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: test "${GITHUB_REF_NAME#v}" = "$(node -p \"require('./package.json').version\")"
+      - run: npm publish --access public

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "selfbench",
+  "name": "self-bench",
   "version": "0.3.0",
   "description": "Turn completed repository changes into durable, private Harbor evaluations",
   "license": "MIT",
@@ -25,7 +25,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "bun run build:server && bun run build:review",
+    "build": "bun run clean && bun run build:server && bun run build:review",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "cli": "bun run src/cli.ts",
     "build:review": "vite build --config review/vite.config.ts",
     "build:server": "tsc -p tsconfig.build.json && bun build src/sandbox-author.ts --target=node --outfile=dist/sandbox-author.bundle.js && bun build src/sandbox-review.ts --target=node --outfile=dist/sandbox-review.bundle.js && bun build src/sandbox-repair.ts --target=node --outfile=dist/sandbox-repair.bundle.js && bun build src/sandbox-validation-repair.ts --target=node --outfile=dist/sandbox-validation-repair.bundle.js",
@@ -34,11 +35,15 @@
     "dev:review": "vite --config review/vite.config.ts",
     "dev:worker": "tsx src/worker-main.ts",
     "format": "biome format --write .",
+    "prepack": "bun run build",
     "start:api": "node dist/api-main.js",
     "start:worker": "node dist/worker-main.js",
     "test": "bun test tests review/src",
     "typecheck:review": "tsc --noEmit -p review/tsconfig.json",
     "validate": "bun run check && bun run test && bun run build"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.17.0",


### PR DESCRIPTION
## Summary
Prepare `self-bench` for npm and add a tokenless GitHub Actions publishing workflow using npm Trusted Publishing.

- Publishes on version tags or a manual dispatch.
- Validates the tag against `package.json` before release.
- Includes the built CLI and review UI in the npm tarball.

## Design
### Release workflow
- `.github/workflows/publish-npm.yml` — validates the project on Node 24/Bun 1.3.14, requests an npm OIDC identity, verifies tagged versions, and publishes from a GitHub-hosted runner.

### Package assembly
- `package.json` — renames the package to `self-bench`, adds clean/prepack steps, and declares public npm access.
- `.npmignore` — keeps local package assembly noise out of the published tarball while allowing the generated `dist/` output.

## Validation
- `bun run validate` — passed: formatting/type checks, 71 tests, server build, and review UI build.
- Parsed `.github/workflows/publish-npm.yml` successfully as YAML.
- Packed and installed `self-bench@0.3.0` in a clean temporary npm project; `selfbench --help` succeeded.

Trusted Publishing cannot bootstrap an unpublished npm package. The first `self-bench` release still requires a one-time publish with an authenticator or a granular token allowed to bypass 2FA; subsequent releases can use this workflow after configuring `mupt-ai/self-bench` and `publish-npm.yml` in npm package settings.
