### PR TITLE
Release self-bench 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-bench",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Turn completed repository changes into durable, private Harbor evaluations",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Bump the npm package to `self-bench@0.3.1` so the merged Trusted Publishing workflow can publish the next release.

## Design
### Release metadata
- `package.json` — updates the package version from `0.3.0` to `0.3.1`; the existing workflow verifies tags against this value before publishing.

## Validation
- `bun run validate` — passed: formatting/type checks, 71 tests, server build, and review UI build.
- Parsed `.github/workflows/publish-npm.yml` successfully as YAML.
