### PR TITLE
Rename CLI to self-bench, bump to 0.3.2, add build metadata and package verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM oven/bun:1.3.14-debian AS build
 
 WORKDIR /app
+ARG SELFBENCH_BUILD_COMMIT
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 COPY biome.json tsconfig.json tsconfig.build.json ./
 COPY src ./src
+COPY scripts ./scripts
 RUN bun run build:server
 
 FROM docker:29.4.0-cli AS docker-cli

--- a/README.md
+++ b/README.md
@@ -26,18 +26,20 @@ Modal execution additionally requires a Modal account and token. Temporal Cloud 
 
 ## Install
 
-The package is named `self-bench`; it installs a command named `selfbench`. Install it globally with Bun:
+Install the CLI from the npm registry with Bun:
 
 ```bash
-bun install --global self-bench
-selfbench --help
+bun add --global self-bench
+self-bench --help
 ```
 
-You can also try it without a global installation:
+For one-off use without a global install:
 
 ```bash
-bunx --package self-bench selfbench --help
+bunx self-bench --help
 ```
+
+The package exposes `dist/cli.js` as `self-bench`.
 
 To develop SelfBench itself, clone the repository and use Bun:
 
@@ -47,7 +49,7 @@ cd self-bench
 bun install --frozen-lockfile
 bun run build
 bun link
-selfbench --help
+self-bench --help
 ```
 
 During development, run the TypeScript entrypoint without linking:
@@ -72,15 +74,15 @@ This starts Postgres, Temporal, the SelfBench API, and a worker on your machine.
 export SELFBENCH_API_TOKEN="$(openssl rand -hex 24)"
 export GH_TOKEN="$(gh auth token)"
 
-selfbench up --backend docker
+self-bench up --backend docker
 export SELFBENCH_API_URL=http://127.0.0.1:8080
 
-selfbench run \
+self-bench run \
   --repo /absolute/path/to/your/repository \
   --easy-count 30 \
   --medium-count 30 \
   --hard-count 10 \
-  --output ./selfbench-evals.tar.gz
+  --output ./self-bench-evals.tar.gz
 ```
 
 The `--repo` directory must be a Git checkout with a GitHub `origin`. SelfBench pins the current `HEAD`; uncommitted changes are ignored. It discovers candidate requests from sanitized local coding-session messages and merged, non-bot GitHub pull requests.
@@ -92,10 +94,10 @@ A run may take hours. `--output` waits for the run to finish, then downloads and
 ## Local commands
 
 ```bash
-selfbench status RUN_ID
-selfbench list
-selfbench cancel RUN_ID
-selfbench download RUN_ID ./selfbench-evals.tar.gz
+self-bench status RUN_ID
+self-bench list
+self-bench cancel RUN_ID
+self-bench download RUN_ID ./self-bench-evals.tar.gz
 ```
 
 If you are working from source rather than using `bun link`, use the same commands through Bun:
@@ -117,7 +119,7 @@ Named Docker volumes retain Temporal history and generated artifacts. Back them 
 For large repositories or unattended runs, use Temporal Cloud for workflow state and Modal for disposable execution sandboxes. Temporal Cloud does not host the SelfBench API or worker; deploy those separately.
 
 ```text
-selfbench CLI
+self-bench CLI
     -> SelfBench API
     -> Temporal Cloud namespace
     -> persistent SelfBench worker
@@ -194,11 +196,11 @@ Provide the Codex auth JSON to the worker at `/home/node/.codex/auth.json` (the 
 ### 4. Run against the hosted service
 
 ```bash
-selfbench run \
+self-bench run \
   --repo /absolute/path/to/your/repository \
   --easy-count 2 \
   --medium-count 2 \
-  --output ./selfbench-evals.tar.gz
+  --output ./self-bench-evals.tar.gz
 ```
 
 The CLI uploads only repository metadata and sanitized provenance. The worker performs discovery, authoring, sandbox validation, review, audit, and export remotely.
@@ -219,17 +221,17 @@ The local `up` command configures one execution backend for the stack:
 
 ```bash
 # Local Docker sandboxes; simplest, usually one activity at a time
-selfbench up --backend docker
+self-bench up --backend docker
 
 # Modal sandboxes; better for concurrency and larger runs
 modal token new
-selfbench up --backend modal
+self-bench up --backend modal
 ```
 
-For Modal, `selfbench up` uses `~/.modal.toml` by default. Override it with:
+For Modal, `self-bench up` uses `~/.modal.toml` by default. Override it with:
 
 ```bash
-selfbench up --backend modal --modal-config /absolute/path/to/.modal.toml
+self-bench up --backend modal --modal-config /absolute/path/to/.modal.toml
 ```
 
 ## Development

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "selfbench-review",
+      "name": "self-bench",
       "dependencies": {
         "@google-cloud/storage": "^7.17.0",
         "@pierre/diffs": "1.2.12",

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,7 +32,10 @@ services:
 
   api:
     image: selfbench:local
-    build: .
+    build:
+      context: .
+      args:
+        SELFBENCH_BUILD_COMMIT: ${SELFBENCH_BUILD_COMMIT:-}
     depends_on:
       - temporal
     environment: &selfbench-environment
@@ -53,7 +56,10 @@ services:
 
   worker:
     image: selfbench:local
-    build: .
+    build:
+      context: .
+      args:
+        SELFBENCH_BUILD_COMMIT: ${SELFBENCH_BUILD_COMMIT:-}
     command: ["node", "dist/worker-main.js"]
     depends_on:
       - temporal

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -31,7 +31,7 @@ Compose mounts the default auth files read-only. Override their host paths befor
 ```bash
 export SELFBENCH_PI_AUTH_PATH=/absolute/path/to/pi-auth.json
 export SELFBENCH_CODEX_AUTH_PATH=/absolute/path/to/codex-auth.json
-node dist/cli.js up
+self-bench up
 ```
 
 ## Execution backends
@@ -41,7 +41,7 @@ node dist/cli.js up
 Build the worker's sandbox image once:
 
 ```bash
-node dist/cli.js up --backend docker
+self-bench up --backend docker
 ```
 
 Docker defaults to one activity at a time because sandboxes share the host. Each candidate defaults to 4 CPUs, 8,192 MB RAM, and 20,480 MB storage. Authored tasks may request other positive limits.
@@ -53,19 +53,19 @@ Authenticate Modal and mount its profile into the worker:
 ```bash
 modal token new
 
-node dist/cli.js up --backend modal
+self-bench up --backend modal
 
 # If your profile is not at ~/.modal.toml:
-node dist/cli.js up --backend modal --modal-config /absolute/path/to/.modal.toml
+self-bench up --backend modal --modal-config /absolute/path/to/.modal.toml
 ```
 
-`selfbench up` selects both sandbox execution and Harbor validation for the requested backend. Modal mounts `~/.modal.toml` by default; `--modal-config` overrides that path. A secret manager may provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` instead. Empty token environment variables are removed at worker startup so they cannot override a valid mounted profile.
+`self-bench up` selects both sandbox execution and Harbor validation for the requested backend. Modal mounts `~/.modal.toml` by default; `--modal-config` overrides that path. A secret manager may provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` instead. Empty token environment variables are removed at worker startup so they cannot override a valid mounted profile.
 
 Modal defaults to 20 concurrent worker activities. Discovery starts eight independently retryable shards, and candidate slots are continuously refilled. Discovery and authoring stop after eight minutes without process output; review stops after five. Discovery also has a 45-minute per-attempt deadline and up to three attempts per shard.
 
 ## CLI behavior
 
-`selfbench run` requires an absolute or relative path to a Git checkout whose `origin` is an HTTPS or SSH GitHub URL. It pins `HEAD`; uncommitted content is excluded.
+`self-bench run` requires an absolute or relative path to a Git checkout whose `origin` is an HTTPS or SSH GitHub URL. It pins `HEAD`; uncommitted content is excluded.
 
 The CLI collects two types of provenance:
 
@@ -75,13 +75,13 @@ The CLI collects two types of provenance:
 GitHub records remain labeled `github-pull-request` and are bound to their own repository, PR number, and canonical URL. Local requests are preferred when they clearly describe the same change. Common credential forms and injected harness context are removed, but this is not a general secret scanner.
 
 ```bash
-node dist/cli.js run \
+self-bench run \
   --repo /absolute/path/to/repository \
   --easy-count 5 \
   --medium-count 10 \
   --hard-count 5 \
   --model gpt-5.6-sol \
-  --output ./selfbench-tasks.tar.gz
+  --output ./self-bench-tasks.tar.gz
 ```
 
 The three tier counts total 1–100. Each is a fixed candidate authoring budget, not an accepted-task target: rejected candidates are not replaced. Discovery expands only until it fills each requested tier budget, then accepted tasks are exported.
@@ -121,13 +121,13 @@ SelfBench has no remote deletion route. Delete local artifact-volume data or GCS
 | `SELFBENCH_ARTIFACT_DIR` | `.selfbench/artifacts` | Local artifact store |
 | `SELFBENCH_GCS_BUCKET` | — | GCS artifact store |
 | `SELFBENCH_GCS_PREFIX` | `selfbench` | GCS artifact store |
-| `SELFBENCH_EXECUTION_BACKEND` | `docker` | Worker; set by `selfbench up --backend` locally |
-| `SELFBENCH_HARBOR_ENVIRONMENT` | execution backend | Worker; set by `selfbench up --backend` locally |
+| `SELFBENCH_EXECUTION_BACKEND` | `docker` | Worker; set by `self-bench up --backend` locally |
+| `SELFBENCH_HARBOR_ENVIRONMENT` | execution backend | Worker; set by `self-bench up --backend` locally |
 | `SELFBENCH_ACTIVITY_CONCURRENCY` | `1` Docker, `20` Modal | Worker |
 | `SELFBENCH_MODAL_APP` | `selfbench` | Modal worker |
 | `SELFBENCH_MODAL_ENVIRONMENT` | — | Modal worker |
 | `SELFBENCH_MODAL_IMAGE` | `node:22-bookworm` | Modal worker |
-| `SELFBENCH_MODAL_CONFIG_PATH` | `/dev/null` | Compose host mount; set by `selfbench up --modal-config` locally |
+| `SELFBENCH_MODAL_CONFIG_PATH` | `/dev/null` | Compose host mount; set by `self-bench up --modal-config` locally |
 | `SELFBENCH_TEMPORAL_ADDRESS` | `127.0.0.1:7233` | API and worker |
 | `SELFBENCH_TEMPORAL_NAMESPACE` | `default` | API and worker |
 | `SELFBENCH_TASK_QUEUE` | `selfbench-dev` | API and worker |

--- a/package.json
+++ b/package.json
@@ -1,25 +1,38 @@
 {
   "name": "self-bench",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Turn completed repository changes into durable, private Harbor evaluations",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/mupt-ai/self-bench.git"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "type": "module",
   "bin": {
-    "selfbench": "dist/cli.js",
-    "selfbench-agent-smoke": "dist/agent-smoke-main.js",
-    "selfbench-eval": "dist/eval-main.js",
-    "selfbench-reaudit": "dist/reaudit-main.js",
-    "selfbench-repair": "dist/repair-main.js",
-    "selfbench-validate": "dist/validate-main.js"
+    "self-bench": "dist/cli.js",
+    "self-bench-agent-smoke": "dist/agent-smoke-main.js",
+    "self-bench-eval": "dist/eval-main.js",
+    "self-bench-reaudit": "dist/reaudit-main.js",
+    "self-bench-repair": "dist/repair-main.js",
+    "self-bench-validate": "dist/validate-main.js"
   },
   "files": [
     "dist",
-    "src/extensions",
-    "src/skills"
+    "src",
+    "docs",
+    "compose.yaml",
+    "Dockerfile",
+    "Dockerfile.sandbox",
+    "bun.lock",
+    "scripts",
+    "biome.json",
+    "tsconfig.json",
+    "tsconfig.build.json",
+    ".dockerignore"
   ],
   "engines": {
     "node": ">=22"
@@ -29,21 +42,21 @@
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "cli": "bun run src/cli.ts",
     "build:review": "vite build --config review/vite.config.ts",
-    "build:server": "tsc -p tsconfig.build.json && bun build src/sandbox-author.ts --target=node --outfile=dist/sandbox-author.bundle.js && bun build src/sandbox-review.ts --target=node --outfile=dist/sandbox-review.bundle.js && bun build src/sandbox-repair.ts --target=node --outfile=dist/sandbox-repair.bundle.js && bun build src/sandbox-validation-repair.ts --target=node --outfile=dist/sandbox-validation-repair.bundle.js",
+    "build:server": "tsc -p tsconfig.build.json && bun build src/sandbox-author.ts --target=node --outfile=dist/sandbox-author.bundle.js && bun build src/sandbox-review.ts --target=node --outfile=dist/sandbox-review.bundle.js && bun build src/sandbox-repair.ts --target=node --outfile=dist/sandbox-repair.bundle.js && bun build src/sandbox-validation-repair.ts --target=node --outfile=dist/sandbox-validation-repair.bundle.js && bun run build:metadata",
+    "build:metadata": "bun scripts/write-build-metadata.ts",
+    "prepack": "bun run build",
+    "prepublishOnly": "bun run validate",
+    "verify:package": "bun scripts/verify-package.ts",
     "check": "biome check . && tsc --noEmit -p tsconfig.json && bun run typecheck:review",
     "dev:api": "tsx src/api-main.ts",
     "dev:review": "vite --config review/vite.config.ts",
     "dev:worker": "tsx src/worker-main.ts",
     "format": "biome format --write .",
-    "prepack": "bun run build",
     "start:api": "node dist/api-main.js",
     "start:worker": "node dist/worker-main.js",
     "test": "bun test tests review/src",
     "typecheck:review": "tsc --noEmit -p review/tsconfig.json",
-    "validate": "bun run check && bun run test && bun run build"
-  },
-  "publishConfig": {
-    "access": "public"
+    "validate": "bun run check && bun run test && bun run build && bun run verify:package"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.17.0",

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+const temporary = await mkdtemp(join(tmpdir(), "self-bench-package-"));
+async function run(command: string, args: string[], cwd = root): Promise<string> {
+  const child = Bun.spawn([command, ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed:\n${stderr || stdout}`);
+  }
+  return stdout;
+}
+
+try {
+  await run("bun", ["pm", "pack", "--destination", temporary]);
+  const tarballs = (await Array.fromAsync(new Bun.Glob("*.tgz").scan({ cwd: temporary }))).map(
+    (name) => join(temporary, name),
+  );
+  const tarball = tarballs[0] ?? (() => {
+    throw new Error("bun pm pack did not create a tarball");
+  })();
+  const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as {
+    name: string;
+    version: string;
+  };
+  const installRoot = join(temporary, "install");
+  await run("mkdir", ["-p", installRoot]);
+  await run("bun", ["init", "--yes"], installRoot);
+  await run("bun", ["add", "--no-save", tarball], installRoot);
+  const executable = join(installRoot, "node_modules", ".bin", "self-bench");
+  const help = await run(executable, ["--help"], installRoot);
+  if (!help.includes("self-bench up")) {
+    throw new Error("installed self-bench did not print the expected CLI help");
+  }
+  for (const asset of ["compose.yaml", "Dockerfile", "Dockerfile.sandbox", "src/skills/selfbench/SKILL.md"]) {
+    await readFile(join(installRoot, "node_modules", packageJson.name, asset));
+  }
+  const installedPackage = JSON.parse(
+    await readFile(join(installRoot, "node_modules", packageJson.name, "package.json"), "utf8"),
+  ) as { name: string; version: string };
+  if (installedPackage.name !== packageJson.name || installedPackage.version !== packageJson.version) {
+    throw new Error("installed package metadata does not match the workspace package");
+  }
+  console.log(`verified ${installedPackage.name}@${installedPackage.version}`);
+} finally {
+  await rm(temporary, { recursive: true, force: true });
+}

--- a/scripts/write-build-metadata.ts
+++ b/scripts/write-build-metadata.ts
@@ -1,0 +1,27 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = new URL("../", import.meta.url);
+const output = new URL("../dist/build-metadata.js", import.meta.url);
+const configuredCommit = process.env.SELFBENCH_BUILD_COMMIT;
+
+let commit = configuredCommit;
+if (!commit) {
+  try {
+    const result = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: root });
+    commit = result.stdout.trim();
+  } catch {
+    commit = "0".repeat(40);
+  }
+}
+if (!/^[0-9a-f]{40}$/i.test(commit)) {
+  throw new Error("SELFBENCH_BUILD_COMMIT must be a full commit SHA");
+}
+
+await mkdir(new URL("../dist/", import.meta.url), { recursive: true });
+await writeFile(
+  output,
+  `// Generated during the build.\nexport const buildCommit = ${JSON.stringify(commit.toLowerCase())};\n`,
+);

--- a/src/agent-smoke-main.ts
+++ b/src/agent-smoke-main.ts
@@ -18,7 +18,7 @@ if (parsed.values.help) {
   console.log(`Attempt installation and instantiation of every pinned Harbor adapter.
 
 Usage:
-  selfbench-agent-smoke --task DIRECTORY --jobs DIRECTORY [options]
+  self-bench-agent-smoke --task DIRECTORY --jobs DIRECTORY [options]
 
 Options:
   --harbor PATH              Harbor executable (default: harbor)

--- a/src/build-metadata.ts
+++ b/src/build-metadata.ts
@@ -1,0 +1,3 @@
+const unsetBuildCommit = "0".repeat(40);
+
+export const buildCommit = process.env.SELFBENCH_BUILD_COMMIT ?? unsetBuildCommit;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
+import { buildCommit } from "./build-metadata.js";
 import { runCommand } from "./process.js";
 import { collectGitHubPullRequestProvenance, collectRepositoryProvenance } from "./provenance.js";
 import { type PolledRunStatus, waitForRun } from "./run-wait.js";
@@ -64,6 +65,7 @@ async function up(args: string[]): Promise<void> {
   const backend = parsed.values.backend;
   const environment = {
     ...process.env,
+    SELFBENCH_BUILD_COMMIT: await resolveSelfBenchCommit(),
     SELFBENCH_EXECUTION_BACKEND: backend,
     SELFBENCH_HARBOR_ENVIRONMENT: backend,
     ...(backend === "modal"
@@ -212,8 +214,17 @@ async function resolveSelfBenchCommit(): Promise<string> {
   if (process.env.SELFBENCH_BUILD_COMMIT) {
     return process.env.SELFBENCH_BUILD_COMMIT;
   }
+  if (/^[0-9a-f]{40}$/i.test(buildCommit) && !/^0+$/.test(buildCommit)) {
+    return buildCommit;
+  }
   const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  return (await runCommand("git", ["-C", root, "rev-parse", "HEAD"])).stdout.trim();
+  try {
+    return (await runCommand("git", ["-C", root, "rev-parse", "HEAD"])).stdout.trim();
+  } catch {
+    throw new Error(
+      "SelfBench was built without commit metadata; set SELFBENCH_BUILD_COMMIT to a full commit SHA",
+    );
+  }
 }
 
 async function passthrough(method: "GET" | "POST", path: string): Promise<void> {
@@ -321,13 +332,13 @@ function printHelp(): void {
   console.log(`SelfBench creates durable tiered Harbor evaluations.
 
 Usage:
-  selfbench up [--backend docker|modal] [--modal-config PATH]
-  selfbench run --repo PATH [--easy-count N] [--medium-count N] [--hard-count N]
-                [--model MODEL] [--run-id ID] [--wait] [--output OUTPUT.tar.gz]
-  selfbench status RUN_ID
-  selfbench cancel RUN_ID
-  selfbench download RUN_ID OUTPUT.tar.gz
-  selfbench list
+  self-bench up [--backend docker|modal] [--modal-config PATH]
+  self-bench run --repo PATH [--easy-count N] [--medium-count N] [--hard-count N]
+                  [--model MODEL] [--run-id ID] [--wait] [--output OUTPUT.tar.gz]
+  self-bench status RUN_ID
+  self-bench cancel RUN_ID
+  self-bench download RUN_ID OUTPUT.tar.gz
+  self-bench list
 
 The up command starts the local stack and configures both sandbox execution and Harbor validation for
 one backend. Modal uses ~/.modal.toml unless --modal-config overrides it.

--- a/src/eval-main.ts
+++ b/src/eval-main.ts
@@ -21,7 +21,7 @@ if (parsed.values.help) {
   console.log(`Run Harbor tasks through the fixed Codex subscription model matrix.
 
 Usage:
-  selfbench-eval (--export FILE.tar.gz | --tasks DIRECTORY) --jobs DIRECTORY [options]
+  self-bench-eval (--export FILE.tar.gz | --tasks DIRECTORY) --jobs DIRECTORY [options]
 
 Options:
   --tasks DIRECTORY          Expanded Harbor tasks (one or more)

--- a/src/reaudit-main.ts
+++ b/src/reaudit-main.ts
@@ -36,7 +36,7 @@ if (parsed.values.help) {
   console.log(`Re-audit expanded Harbor tasks for test-to-gold coupling.
 
 Usage:
-  selfbench-reaudit --tasks DIRECTORY --output REPORT.json [options]
+  self-bench-reaudit --tasks DIRECTORY --output REPORT.json [options]
 
 Options:
   --concurrency N  Concurrent Sol reviews (default: 10)

--- a/src/repair-main.ts
+++ b/src/repair-main.ts
@@ -27,7 +27,7 @@ if (parsed.values.help) {
   console.log(`Repair coupled tests in expanded Harbor tasks.
 
 Usage:
-  selfbench-repair --tasks DIRECTORY --review REPORT.json --output DIRECTORY [options]
+  self-bench-repair --tasks DIRECTORY --review REPORT.json --output DIRECTORY [options]
 
 Options:
   --concurrency N  Concurrent repair sandboxes (default: 9)

--- a/src/validate-main.ts
+++ b/src/validate-main.ts
@@ -21,7 +21,7 @@ if (parsed.values.help) {
   console.log(`Run Harbor nop and oracle gates for expanded SelfBench tasks.
 
 Usage:
-  selfbench-validate --tasks DIRECTORY --jobs DIRECTORY [options]
+  self-bench-validate --tasks DIRECTORY --jobs DIRECTORY [options]
 
 Options:
   --environment NAME  Harbor environment (default: modal)

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -24,7 +24,7 @@ describe("SelfBench CLI", () => {
     await writeFile(
       docker,
       `#!/bin/sh
-printf '%s|%s|%s|%s\\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_ENVIRONMENT" "$SELFBENCH_MODAL_CONFIG_PATH" >> "$DOCKER_CALLS"
+printf '%s|%s|%s|%s|%s\\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_ENVIRONMENT" "$SELFBENCH_MODAL_CONFIG_PATH" "$SELFBENCH_BUILD_COMMIT" >> "$DOCKER_CALLS"
 `,
     );
     await chmod(docker, 0o755);
@@ -53,7 +53,8 @@ printf '%s|%s|%s|%s\\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_E
     const invocations = await readFile(calls, "utf8");
     expect(invocations).not.toContain("Dockerfile.sandbox");
     expect(invocations).toContain("compose --file");
-    expect(invocations).toContain(`|modal|modal|${modalConfig}`);
+    expect(invocations).toContain(`|modal|modal|${modalConfig}|`);
+    expect(invocations).toMatch(/\|[0-9a-f]{40}\n/);
   });
 
   test("run --output waits for completion and downloads a verified export", async () => {


### PR DESCRIPTION
## Summary

Renames the npm CLI from `selfbench` to `self-bench`, bumps to `0.3.2`, and adds build-time commit metadata + installed-package smoke testing so the npm-published CLI works correctly and reports its revision without a `.git` checkout. The previous `0.3.0` npm release exposed wrong (`selfbench`) bin names and `0.3.1` failed to publish due to a workflow shell bug already fixed on main.

- All user-facing CLI commands now use `self-bench` / `self-bench-*`; internal `SELFBENCH_*` env vars, Docker image names, and task-queue identifiers are unchanged.
- npm tarball now includes Docker, Compose, docs, skills, and build scripts so `self-bench up` works from a global npm install.

## Design

### Package metadata and lifecycle
- `package.json` — bin entries renamed `selfbench-*` → `self-bench-*`; version `0.3.1` → `0.3.2`; `files` expanded to include `src`, `docs`, `compose.yaml`, `Dockerfile`, `Dockerfile.sandbox`, `bun.lock`, `scripts`, `biome.json`, `tsconfig.json`, `tsconfig.build.json`, `.dockerignore`; added `build:metadata`, `verify:package`, `prepack`, `prepublishOnly` scripts; `validate` now ends with `verify:package`.

### Build commit embedding
- `src/build-metadata.ts` — static placeholder exporting `buildCommit` (all-zeros), overwritten by generated `dist/build-metadata.js` at build time.
- `scripts/write-build-metadata.ts` — generates `dist/build-metadata.js` with the git commit SHA (from `SELFBENCH_BUILD_COMMIT` env or `git rev-parse HEAD`), so installed packages report their revision without `.git`.
- `src/cli.ts` `resolveSelfBenchCommit()` — checks env → build metadata → `git rev-parse` (throws if all fail); `up()` sets `SELFBENCH_BUILD_COMMIT` in the Compose environment.
- `Dockerfile` — added `ARG SELFBENCH_BUILD_COMMIT` and `COPY scripts ./scripts` so Docker builds embed the commit into `dist/build-metadata.js`.
- `compose.yaml` — both `api` and `worker` services pass `SELFBENCH_BUILD_COMMIT` as a build arg from the host environment.

### Package verification
- `scripts/verify-package.ts` — packs a tarball, installs it in a temp dir, runs `self-bench --help`, checks that Docker/Compose/skills assets are present, and verifies package metadata.
- `tests/cli.test.ts` — updated docker mock to capture `SELFBENCH_BUILD_COMMIT` and assert a 40-char hex commit is propagated.

### Docs and help text
- `src/cli.ts`, `src/*-main.ts` — all `Usage:` help strings updated from `selfbench-*` to `self-bench-*`.
- `README.md`, `docs/operations.md` — install instructions now show `bun add --global self-bench` / `bunx self-bench`; all user-facing command examples renamed.

## Validation

- `bun run validate` — 71 tests pass, 0 fail; biome check clean; tsc clean; build succeeds; `verify:package` prints `verified self-bench@0.3.2`.
- `npm pack` + `npm install` + `./node_modules/.bin/self-bench --help` — confirmed bin resolves to `self-bench`, help text shows `self-bench` commands, tarball contains all 557 files including Docker/Compose/docs/skills assets.
- Independent reviewer: no blockers; 5 low-severity notes (tarball size from `dist/review/`, redundant builds during publish, bun vs npm tooling in smoke test, pre-existing missing `--provenance`, dead `.npmignore` entries) — none block 0.3.2.
- `v0.3.1` tag publish failed on the existing workflow (shell syntax bug, fixed in PR #30 already on main); this PR does not touch the workflow.
