### PR TITLE
Make private benchmark creation the primary README workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,262 +1,180 @@
-# SelfBench
+# self-bench
 
-SelfBench turns completed GitHub changes into private [Harbor](https://harborframework.com/) evaluations for coding agents. It finds real feature requests, builds tasks from the repository's base commit, hides the tests and reference solution, and checks that each task fails without a solution and passes with one.
+**self-bench builds private coding-agent benchmarks from work already completed in your repository, so you can compare coding agents and models on tasks drawn from your own codebase.**
 
-SelfBench is distributed as the [`self-bench`](https://www.npmjs.com/package/self-bench) package and installed with **Bun**.
+It finds completed requests from local coding sessions and merged GitHub pull requests, then reconstructs each task from the commit before the change. For every accepted task, self-bench creates hidden tests and a reference solution, proves that the task fails without a solution and passes with the original implementation, and exports a native task for [Harbor](https://harborframework.com/), a runner for coding-agent evaluations.
 
-## Choose your setup
+The result is a private `.tar.gz` benchmark that you can run against multiple models:
 
-| Setup | Best for | Execution | State |
-| --- | --- | --- | --- |
-| Local | Trying SelfBench or small runs | Docker on your machine | Local Docker volumes |
-| Temporal Cloud | Large repositories, long runs, and reliable unattended execution | Modal sandboxes | Temporal Cloud + object storage |
+```text
+Your repository history
+        ↓
+completed requests + implementations
+        ↓
+validated Harbor tasks with hidden tests
+        ↓
+gpt-5.6-luna vs gpt-5.6-terra vs gpt-5.6-sol
+```
 
-After a run is submitted, the workflow continues independently of the waiting CLI process. The local worker still depends on your machine and its Docker stack; Temporal Cloud is the recommended setup when a run may take hours or your laptop should not be responsible for the worker.
+## Quickstart
 
-## Prerequisites
+This path runs the self-bench API, worker, and [Temporal](https://temporal.io/) workflow state locally while using [Modal](https://modal.com/) for disposable task-generation and validation sandboxes.
 
-Installing the package requires [Bun](https://bun.sh/) 1.3.14 or newer. Running evaluations additionally requires:
+### Prerequisites
 
+- [Bun](https://bun.sh/) 1.3.14 or newer
 - Docker with Compose
-- `gh`, authenticated with access to the source repository
-- Pi with an authenticated `openai-codex` account
-- Codex CLI with an authenticated account
+- [Modal](https://modal.com/) CLI, account, and token (`pip install modal`)
+- [`gh`](https://cli.github.com/), authenticated with read access to the repository
+- An OpenAI API key with access to `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
+- A Git checkout with a GitHub `origin` and completed work in its history
 
-Modal execution additionally requires a Modal account and token. Temporal Cloud execution additionally requires a Temporal Cloud namespace and a durable artifact store such as Google Cloud Storage.
-
-## Install
-
-Install the CLI from the npm registry with Bun:
+Install self-bench and authenticate Modal and GitHub:
 
 ```bash
 bun add --global self-bench
-self-bench --help
+modal token new
+gh auth login
 ```
 
-For one-off use without a global install:
+Set the model and GitHub credentials used by the local worker, plus a random token that protects the local self-bench API:
 
 ```bash
-bunx self-bench --help
+export OPENAI_API_KEY=...
+export GH_TOKEN="$(gh auth token)"
+export SELFBENCH_API_TOKEN="$(openssl rand -hex 24)"
 ```
 
-The package exposes `dist/cli.js` as `self-bench`.
+### 1. Start self-bench
 
-To develop SelfBench itself, clone the repository and use Bun:
+```bash
+self-bench up --backend modal
+export SELFBENCH_API_URL=http://127.0.0.1:8080
+```
+
+This starts Postgres, Temporal, the self-bench API, and a worker in Docker. The worker sends sandbox work to Modal; `SELFBENCH_API_URL` tells subsequent CLI commands where to reach the local API.
+
+### 2. Build a benchmark
+
+```bash
+self-bench run \
+  --repo /absolute/path/to/your/repository \
+  --easy-count 10 \
+  --medium-count 10 \
+  --hard-count 10 \
+  --output ./self-bench-evals.tar.gz
+```
+
+Easy, medium, and hard candidates require at least 20, 50, and 100 changed implementation lines across 1, 2, and 3 paths respectively; the counts are generation budgets, not guarantees that every candidate will pass validation.
+
+The repository must be a Git checkout with a GitHub `origin`. self-bench pins its current `HEAD`, ignores uncommitted changes, and may take hours to author, validate, review, and export the accepted tasks. `--output` waits for completion and verifies the downloaded archive with SHA-256.
+
+### 3. Compare models with Harbor
+
+Install Harbor and extract the generated tasks:
+
+```bash
+uv tool install --python 3.12 'harbor[modal]==0.20.1.dev202608040148'
+
+mkdir -p ./self-bench-export ./self-bench-tasks
+tar -xzf ./self-bench-evals.tar.gz -C ./self-bench-export
+for archive in ./self-bench-export/tasks/*.tar.gz; do
+  task_id="$(basename "$archive" .tar.gz)"
+  mkdir -p "./self-bench-tasks/$task_id"
+  tar -xzf "$archive" --strip-components=1 -C "./self-bench-tasks/$task_id"
+done
+```
+
+Run Harbor's Codex agent adapter once per model. Each command evaluates all extracted tasks at high reasoning:
+
+```bash
+for model in gpt-5.6-luna gpt-5.6-terra gpt-5.6-sol; do
+  harbor run \
+    --path ./self-bench-tasks \
+    --agent codex \
+    --model "$model" \
+    --ak version=0.146.1 \
+    --ak reasoning_effort=high \
+    --env modal \
+    --jobs-dir "./harbor-jobs/$model" \
+    --n-concurrent 20 \
+    --yes
+done
+```
+
+Harbor stores the three result sets under `./harbor-jobs/`. The evaluated agent receives the base repository and task instruction, but not the hidden tests or reference solution.
+
+See [Running self-bench evaluations](docs/evaluations.md) for running one task and using the optional resumable matrix helper.
+
+## Run management
+
+Closing the waiting CLI does not cancel a submitted workflow. If the local worker or Docker stack stops, work pauses until the worker is restarted.
+
+```bash
+self-bench list                    # find run IDs
+self-bench status RUN_ID
+self-bench cancel RUN_ID
+self-bench download RUN_ID ./self-bench-evals.tar.gz
+```
+
+Stop the local stack with:
+
+```bash
+self-bench down
+```
+
+Named Docker volumes retain Temporal history and generated artifacts.
+
+## Other deployments
+
+The quickstart is the recommended setup: a local stack with Modal sandboxes.
+
+- **Local stack + Docker sandboxes:** use `self-bench up --backend docker` when you want all execution on your machine.
+- **Temporal Cloud + Modal:** use this for persistent unattended workers and large repositories.
+
+See [Operations and deployment](docs/operations.md) for backend configuration, credentials, persistence, object storage, and the complete Temporal Cloud deployment.
+
+## How tasks are validated
+
+An accepted task must:
+
+1. Preserve a real human request from repository history.
+2. Start from the repository state before the completed change.
+3. Include hidden tests that fail against the base snapshot.
+4. Pass after applying the original implementation.
+5. Survive deterministic reruns and an independent model review that rejects tests tied to private details of the reference solution.
+
+Exports contain repository snapshots, hidden tests, and reference solutions. They are sensitive and unencrypted; keep them private.
+
+See [Task construction and validation](docs/task-construction.md) for the full acceptance rules and archive format.
+
+## Development
 
 ```bash
 git clone https://github.com/mupt-ai/self-bench.git
 cd self-bench
 bun install --frozen-lockfile
-bun run build
-bun link
-self-bench --help
+bun run validate
 ```
 
-During development, run the TypeScript entrypoint without linking:
+Run the CLI directly from source:
 
 ```bash
 bun run cli -- --help
-```
-
-Authenticate the tools before starting a run:
-
-```bash
-gh auth login
-# In Pi: /login -> OpenAI Codex
-codex login
-```
-
-## Quick start: local Docker
-
-This starts Postgres, Temporal, the SelfBench API, and a worker on your machine. The worker runs sandbox validation through Docker.
-
-```bash
-export SELFBENCH_API_TOKEN="$(openssl rand -hex 24)"
-export GH_TOKEN="$(gh auth token)"
-
-self-bench up --backend docker
-export SELFBENCH_API_URL=http://127.0.0.1:8080
-
-self-bench run \
-  --repo /absolute/path/to/your/repository \
-  --easy-count 30 \
-  --medium-count 30 \
-  --hard-count 10 \
-  --output ./self-bench-evals.tar.gz
-```
-
-The `--repo` directory must be a Git checkout with a GitHub `origin`. SelfBench pins the current `HEAD`; uncommitted changes are ignored. It discovers candidate requests from sanitized local coding-session messages and merged, non-bot GitHub pull requests.
-
-This quick start authors 70 candidates: 30 easy, 30 medium, and 10 hard. Counts are authoring budgets, not accepted-task guarantees. Candidates can be rejected during authoring, validation, audit, or review, and rejected candidates are not replaced.
-
-A run may take hours. `--output` waits for the run to finish, then downloads and SHA-256-verifies the accepted tasks.
-
-## Local commands
-
-```bash
-self-bench status RUN_ID
-self-bench list
-self-bench cancel RUN_ID
-self-bench download RUN_ID ./self-bench-evals.tar.gz
-```
-
-If you are working from source rather than using `bun link`, use the same commands through Bun:
-
-```bash
-bun run cli -- status RUN_ID
-```
-
-Stop the local stack with Docker Compose:
-
-```bash
-docker compose down
-```
-
-Named Docker volumes retain Temporal history and generated artifacts. Back them up before removing them if you need to resume or inspect old runs.
-
-## Reliable setup for larger repositories
-
-For large repositories or unattended runs, use Temporal Cloud for workflow state and Modal for disposable execution sandboxes. Temporal Cloud does not host the SelfBench API or worker; deploy those separately.
-
-```text
-self-bench CLI
-    -> SelfBench API
-    -> Temporal Cloud namespace
-    -> persistent SelfBench worker
-    -> Modal sandboxes
-    -> GCS artifact storage
-```
-
-The API and worker must use the same image version, Temporal namespace, task queue, artifact configuration, and `SELFBENCH_BUILD_COMMIT`. Keep the worker running on a long-lived container service; do not run it on a scale-to-zero request service. The API can run as a normal HTTP service.
-
-### 1. Prepare Temporal Cloud and GCS
-
-Create a Temporal Cloud namespace and obtain its address, namespace, API key, and TLS settings. Create a GCS bucket for SelfBench artifacts and give the worker/API service accounts access only to the SelfBench prefix.
-
-Set these values in the API and worker environments:
-
-```bash
-SELFBENCH_TEMPORAL_ADDRESS=your-namespace.tmprl.cloud:7233
-SELFBENCH_TEMPORAL_NAMESPACE=your-namespace
-SELFBENCH_TEMPORAL_API_KEY=...
-SELFBENCH_TEMPORAL_TLS=true
-SELFBENCH_TASK_QUEUE=selfbench-production
-SELFBENCH_ARTIFACT_BACKEND=gcs
-SELFBENCH_GCS_BUCKET=your-selfbench-artifacts
-SELFBENCH_GCS_PREFIX=selfbench
-```
-
-Do not use the local Compose defaults (`temporal` database credentials, loopback Temporal address, or local artifact volume) in a hosted deployment.
-
-### 2. Deploy the API
-
-Build and deploy `Dockerfile` as a service listening on port 8080. Configure:
-
-```bash
-SELFBENCH_API_HOST=0.0.0.0
-SELFBENCH_API_TOKEN=use-a-secret-value
-SELFBENCH_ARTIFACT_BACKEND=gcs
-SELFBENCH_GCS_BUCKET=your-selfbench-artifacts
-SELFBENCH_GCS_PREFIX=selfbench
-SELFBENCH_TEMPORAL_ADDRESS=...
-SELFBENCH_TEMPORAL_NAMESPACE=...
-SELFBENCH_TEMPORAL_API_KEY=...
-SELFBENCH_TEMPORAL_TLS=true
-SELFBENCH_TASK_QUEUE=selfbench-production
-```
-
-Then point the CLI at the API:
-
-```bash
-export SELFBENCH_API_URL=https://selfbench-api.example.com
-export SELFBENCH_API_TOKEN=use-a-secret-value
-```
-
-### 3. Deploy the worker
-
-Run the same image with this command:
-
-```bash
-node dist/temporal/worker-main.js
-```
-
-Give the worker the Temporal, GCS, and task-queue settings above, plus the credentials it needs to discover, author, validate, and review tasks:
-
-```bash
-SELFBENCH_EXECUTION_BACKEND=modal
-SELFBENCH_HARBOR_ENVIRONMENT=modal
-MODAL_TOKEN_ID=...
-MODAL_TOKEN_SECRET=...
-GH_TOKEN=...
-SELFBENCH_PI_AUTH_JSON=...
-```
-
-Provide the Codex auth JSON to the worker at `/home/node/.codex/auth.json` (the default location in the production image), for example through a read-only secret mount. Alternatively, mount it elsewhere and set `CODEX_AUTH_JSON_PATH` to that file. Keep model credentials in the worker only; the API does not need them.
-
-### 4. Run against the hosted service
-
-```bash
-self-bench run \
-  --repo /absolute/path/to/your/repository \
-  --easy-count 2 \
-  --medium-count 2 \
-  --output ./self-bench-evals.tar.gz
-```
-
-The CLI uploads only repository metadata and sanitized provenance. The worker performs discovery, authoring, sandbox validation, review, audit, and export remotely.
-
-### Large-repository guidance
-
-- Prefer Modal over local Docker so the run is not tied to your laptop's CPU, memory, or Docker daemon.
-- Start with one or two candidates per tier to confirm credentials, provenance, and repository compatibility before increasing the budget.
-- Treat counts as authoring attempts, not accepted-task guarantees.
-- Keep the worker alive for the entire run; discovery and authoring are retryable, but a missing worker stops progress.
-- Keep GCS and Temporal state persistent. Do not delete the artifact prefix or Temporal namespace while runs are active.
-- Use a dedicated task queue for each deployment and ensure the API and worker use exactly the same value.
-- Use `status`, `list`, and `download` from any machine that can reach the API.
-
-## Backend options
-
-The local `up` command configures one execution backend for the stack:
-
-```bash
-# Local Docker sandboxes; simplest, usually one activity at a time
-self-bench up --backend docker
-
-# Modal sandboxes; better for concurrency and larger runs
-modal token new
-self-bench up --backend modal
-```
-
-For Modal, `self-bench up` uses `~/.modal.toml` by default. Override it with:
-
-```bash
-self-bench up --backend modal --modal-config /absolute/path/to/.modal.toml
-```
-
-## Development
-
-```bash
-bun install --frozen-lockfile
-bun run check
-bun run test
-bun run build
-bun run validate
 ```
 
 Useful development commands:
 
 ```bash
-bun run cli -- --help
 bun run dev:api
 bun run dev:worker
 bun run dev:review
 ```
 
-More detail is available in:
+## Documentation
 
-- [Task construction](docs/task-construction.md)
-- [Evaluation workflows](docs/evaluations.md)
+- [Task construction and validation](docs/task-construction.md)
+- [Running evaluations](docs/evaluations.md)
 - [Operations and deployment](docs/operations.md)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # self-bench
 
+[![npm version](https://img.shields.io/npm/v/self-bench?color=blue&label=npm)](https://www.npmjs.com/package/self-bench)
+[![CI](https://github.com/mupt-ai/self-bench/actions/workflows/ci.yml/badge.svg)](https://github.com/mupt-ai/self-bench/actions/workflows/ci.yml)
+[![license](https://img.shields.io/github/license/mupt-ai/self-bench?color=green)](./LICENSE)
+[![Bun](https://img.shields.io/badge/runtime-Bun-f9f1e1?logo=bun&logoColor=000)](https://bun.sh/)
+[![TypeScript](https://img.shields.io/badge/lang-TypeScript-3178c6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
+
 **self-bench builds private coding-agent benchmarks from work already completed in your repository, so you can compare coding agents and models on tasks drawn from your own codebase.**
 
 It finds completed requests from local coding sessions and merged GitHub pull requests, then reconstructs each task from the commit before the change. For every accepted task, self-bench creates hidden tests and a reference solution, proves that the task fails without a solution and passes with the original implementation, and exports a native task for [Harbor](https://harborframework.com/), a runner for coding-agent evaluations.

--- a/compose.yaml
+++ b/compose.yaml
@@ -66,17 +66,17 @@ services:
     environment:
       <<: *selfbench-environment
       GH_TOKEN: ${GH_TOKEN:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       MODAL_TOKEN_ID: ${MODAL_TOKEN_ID:-}
       MODAL_TOKEN_SECRET: ${MODAL_TOKEN_SECRET:-}
-      CODEX_AUTH_JSON_PATH: /root/.codex/auth.json
+      SELFBENCH_PI_AUTH_JSON: ${SELFBENCH_PI_AUTH_JSON:-}
+      SELFBENCH_CODEX_AUTH_JSON: ${SELFBENCH_CODEX_AUTH_JSON:-}
     user: root
     group_add:
       - ${DOCKER_GID:-0}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${SELFBENCH_MODAL_CONFIG_PATH:-/dev/null}:/root/.modal.toml:ro
-      - ${SELFBENCH_PI_AUTH_PATH:-${HOME}/.pi/agent/auth.json}:/root/.pi/agent/auth.json:ro
-      - ${SELFBENCH_CODEX_AUTH_PATH:-${HOME}/.codex/auth.json}:/root/.codex/auth.json:ro
       - artifacts:/var/lib/selfbench/artifacts
     restart: on-failure
 

--- a/docs/evaluations.md
+++ b/docs/evaluations.md
@@ -1,6 +1,6 @@
-# Running SelfBench evaluations
+# Running self-bench evaluations
 
-A SelfBench export contains a manifest and one archive per accepted Harbor task:
+A self-bench export contains a manifest and one archive per accepted Harbor task:
 
 ```text
 manifest.json
@@ -28,14 +28,13 @@ TASK_ID="$(jq -r '.tasks[0].taskId' ./export/manifest.json)"
 tar -xzf "./export/tasks/$TASK_ID.tar.gz" -C ./selected-task
 ```
 
-Install Harbor and run Codex against it:
+Install Harbor and run Codex against it with API-key authentication:
 
 ```bash
 uv tool install --python 3.12 'harbor[modal]==0.20.1.dev202608040148'
 
-export CODEX_FORCE_AUTH_JSON=1
-export CODEX_AUTH_JSON_PATH="$HOME/.codex/auth.json"
-env -u OPENAI_API_KEY harbor run \
+export OPENAI_API_KEY=...
+harbor run \
   --path ./selected-task/harbor-task \
   --agent codex \
   --model gpt-5.6-sol \
@@ -50,18 +49,20 @@ The `solution/` directory is used only for explicit oracle validation and is nev
 
 ## Run the model matrix
 
-The included matrix runner evaluates every exported task with `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`. It reuses completed Harbor jobs after a restart.
+The included matrix runner evaluates every exported task with `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, all at high reasoning. It reuses completed Harbor jobs after a restart.
 
-From the SelfBench checkout:
+From the self-bench checkout:
 
 ```bash
-env -u OPENAI_API_KEY node dist/eval-main.js \
+export OPENAI_API_KEY=...
+node dist/eval-main.js \
   --export ./my-evals.tar.gz \
   --jobs ./matrix-jobs \
   --harbor harbor \
   --environment modal \
-  --concurrency 20 \
-  --auth "$HOME/.codex/auth.json"
+  --concurrency 20
 ```
 
-The harness requires ChatGPT-backed Codex authentication and does not forward `OPENAI_API_KEY`.
+The runner writes per-task Harbor jobs and a combined `./matrix-jobs/summary.json`.
+
+ChatGPT subscription authentication remains supported for existing deployments: omit `OPENAI_API_KEY` and pass `--auth /path/to/codex-auth.json`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,21 +18,12 @@ Temporal and artifact state live in the `selfbench_temporal-postgres` and `selfb
 
 ## Credentials
 
-SelfBench uses three separate credentials:
+self-bench requires GitHub and model credentials:
 
 - `gh auth login` supplies read access to merged pull requests. Export `GH_TOKEN="$(gh auth token)"` for the worker. Write access is not required.
-- Pi's `openai-codex` entry in `~/.pi/agent/auth.json` powers discovery, authoring, and review.
-- `~/.codex/auth.json` powers the constrained repair step and agent evaluation.
+- `OPENAI_API_KEY` powers discovery, authoring, review, constrained repair, and model evaluation. This is the recommended model-authentication path.
 
-Both model credentials must be backed by a ChatGPT subscription. SelfBench removes API-key fields and does not fall back to `OPENAI_API_KEY`.
-
-Compose mounts the default auth files read-only. Override their host paths before starting the stack when necessary:
-
-```bash
-export SELFBENCH_PI_AUTH_PATH=/absolute/path/to/pi-auth.json
-export SELFBENCH_CODEX_AUTH_PATH=/absolute/path/to/codex-auth.json
-self-bench up
-```
+Existing deployments may continue using ChatGPT subscription authentication by providing both `SELFBENCH_PI_AUTH_JSON` and `SELFBENCH_CODEX_AUTH_JSON`. API-key authentication takes precedence when `OPENAI_API_KEY` is set.
 
 ## Execution backends
 
@@ -131,11 +122,11 @@ SelfBench has no remote deletion route. Delete local artifact-volume data or GCS
 | `SELFBENCH_TEMPORAL_ADDRESS` | `127.0.0.1:7233` | API and worker |
 | `SELFBENCH_TEMPORAL_NAMESPACE` | `default` | API and worker |
 | `SELFBENCH_TASK_QUEUE` | `selfbench-dev` | API and worker |
-| `SELFBENCH_PI_AUTH_PATH` | `~/.pi/agent/auth.json` | Compose host mount |
-| `SELFBENCH_PI_AUTH_JSON` | — | Worker secret alternative |
-| `SELFBENCH_CODEX_AUTH_PATH` | `~/.codex/auth.json` | Compose host mount |
+| `OPENAI_API_KEY` | — | Worker sandboxes and matrix harness |
+| `SELFBENCH_PI_AUTH_JSON` | — | Optional Pi subscription-auth fallback |
+| `SELFBENCH_CODEX_AUTH_JSON` | — | Optional Codex subscription-auth fallback |
 | `GH_TOKEN` | — | Worker GitHub reads |
-| `CODEX_AUTH_JSON_PATH` | `~/.codex/auth.json` | Worker and matrix harness |
+| `CODEX_AUTH_JSON_PATH` | `~/.codex/auth.json` | Optional matrix subscription-auth file |
 
 ## Cloud topology
 
@@ -161,7 +152,7 @@ SELFBENCH_HARBOR_ENVIRONMENT=modal
 MODAL_TOKEN_ID=...
 MODAL_TOKEN_SECRET=...
 GH_TOKEN=...
-SELFBENCH_PI_AUTH_JSON=...
+OPENAI_API_KEY=...
 ```
 
 The worker owns model, GitHub, Modal, and Harbor credentials. Use separate least-privilege service accounts and a secret manager. Grant GCS object access only to the configured prefix, use a TLS-enabled Temporal namespace, and keep API/worker image digests and `SELFBENCH_TASK_QUEUE` identical.
@@ -173,6 +164,6 @@ This repository defines the application boundary, not turnkey cloud infrastructu
 - Exports contain source snapshots, held-out tests, and reference solutions. They are sensitive and unencrypted.
 - Artifact references carry byte length and SHA-256; reads verify integrity.
 - Local artifact paths and GCS object names are confined to their configured roots. GCS IAM should enforce the same prefix independently.
-- Author and review sandboxes receive only Pi's validated `openai-codex` OAuth entry. Repair receives a validated ChatGPT Codex token set with API-key fields removed.
+- Sandboxes receive only the selected model credential: `OPENAI_API_KEY` by default, or a stage-specific subscription credential for compatibility deployments.
 - Sandboxes contain both a source checkout and a short-lived model credential. Use SelfBench only with repositories you trust to execute; it is not a malware-analysis service.
 - Docker uses disposable containers and volumes and removes them after normal completion. A host crash can leave resources for an operator to inspect and remove. Modal uses disposable Sandboxes.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,9 @@ switch (command) {
   case "run":
     await run(rest);
     break;
+  case "down":
+    await down();
+    break;
   case "status":
     await passthrough("GET", `/v1/runs/${requiredArgument(rest, "run ID")}`);
     break;
@@ -95,6 +98,11 @@ async function up(args: string[]): Promise<void> {
     env: environment,
   });
   console.log(`SelfBench is running with the ${backend} backend at http://127.0.0.1:8080`);
+}
+
+async function down(): Promise<void> {
+  const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  await runCommand("docker", ["compose", "--file", resolve(projectRoot, "compose.yaml"), "down"]);
 }
 
 async function run(args: string[]): Promise<void> {
@@ -333,6 +341,7 @@ function printHelp(): void {
 
 Usage:
   self-bench up [--backend docker|modal] [--modal-config PATH]
+  self-bench down
   self-bench run --repo PATH [--easy-count N] [--medium-count N] [--hard-count N]
                   [--model MODEL] [--run-id ID] [--wait] [--output OUTPUT.tar.gz]
   self-bench status RUN_ID

--- a/src/codex-review.ts
+++ b/src/codex-review.ts
@@ -28,45 +28,54 @@ export const couplingReviewSchema = z.object({
 export type CouplingReview = z.infer<typeof couplingReviewSchema>;
 
 export async function reviewCouplingWithCodex(input: {
-  readonly authJson: string;
+  readonly apiKey?: string;
+  readonly authJson?: string;
   readonly prompt: string;
   readonly signal?: AbortSignal;
   readonly fetch?: typeof fetch;
 }): Promise<CouplingReview> {
-  const credential = parseCredential(input.authJson);
-  const accountId = accountIdFromToken(credential.access);
+  const subscription =
+    !input.apiKey && input.authJson ? parseCredential(input.authJson) : undefined;
+  if (!input.apiKey && !subscription) {
+    throw new Error("OpenAI model authentication is required");
+  }
   const request = input.fetch ?? fetch;
-  const response = await request("https://chatgpt.com/backend-api/codex/responses", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${credential.access}`,
-      "ChatGPT-Account-Id": accountId,
-      Originator: "selfbench",
-      "OpenAI-Beta": "responses=experimental",
-      Accept: "text/event-stream",
-      "Content-Type": "application/json",
+  const response = await request(
+    subscription
+      ? "https://chatgpt.com/backend-api/codex/responses"
+      : "https://api.openai.com/v1/responses",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${subscription?.access ?? input.apiKey}`,
+        ...(subscription ? { "ChatGPT-Account-Id": accountIdFromToken(subscription.access) } : {}),
+        Originator: "selfbench",
+        "OpenAI-Beta": "responses=experimental",
+        Accept: "text/event-stream",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: COUPLING_REVIEW_MODEL,
+        store: false,
+        stream: true,
+        instructions:
+          "You are an independent benchmark-quality reviewer. Analyze the supplied evidence and call submit_review exactly once.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: input.prompt }],
+          },
+        ],
+        reasoning: { effort: "high", summary: "auto" },
+        text: { verbosity: "low" },
+        include: ["reasoning.encrypted_content"],
+        tools: [reviewTool()],
+        tool_choice: { type: "function", name: "submit_review" },
+        parallel_tool_calls: false,
+      }),
+      ...(input.signal ? { signal: input.signal } : {}),
     },
-    body: JSON.stringify({
-      model: COUPLING_REVIEW_MODEL,
-      store: false,
-      stream: true,
-      instructions:
-        "You are an independent benchmark-quality reviewer. Analyze the supplied evidence and call submit_review exactly once.",
-      input: [
-        {
-          role: "user",
-          content: [{ type: "input_text", text: input.prompt }],
-        },
-      ],
-      reasoning: { effort: "high", summary: "auto" },
-      text: { verbosity: "low" },
-      include: ["reasoning.encrypted_content"],
-      tools: [reviewTool()],
-      tool_choice: { type: "function", name: "submit_review" },
-      parallel_tool_calls: false,
-    }),
-    ...(input.signal ? { signal: input.signal } : {}),
-  });
+  );
   const responseText = await response.text();
   if (!response.ok) {
     throw new Error(
@@ -74,6 +83,27 @@ export async function reviewCouplingWithCodex(input: {
     );
   }
   return parseCodexReviewEvents(responseText);
+}
+
+function parseCredential(value: string): { access: string } {
+  const parsed = JSON.parse(value) as unknown;
+  const credential = isRecord(parsed) ? parsed["openai-codex"] : undefined;
+  if (!isRecord(credential) || typeof credential.access !== "string") {
+    throw new Error("Pi auth does not contain an OpenAI Codex subscription access token");
+  }
+  return { access: credential.access };
+}
+
+function accountIdFromToken(token: string): string {
+  const payload = JSON.parse(
+    Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8"),
+  ) as unknown;
+  const auth = isRecord(payload) ? payload["https://api.openai.com/auth"] : undefined;
+  const accountId = isRecord(auth) ? auth.chatgpt_account_id : undefined;
+  if (typeof accountId !== "string" || !accountId) {
+    throw new Error("OpenAI Codex subscription token has no ChatGPT account ID");
+  }
+  return accountId;
 }
 
 export function parseCodexReviewEvents(value: string): CouplingReview {
@@ -146,27 +176,6 @@ ${testPatch}
 ${goldPatch}
 \`\`\`
 `;
-}
-
-function parseCredential(value: string): { access: string } {
-  const parsed = JSON.parse(value) as unknown;
-  const credential = isRecord(parsed) ? parsed["openai-codex"] : undefined;
-  if (!isRecord(credential) || typeof credential.access !== "string") {
-    throw new Error("Pi auth does not contain an OpenAI Codex subscription access token");
-  }
-  return { access: credential.access };
-}
-
-function accountIdFromToken(token: string): string {
-  const payload = JSON.parse(
-    Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8"),
-  ) as unknown;
-  const auth = isRecord(payload) ? payload["https://api.openai.com/auth"] : undefined;
-  const accountId = isRecord(auth) ? auth.chatgpt_account_id : undefined;
-  if (typeof accountId !== "string" || !accountId) {
-    throw new Error("OpenAI Codex subscription token has no ChatGPT account ID");
-  }
-  return accountId;
 }
 
 function reviewTool(): Record<string, unknown> {

--- a/src/eval-main.ts
+++ b/src/eval-main.ts
@@ -18,7 +18,7 @@ const parsed = parseArgs({
   strict: true,
 });
 if (parsed.values.help) {
-  console.log(`Run Harbor tasks through the fixed Codex subscription model matrix.
+  console.log(`Run Harbor tasks through the fixed Codex model matrix.
 
 Usage:
   self-bench-eval (--export FILE.tar.gz | --tasks DIRECTORY) --jobs DIRECTORY [options]
@@ -29,7 +29,7 @@ Options:
   --environment docker|modal Execution environment (default: modal)
   --concurrency N            Concurrent trials (default: 3)
   --model MODEL              Run only this model; may be repeated
-  --auth FILE                Codex ChatGPT auth.json path
+  --auth FILE                Optional Codex ChatGPT auth.json fallback
   -h, --help                 Show this help`);
   process.exit(0);
 }

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -4,7 +4,7 @@ import { basename, join, resolve } from "node:path";
 import { archiveIncompleteHarborJob, tryReadHarborJobResult } from "./harbor-results.js";
 import { parallelMap } from "./parallel.js";
 import { runCommand } from "./process.js";
-import { assertCodexSubscriptionAuth } from "./subscription-auth.js";
+import { assertCodexSubscriptionAuth, openAiApiKey } from "./subscription-auth.js";
 
 export const MATRIX_MODELS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const;
 export type MatrixModel = (typeof MATRIX_MODELS)[number];
@@ -40,8 +40,11 @@ export async function runMatrix(options: MatrixOptions): Promise<readonly Matrix
   const tasksDirectory = join(root, "tasks");
   await mkdir(root, { recursive: true });
   const taskDirectories = await resolveMatrixTasks(options, tasksDirectory);
+  const apiKey = openAiApiKey();
   const authPath = resolve(options.authPath ?? join(homedir(), ".codex/auth.json"));
-  await assertSubscriptionAuth(authPath);
+  if (!apiKey) {
+    await assertSubscriptionAuth(authPath);
+  }
   const models = options.models ?? MATRIX_MODELS;
   if (models.length < 1) {
     throw new Error("provide at least one evaluation model");
@@ -55,7 +58,7 @@ export async function runMatrix(options: MatrixOptions): Promise<readonly Matrix
       jobsDirectory: root,
       harborPath: options.harborPath ?? "harbor",
       environment: options.environment ?? "modal",
-      authPath,
+      ...(!apiKey ? { authPath } : {}),
       ...item,
     });
     completed += 1;
@@ -69,7 +72,7 @@ export async function runMatrix(options: MatrixOptions): Promise<readonly Matrix
         schemaVersion: 1,
         agent: "codex",
         agentVersion: CODEX_VERSION,
-        auth: "codex-subscription",
+        auth: apiKey ? "openai-api-key" : "codex-subscription",
         reasoningEffort: "high",
         models,
         taskCount: taskDirectories.length,
@@ -112,7 +115,7 @@ async function runTrial(input: {
   readonly jobsDirectory: string;
   readonly harborPath: string;
   readonly environment: "docker" | "modal";
-  readonly authPath: string;
+  readonly authPath?: string;
 }): Promise<MatrixTrialSummary> {
   const taskId = basename(input.taskDirectory);
   const jobName = `${taskId}-${input.model}`.toLowerCase().replace(/[^a-z0-9_.-]/g, "-");
@@ -123,9 +126,11 @@ async function runTrial(input: {
   await archiveIncompleteHarborJob(input.jobsDirectory, jobName);
 
   const environment = { ...process.env };
-  delete environment.OPENAI_API_KEY;
-  environment.CODEX_FORCE_AUTH_JSON = "1";
-  environment.CODEX_AUTH_JSON_PATH = input.authPath;
+  if (input.authPath) {
+    delete environment.OPENAI_API_KEY;
+    environment.CODEX_FORCE_AUTH_JSON = "1";
+    environment.CODEX_AUTH_JSON_PATH = input.authPath;
+  }
   let result: Awaited<ReturnType<typeof runCommand>>;
   try {
     result = await runCommand(

--- a/src/reaudit-main.ts
+++ b/src/reaudit-main.ts
@@ -20,7 +20,7 @@ import {
 import { parallelMap } from "./parallel.js";
 import { runCommand } from "./process.js";
 import { createSandboxExecutor, type SandboxExecutor } from "./sandbox.js";
-import { loadPiSubscriptionAuth } from "./subscription-auth.js";
+import { loadPiModelAuth } from "./subscription-auth.js";
 
 const parsed = parseArgs({
   options: {
@@ -50,9 +50,9 @@ const outputPath = resolve(parsed.values.output ?? fail("--output is required"))
 const concurrency = positiveInteger(parsed.values.concurrency, "--concurrency");
 const config = loadConfig();
 const sandbox = createSandboxExecutor(config.execution);
-const [taskIds, piAuth, reviewer] = await Promise.all([
+const [taskIds, modelAuth, reviewer] = await Promise.all([
   readdir(tasksDirectory),
-  loadPiSubscriptionAuth(),
+  loadPiModelAuth(),
   readFile(join(assetRoot(), "dist/sandbox-review.bundle.js")),
 ]);
 const directories = (
@@ -79,7 +79,7 @@ const tasks = await parallelMap(directories, concurrency, async (taskDirectory) 
   const taskId = basename(taskDirectory);
   console.error(`reviewing ${taskId}`);
   try {
-    const report = await auditTask(taskDirectory, taskId, piAuth, reviewer, sandbox);
+    const report = await auditTask(taskDirectory, taskId, modelAuth, reviewer, sandbox);
     console.error(`${taskId}: ${report.resolution.verdict}`);
     return report;
   } catch (error) {
@@ -113,7 +113,7 @@ console.log(JSON.stringify({ output: outputPath, ...report.summary }, null, 2));
 async function auditTask(
   taskDirectory: string,
   taskId: string,
-  piAuth: string,
+  modelAuth: { apiKey?: string; authJson?: string },
   reviewer: Uint8Array,
   sandbox: SandboxExecutor,
 ) {
@@ -151,7 +151,10 @@ async function auditTask(
         },
       ],
       outputPaths: ["/work/review.json"],
-      secrets: { SELFBENCH_PI_AUTH_JSON: piAuth },
+      secrets: {
+        ...(modelAuth.apiKey ? { OPENAI_API_KEY: modelAuth.apiKey } : {}),
+        ...(modelAuth.authJson ? { SELFBENCH_PI_AUTH_JSON: modelAuth.authJson } : {}),
+      },
       environment: { SELFBENCH_REVIEW_OUTPUT: "/work/review.json" },
       command: ["node", "/work/sandbox-review.js"],
     });

--- a/src/repair-main.ts
+++ b/src/repair-main.ts
@@ -9,7 +9,7 @@ import { loadConfig } from "./config.js";
 import { parallelMap } from "./parallel.js";
 import { runCommand } from "./process.js";
 import { createSandboxExecutor } from "./sandbox.js";
-import { loadCodexSubscriptionAuth } from "./subscription-auth.js";
+import { loadCodexModelAuth } from "./subscription-auth.js";
 
 const parsed = parseArgs({
   options: {
@@ -79,8 +79,8 @@ for (const source of sourceTasks) {
 
 const config = loadConfig();
 const sandbox = createSandboxExecutor(config.execution);
-const [authJson, repairer] = await Promise.all([
-  loadCodexSubscriptionAuth(),
+const [modelAuth, repairer] = await Promise.all([
+  loadCodexModelAuth(),
   readFile(join(assetRoot(), "dist/sandbox-repair.bundle.js")),
 ]);
 const results = await parallelMap([...coupled.values()], concurrency, async (taskReview) => {
@@ -103,7 +103,10 @@ const results = await parallelMap([...coupled.values()], concurrency, async (tas
         { path: "/work/sandbox-repair.js", contents: repairer },
       ],
       outputPaths: ["/work/repaired-task.tar.gz", "/work/repair-report.json"],
-      secrets: { SELFBENCH_CODEX_AUTH_JSON: authJson },
+      secrets: {
+        ...(modelAuth.apiKey ? { OPENAI_API_KEY: modelAuth.apiKey } : {}),
+        ...(modelAuth.authJson ? { SELFBENCH_CODEX_AUTH_JSON: modelAuth.authJson } : {}),
+      },
       environment: { SELFBENCH_REPAIR_MODEL: parsed.values.model ?? "gpt-5.6-sol" },
       command: [
         "node",

--- a/src/sandbox-repair.ts
+++ b/src/sandbox-repair.ts
@@ -50,13 +50,15 @@ await runCommand("git", [
 ]);
 await runCommand("git", ["-C", repositoryDirectory, "add", "-N", "--all"]);
 
+const codexAuth = process.env.SELFBENCH_CODEX_AUTH_JSON;
+const apiKey = process.env.OPENAI_API_KEY;
+if (!apiKey && !codexAuth) {
+  fail("OPENAI_API_KEY or SELFBENCH_CODEX_AUTH_JSON is required");
+}
 const codexHome = join(homedir(), ".codex");
 const authPath = join(codexHome, "auth.json");
 await mkdir(codexHome, { recursive: true });
-await writeFile(
-  authPath,
-  process.env.SELFBENCH_CODEX_AUTH_JSON ?? fail("SELFBENCH_CODEX_AUTH_JSON is required"),
-);
+await writeFile(authPath, codexAuth ?? `${JSON.stringify({ OPENAI_API_KEY: apiKey })}\n`);
 await chmod(authPath, 0o600);
 const promptPath = join(tmpdir(), `selfbench-repair-${taskId}.md`);
 await writeFile(
@@ -86,7 +88,7 @@ const codex = await runCommand(
   {
     allowFailure: true,
     timeoutMs: 90 * 60 * 1000,
-    env: withoutApiKey(process.env),
+    env: process.env,
     input: await readFile(promptPath, "utf8"),
     onOutput: (stream, chunk) => {
       (stream === "stdout" ? process.stdout : process.stderr).write(chunk);
@@ -148,12 +150,6 @@ await writeFile(
     2,
   )}\n`,
 );
-
-function withoutApiKey(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const output = { ...environment };
-  delete output.OPENAI_API_KEY;
-  return output;
-}
 
 function fail(message: string): never {
   throw new Error(message);

--- a/src/sandbox-review.ts
+++ b/src/sandbox-review.ts
@@ -1,17 +1,19 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { reviewCouplingWithCodex } from "./codex-review.js";
 
+const apiKey = process.env.OPENAI_API_KEY;
 const authJson = process.env.SELFBENCH_PI_AUTH_JSON;
 const outputPath = process.env.SELFBENCH_REVIEW_OUTPUT;
-if (!authJson) {
-  throw new Error("SELFBENCH_PI_AUTH_JSON is required");
+if (!apiKey && !authJson) {
+  throw new Error("OPENAI_API_KEY or SELFBENCH_PI_AUTH_JSON is required");
 }
 if (!outputPath) {
   throw new Error("SELFBENCH_REVIEW_OUTPUT is required");
 }
 
 const review = await reviewCouplingWithCodex({
-  authJson,
+  ...(apiKey ? { apiKey } : {}),
+  ...(authJson ? { authJson } : {}),
   prompt: await readFile("/work/review-input.md", "utf8"),
 });
 await writeFile(outputPath, `${JSON.stringify(review, null, 2)}\n`, { flag: "wx" });

--- a/src/sandbox-validation-repair.ts
+++ b/src/sandbox-validation-repair.ts
@@ -68,10 +68,19 @@ await Promise.all([
 ]);
 
 const piHome = join(homedir(), ".pi/agent");
-const piAuth = process.env.SELFBENCH_PI_AUTH_JSON ?? fail("SELFBENCH_PI_AUTH_JSON is required");
+const piAuth = process.env.SELFBENCH_PI_AUTH_JSON;
+if (!process.env.OPENAI_API_KEY && !piAuth) {
+  fail("OPENAI_API_KEY or SELFBENCH_PI_AUTH_JSON is required");
+}
 await mkdir(piHome, { recursive: true });
 await Promise.all([
-  writeFile(join(piHome, "auth.json"), piAuth).then(() => chmod(join(piHome, "auth.json"), 0o600)),
+  ...(piAuth
+    ? [
+        writeFile(join(piHome, "auth.json"), piAuth).then(() =>
+          chmod(join(piHome, "auth.json"), 0o600),
+        ),
+      ]
+    : []),
   writeFile(join(piHome, "settings.json"), `${JSON.stringify({ transport: "auto" })}\n`),
 ]);
 const promptPath = join(tmpdir(), `selfbench-validation-repair-${originalDefinition.taskId}.md`);
@@ -98,7 +107,7 @@ const pi = await runCommand(
     "--no-context-files",
     "--no-extensions",
     "--provider",
-    "openai-codex",
+    process.env.OPENAI_API_KEY ? "openai" : "openai-codex",
     "--model",
     process.env.SELFBENCH_REPAIR_MODEL ?? "gpt-5.6-sol",
     "--thinking",
@@ -111,7 +120,7 @@ const pi = await runCommand(
     allowFailure: true,
     timeoutMs: 90 * 60 * 1000,
     cwd: repositoryDirectory,
-    env: withoutApiKey(process.env),
+    env: process.env,
     onOutput: (stream, chunk) => {
       (stream === "stdout" ? process.stdout : process.stderr).write(chunk);
     },
@@ -162,12 +171,6 @@ await Promise.all([
     )}\n`,
   ),
 ]);
-
-function withoutApiKey(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const output = { ...environment };
-  delete output.OPENAI_API_KEY;
-  return output;
-}
 
 function fail(message: string): never {
   throw new Error(message);

--- a/src/subscription-auth.ts
+++ b/src/subscription-auth.ts
@@ -3,6 +3,34 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { runCommand } from "./process.js";
 
+export interface PiModelAuth {
+  readonly provider: "openai" | "openai-codex";
+  readonly apiKey?: string;
+  readonly authJson?: string;
+}
+
+export interface CodexModelAuth {
+  readonly apiKey?: string;
+  readonly authJson?: string;
+}
+
+export function openAiApiKey(): string | undefined {
+  const key = process.env.OPENAI_API_KEY?.trim();
+  return key || undefined;
+}
+
+export async function loadPiModelAuth(): Promise<PiModelAuth> {
+  const apiKey = openAiApiKey();
+  return apiKey
+    ? { provider: "openai", apiKey }
+    : { provider: "openai-codex", authJson: await loadPiSubscriptionAuth() };
+}
+
+export async function loadCodexModelAuth(): Promise<CodexModelAuth> {
+  const apiKey = openAiApiKey();
+  return apiKey ? { apiKey } : { authJson: await loadCodexSubscriptionAuth() };
+}
+
 export async function loadPiSubscriptionAuth(): Promise<string> {
   const raw =
     process.env.SELFBENCH_PI_AUTH_JSON ??
@@ -28,7 +56,8 @@ export function assertCodexSubscriptionAuth(value: unknown, source = "Codex auth
 
 export async function loadCodexSubscriptionAuth(): Promise<string> {
   const path = process.env.CODEX_AUTH_JSON_PATH ?? join(homedir(), ".codex/auth.json");
-  const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+  const raw = process.env.SELFBENCH_CODEX_AUTH_JSON ?? (await readFile(path, "utf8"));
+  const parsed = JSON.parse(raw) as unknown;
   assertCodexSubscriptionAuth(parsed, path);
   const auth = parsed as Record<string, unknown>;
   return JSON.stringify({

--- a/src/temporal/activities.ts
+++ b/src/temporal/activities.ts
@@ -44,11 +44,7 @@ import { sha256 } from "../hash.js";
 import { runCommand } from "../process.js";
 import { assertProvenanceMatchesPullRequest, type ProvenanceMessage } from "../provenance.js";
 import { createSandboxExecutor, type SandboxExecutor, type SandboxRunOptions } from "../sandbox.js";
-import {
-  githubToken,
-  loadCodexSubscriptionAuth,
-  loadPiSubscriptionAuth,
-} from "../subscription-auth.js";
+import { githubToken, loadCodexModelAuth, loadPiModelAuth } from "../subscription-auth.js";
 
 const HARBOR_INFRASTRUCTURE_FAILURE_TYPE = "HarborInfrastructureFailure";
 const DISCOVERY_TIMEOUT_MS = 45 * 60 * 1000;
@@ -177,7 +173,7 @@ async function discoverCandidateShard(
   } else {
     const [extension, piAuth, ghToken] = await Promise.all([
       readAsset("src/extensions/discovery.ts"),
-      loadPiSubscriptionAuth(),
+      loadPiModelAuth(),
       githubToken(),
     ]);
     Context.current().heartbeat(
@@ -199,7 +195,8 @@ async function discoverCandidateShard(
             ],
             outputPaths: ["/work/discovery.json"],
             secrets: {
-              SELFBENCH_PI_AUTH_JSON: piAuth,
+              ...(piAuth.apiKey ? { OPENAI_API_KEY: piAuth.apiKey } : {}),
+              ...(piAuth.authJson ? { SELFBENCH_PI_AUTH_JSON: piAuth.authJson } : {}),
               ...(ghToken ? { GH_TOKEN: ghToken } : {}),
             },
             environment: {
@@ -355,7 +352,7 @@ async function authorCandidate(
     readAsset("src/extensions/authoring.ts"),
     readAsset("src/skills/selfbench/SKILL.md"),
     readAsset("dist/sandbox-author.bundle.js"),
-    loadPiSubscriptionAuth(),
+    loadPiModelAuth(),
     githubToken(),
   ]);
   const prompt = authoringPrompt(run, candidate);
@@ -377,7 +374,8 @@ async function authorCandidate(
           ],
           outputPaths: ["/work/task.tar.gz", "/work/definition.json"],
           secrets: {
-            SELFBENCH_PI_AUTH_JSON: piAuth,
+            ...(piAuth.apiKey ? { OPENAI_API_KEY: piAuth.apiKey } : {}),
+            ...(piAuth.authJson ? { SELFBENCH_PI_AUTH_JSON: piAuth.authJson } : {}),
             ...(ghToken ? { GH_TOKEN: ghToken } : {}),
           },
           environment: {
@@ -590,9 +588,8 @@ async function repairValidationTask(
     store.get(input.task.bundle),
     store.get(input.task.definition),
     readAsset("dist/sandbox-validation-repair.bundle.js"),
-    loadPiSubscriptionAuth(),
-  ]);
-  // Full verifier logs remain durable artifacts. The validation reason already carries bounded
+    loadPiModelAuth(),
+  ]); // Full verifier logs remain durable artifacts. The validation reason already carries bounded
   // tails for failed gates, which keeps the repair prompt within the model context window.
   const diagnostics = Buffer.from(input.validation.reason ?? "validation failed without a reason");
   const result = await withActivityHeartbeats(
@@ -615,7 +612,10 @@ async function repairValidationTask(
             "/work/repaired-test.patch",
             "/work/repair-report.json",
           ],
-          secrets: { SELFBENCH_PI_AUTH_JSON: authJson },
+          secrets: {
+            ...(authJson.apiKey ? { OPENAI_API_KEY: authJson.apiKey } : {}),
+            ...(authJson.authJson ? { SELFBENCH_PI_AUTH_JSON: authJson.authJson } : {}),
+          },
           environment: { SELFBENCH_REPAIR_MODEL: input.run.authoring.model },
           command: [
             "node",
@@ -703,7 +703,7 @@ async function reviewTask(
     });
     const [reviewer, authJson] = await Promise.all([
       readAsset("dist/sandbox-review.bundle.js"),
-      loadPiSubscriptionAuth(),
+      loadPiModelAuth(),
     ]);
     const result = await withActivityHeartbeats(
       `running sandboxed coupling review for ${input.task.taskId}`,
@@ -727,7 +727,10 @@ async function reviewTask(
               },
             ],
             outputPaths: ["/work/review.json"],
-            secrets: { SELFBENCH_PI_AUTH_JSON: authJson },
+            secrets: {
+              ...(authJson.apiKey ? { OPENAI_API_KEY: authJson.apiKey } : {}),
+              ...(authJson.authJson ? { SELFBENCH_PI_AUTH_JSON: authJson.authJson } : {}),
+            },
             environment: { SELFBENCH_REVIEW_OUTPUT: "/work/review.json" },
             command: ["node", "/work/sandbox-review.js"],
           },
@@ -795,7 +798,7 @@ async function repairTask(
     store.get(input.task.bundle),
     store.get(input.review),
     readAsset("dist/sandbox-repair.bundle.js"),
-    loadCodexSubscriptionAuth(),
+    loadCodexModelAuth(),
   ]);
   const result = await withActivityHeartbeats(
     `running test repair sandbox for ${input.task.taskId}`,
@@ -812,7 +815,10 @@ async function repairTask(
             { path: "/work/sandbox-repair.js", contents: repairer },
           ],
           outputPaths: ["/work/repaired-task.tar.gz", "/work/repair-report.json"],
-          secrets: { SELFBENCH_CODEX_AUTH_JSON: authJson },
+          secrets: {
+            ...(authJson.apiKey ? { OPENAI_API_KEY: authJson.apiKey } : {}),
+            ...(authJson.authJson ? { SELFBENCH_CODEX_AUTH_JSON: authJson.authJson } : {}),
+          },
           environment: { SELFBENCH_REPAIR_MODEL: input.run.authoring.model },
           command: [
             "node",
@@ -979,7 +985,7 @@ function modalAgentScript(extension: string, tool: string): string {
 clone_source
 cd /work/repo
 pi --print --mode json --no-session --no-approve --no-skills --no-prompt-templates --no-context-files --no-extensions \\
-  --extension /work/${extension} --provider openai-codex --model "$AUTHOR_MODEL" --thinking high \\
+  --extension /work/${extension} --provider "$(model_provider)" --model "$AUTHOR_MODEL" --thinking high \\
   --tools read,bash,grep,find,ls,${tool} "$(cat /work/prompt.txt)" 2>&1`;
 }
 
@@ -990,7 +996,7 @@ mkdir -p /work/tasks
 cd /work/repo
 pi --print --mode json --no-session --no-approve --no-prompt-templates --no-context-files --no-extensions \\
   --skill /work/selfbench-skill --extension /work/authoring.ts \\
-  --provider openai-codex --model "$AUTHOR_MODEL" --thinking high \\
+  --provider "$(model_provider)" --model "$AUTHOR_MODEL" --thinking high \\
   --tools read,bash,grep,find,ls,submit_task "$(cat /work/prompt.txt)" 2>&1
 node /work/sandbox-author.js /work/tasks /work/repo /work/harbor-task
 cp /work/tasks/*/definition.json /work/definition.json
@@ -1000,9 +1006,13 @@ tar -czf /work/task.tar.gz -C /work harbor-task`;
 function sandboxBootstrap(): string {
   return `set -euo pipefail
 mkdir -p "$HOME/.pi/agent"
-printf '%s' "$SELFBENCH_PI_AUTH_JSON" > "$HOME/.pi/agent/auth.json"
+if [ -n "\${SELFBENCH_PI_AUTH_JSON:-}" ]; then
+  printf '%s' "$SELFBENCH_PI_AUTH_JSON" > "$HOME/.pi/agent/auth.json"
+  chmod 600 "$HOME/.pi/agent/auth.json"
+fi
 printf '%s\n' '{"transport":"auto"}' > "$HOME/.pi/agent/settings.json"
-chmod 600 "$HOME/.pi/agent/auth.json" "$HOME/.pi/agent/settings.json"
+chmod 600 "$HOME/.pi/agent/settings.json"
+model_provider() { [ -n "\${OPENAI_API_KEY:-}" ] && printf openai || printf openai-codex; }
 cleanup() { rm -f "$HOME/.pi/agent/auth.json" "$HOME/.pi/agent/settings.json" "$HOME/.git-credentials"; }
 trap cleanup EXIT
 clone_source() {

--- a/tests/codex-review.test.ts
+++ b/tests/codex-review.test.ts
@@ -1,7 +1,83 @@
 import { describe, expect, test } from "bun:test";
-import { parseCodexReviewEvents } from "../src/codex-review.js";
+import { parseCodexReviewEvents, reviewCouplingWithCodex } from "../src/codex-review.js";
 
 describe("Codex coupling review", () => {
+  test("uses the public Responses API with API-key authentication", async () => {
+    let requestedUrl = "";
+    let authorization = "";
+    const fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      requestedUrl = String(input);
+      authorization = new Headers(init?.headers).get("authorization") ?? "";
+      return new Response(
+        `data: ${JSON.stringify({
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            name: "submit_review",
+            arguments: JSON.stringify({
+              verdict: "clean",
+              reason: "base contract",
+              findings: [
+                {
+                  artifact: "route",
+                  category: "endpoint_path",
+                  disposition: "base_contract",
+                  evidence: "Present in base.",
+                },
+              ],
+              counterexample: "An alternative implementation would pass.",
+            }),
+          },
+        })}\n\ndata: [DONE]\n`,
+        { status: 200 },
+      );
+    }) as typeof globalThis.fetch;
+
+    await reviewCouplingWithCodex({ apiKey: "api-key", prompt: "review", fetch });
+
+    expect(requestedUrl).toBe("https://api.openai.com/v1/responses");
+    expect(authorization).toBe("Bearer api-key");
+  });
+
+  test("prefers the API key when both auth forms are supplied", async () => {
+    let requestedUrl = "";
+    const fetch = (async (input: string | URL | Request) => {
+      requestedUrl = String(input);
+      return new Response(
+        `data: ${JSON.stringify({
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            name: "submit_review",
+            arguments: JSON.stringify({
+              verdict: "clean",
+              reason: "base contract",
+              findings: [
+                {
+                  artifact: "route",
+                  category: "endpoint_path",
+                  disposition: "base_contract",
+                  evidence: "Present.",
+                },
+              ],
+              counterexample: "Alternative passes.",
+            }),
+          },
+        })}\ndata: [DONE]\n`,
+        { status: 200 },
+      );
+    }) as typeof globalThis.fetch;
+
+    await reviewCouplingWithCodex({
+      apiKey: "api-key",
+      authJson: JSON.stringify({ "openai-codex": { access: "not-used" } }),
+      prompt: "review",
+      fetch,
+    });
+
+    expect(requestedUrl).toBe("https://api.openai.com/v1/responses");
+  });
+
   test("parses the forced submit_review tool call", () => {
     const review = parseCodexReviewEvents(
       `data: ${JSON.stringify({

--- a/tests/subscription-auth.test.ts
+++ b/tests/subscription-auth.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { assertCodexSubscriptionAuth, loadPiSubscriptionAuth } from "../src/subscription-auth.js";
+import {
+  assertCodexSubscriptionAuth,
+  loadCodexModelAuth,
+  loadPiModelAuth,
+  loadPiSubscriptionAuth,
+} from "../src/subscription-auth.js";
 
 afterEach(() => {
+  delete process.env.OPENAI_API_KEY;
   delete process.env.SELFBENCH_PI_AUTH_JSON;
 });
 
@@ -16,6 +22,13 @@ describe("subscription authentication", () => {
     expect(() =>
       assertCodexSubscriptionAuth({ auth_mode: "apikey", tokens: { access_token: "token" } }),
     ).toThrow("ChatGPT subscription token set");
+  });
+
+  test("prefers one OpenAI API key for Pi and Codex sandboxes", async () => {
+    process.env.OPENAI_API_KEY = "  api-key  ";
+
+    expect(await loadPiModelAuth()).toEqual({ provider: "openai", apiKey: "api-key" });
+    expect(await loadCodexModelAuth()).toEqual({ apiKey: "api-key" });
   });
 
   test("passes only the OpenAI subscription credential to sandboxes", async () => {


### PR DESCRIPTION
## Summary
Refocuses the public README on self-bench's core job: turning completed repository work into private coding-agent benchmarks and comparing models through Harbor.

- Makes local self-bench + Modal the canonical quickstart.
- Uses `OPENAI_API_KEY` as the default model credential while preserving subscription-auth fallbacks.
- Adds `self-bench down` so globally installed users can stop the packaged Compose stack.

## Design
### Public workflow and operations
- `README.md` — replaces deployment-first framing with a concise product explanation, 10/10/10 candidate quickstart, direct Harbor commands for Luna/Terra/Sol at high reasoning, run-management guidance, and links to advanced documentation.
- `docs/evaluations.md` — documents API-key evaluation auth and the Harbor/model workflow.
- `docs/operations.md` — keeps Docker, Temporal Cloud, persistence, and subscription fallback details outside the main quickstart.
- `src/cli.ts` — adds `self-bench down`, resolving the packaged `compose.yaml` just like `self-bench up`.

### Model authentication
- `src/subscription-auth.ts` — centralizes API-key-first Pi and Codex credential loading while retaining Pi/Codex subscription JSON as compatibility fallbacks.
- `src/temporal/activities.ts` — forwards the selected credential form to authoring, review, repair, and evaluation activities.
- `src/codex-review.ts` — uses the public Responses API for API keys, retains the ChatGPT subscription endpoint fallback, and enforces API-key precedence.
- `src/sandbox-repair.ts` — materializes the minimal Codex auth file required by the pinned CLI when using an API key.
- `compose.yaml` — forwards `OPENAI_API_KEY` and optional fallback JSON without requiring host auth-file mounts.
- `tests/subscription-auth.test.ts` and `tests/codex-review.test.ts` — cover credential selection, API authentication, and precedence.

## Validation
- `bun run check` — passed (Biome, main TypeScript, and review TypeScript checks).
- `bun test` — passed before the final precedence test was added: 73 passed, 0 failed.
- `bun test tests/codex-review.test.ts tests/cli.test.ts tests/subscription-auth.test.ts` — passed after final changes: 10 passed, 0 failed.
- `bun run build` — passed; Vite emitted only its existing chunk-size warning.
- `bun run verify:package` — passed for `self-bench@0.3.2`.
- `git diff --check` — passed.
- No paid end-to-end OpenAI/Modal run was performed.
