### PR TITLE
Fix npm release guard and document installation

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,5 +34,7 @@ jobs:
       - run: bun run validate
       - name: Verify tag matches package version
         if: startsWith(github.ref, 'refs/tags/')
-        run: test "${GITHUB_REF_NAME#v}" = "$(node -p \"require('./package.json').version\")"
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          test "${GITHUB_REF_NAME#v}" = "$package_version"
       - run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SelfBench turns completed GitHub changes into private [Harbor](https://harborframework.com/) evaluations for coding agents. It finds real feature requests, builds tasks from the repository's base commit, hides the tests and reference solution, and checks that each task fails without a solution and passes with one.
 
-SelfBench is a TypeScript package. Use **Bun** to install dependencies, build the package, and run the development CLI.
+SelfBench is distributed as the [`self-bench`](https://www.npmjs.com/package/self-bench) npm package. The published CLI requires Node.js 22 or newer. Use **Bun** only when developing SelfBench from source.
 
 ## Choose your setup
 
@@ -15,31 +15,37 @@ After a run is submitted, the workflow continues independently of the waiting CL
 
 ## Prerequisites
 
-All setups require:
+Installing the npm package requires Node.js 22 or newer. Running evaluations additionally requires:
 
-- [Bun](https://bun.sh/) 1.3.14 or newer
 - Docker with Compose
-- Node.js 22 or newer (the built service images use Node)
 - `gh`, authenticated with access to the source repository
 - Pi with an authenticated `openai-codex` account
 - Codex CLI with an authenticated account
 
-Modal execution additionally requires a Modal account and token. Temporal Cloud execution additionally requires a Temporal Cloud namespace and a durable artifact store such as Google Cloud Storage.
+Building SelfBench from source requires [Bun](https://bun.sh/) 1.3.14 or newer. Modal execution additionally requires a Modal account and token. Temporal Cloud execution additionally requires a Temporal Cloud namespace and a durable artifact store such as Google Cloud Storage.
 
-## Install from source
+## Install
 
-The package is not currently published to npm. Clone the repository and build it locally:
+The npm package is named `self-bench`; it installs a command named `selfbench`. Install it globally:
+
+```bash
+npm install --global self-bench
+selfbench --help
+```
+
+You can also try it without a global installation:
+
+```bash
+npx --yes --package self-bench selfbench --help
+```
+
+To develop SelfBench itself, clone the repository and use Bun:
 
 ```bash
 git clone https://github.com/mupt-ai/self-bench.git
 cd self-bench
 bun install --frozen-lockfile
 bun run build
-```
-
-The compiled CLI is `dist/cli.js`, and the package exposes it as `selfbench`. To use `selfbench` directly from this checkout:
-
-```bash
 bun link
 selfbench --help
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SelfBench turns completed GitHub changes into private [Harbor](https://harborframework.com/) evaluations for coding agents. It finds real feature requests, builds tasks from the repository's base commit, hides the tests and reference solution, and checks that each task fails without a solution and passes with one.
 
-SelfBench is distributed as the [`self-bench`](https://www.npmjs.com/package/self-bench) npm package. The published CLI requires Node.js 22 or newer. Use **Bun** only when developing SelfBench from source.
+SelfBench is distributed as the [`self-bench`](https://www.npmjs.com/package/self-bench) package and installed with **Bun**.
 
 ## Choose your setup
 
@@ -15,28 +15,28 @@ After a run is submitted, the workflow continues independently of the waiting CL
 
 ## Prerequisites
 
-Installing the npm package requires Node.js 22 or newer. Running evaluations additionally requires:
+Installing the package requires [Bun](https://bun.sh/) 1.3.14 or newer. Running evaluations additionally requires:
 
 - Docker with Compose
 - `gh`, authenticated with access to the source repository
 - Pi with an authenticated `openai-codex` account
 - Codex CLI with an authenticated account
 
-Building SelfBench from source requires [Bun](https://bun.sh/) 1.3.14 or newer. Modal execution additionally requires a Modal account and token. Temporal Cloud execution additionally requires a Temporal Cloud namespace and a durable artifact store such as Google Cloud Storage.
+Modal execution additionally requires a Modal account and token. Temporal Cloud execution additionally requires a Temporal Cloud namespace and a durable artifact store such as Google Cloud Storage.
 
 ## Install
 
-The npm package is named `self-bench`; it installs a command named `selfbench`. Install it globally:
+The package is named `self-bench`; it installs a command named `selfbench`. Install it globally with Bun:
 
 ```bash
-npm install --global self-bench
+bun install --global self-bench
 selfbench --help
 ```
 
 You can also try it without a global installation:
 
 ```bash
-npx --yes --package self-bench selfbench --help
+bunx --package self-bench selfbench --help
 ```
 
 To develop SelfBench itself, clone the repository and use Bun:


### PR DESCRIPTION
## Summary
Fix the npm publish workflow's version guard and document installation from the published `self-bench` package.

## Design
### Release workflow
- `.github/workflows/publish-npm.yml` — uses a YAML block scalar and valid nested shell quoting when reading `package.json`, avoiding the syntax error from the first `v0.3.1` run.

### Installation documentation
- `README.md` — replaces the obsolete source-only installation claim with global npm and one-off `npx` commands, explains the `self-bench` package versus `selfbench` executable names, and separates install prerequisites from evaluation runtime prerequisites.

## Validation
- Ran the exact version guard locally with `GITHUB_REF_NAME=v0.3.1`; it passed against package version `0.3.1`.
- `npm exec --yes --package=self-bench@0.3.0 -- selfbench --help` passed against the published package.
- `bun run check` passed.
- Parsed the workflow successfully as YAML.
- `git diff --check` passed.
- First-reader README review found the npm installation actionable; its prerequisite and package/CLI naming concerns were addressed in the final edit.
