### PR TITLE
Add guided Vercel Sandbox setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Named Docker volumes retain Temporal history and generated artifacts.
 The quickstart is the recommended setup: a local stack with Modal sandboxes.
 
 - **Local stack + Docker sandboxes:** use `self-bench up --backend docker` when you want all execution on your machine.
-- **Local stack + Vercel Sandbox:** configure a Vercel project, access token, and digest-pinned VCR image, then explicitly choose Docker or Modal for Harbor validation.
+- **Local stack + Vercel Sandbox:** run `self-bench setup vercel`, then explicitly choose Docker or Modal for Harbor validation.
 - **Temporal Cloud + Modal:** use this for persistent unattended workers and large repositories.
 
 See [Operations and deployment](docs/operations.md) for backend configuration, credentials, persistence, object storage, and the complete Temporal Cloud deployment.
@@ -149,6 +149,7 @@ self-bench up --backend docker
 self-bench up --backend modal
 
 # Vercel generation with either supported Harbor environment
+self-bench setup vercel
 self-bench up --backend vercel --harbor-environment docker
 self-bench up --backend vercel --harbor-environment modal
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "self-bench",
       "dependencies": {
+        "@clack/prompts": "1.7.0",
         "@google-cloud/storage": "^7.17.0",
         "@temporalio/activity": "^1.13.2",
         "@temporalio/client": "^1.13.2",
@@ -153,6 +154,10 @@
     "@cbor-extract/cbor-extract-linux-x64": ["@cbor-extract/cbor-extract-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA=="],
 
     "@cbor-extract/cbor-extract-win32-x64": ["@cbor-extract/cbor-extract-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA=="],
+
+    "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
+
+    "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.0", "@earendil-works/pi-telemetry": "^0.84.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-L1lw0lwR5LXCzGEeHD9XNEruU2bg0H8clOA8ySdGMHvxutp8GC+yZL6MZp4tqQRnLKP3gHmY7TrWzQ3YnFdJYQ=="],
 
@@ -696,7 +701,13 @@
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
     "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
 
@@ -953,6 +964,8 @@
     "shiki": ["shiki@4.4.3", "", { "dependencies": { "@shikijs/core": "4.4.3", "@shikijs/engine-javascript": "4.4.3", "@shikijs/engine-oniguruma": "4.4.3", "@shikijs/langs": "4.4.3", "@shikijs/themes": "4.4.3", "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "smol-toml": ["smol-toml@1.7.1", "", {}, "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ=="],
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,7 +25,7 @@ self-bench requires GitHub and model credentials:
 
 Existing deployments may continue using ChatGPT subscription authentication by providing both `SELFBENCH_PI_AUTH_JSON` and `SELFBENCH_CODEX_AUTH_JSON`. API-key authentication takes precedence when `OPENAI_API_KEY` is set.
 
-Sandbox-provider credentials are separate. Modal accepts its mounted profile or token pair. Vercel execution requires the explicit `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, and `VERCEL_PROJECT_ID` triple described below. Keep all of these on the worker; the API does not need provider or model credentials.
+Sandbox-provider credentials are separate. Modal accepts its mounted profile or token pair. For a local Vercel worker, `self-bench setup vercel` stores a project-scoped token in an owner-only local profile. Unattended workers use the equivalent `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, and `VERCEL_PROJECT_ID` environment variables. Keep provider credentials on the worker; the API does not need them.
 
 ## Execution backends and Harbor
 
@@ -40,7 +40,7 @@ self-bench up --backend docker --harbor-environment modal
 self-bench up --backend modal --harbor-environment docker
 ```
 
-Use `--modal-config` whenever either side uses Modal. A worker has one fixed pairing; do not run workers with different provider settings on the same Temporal task queue. Run and export metadata record both choices.
+Use `--modal-config` whenever either side uses Modal. A worker has one fixed pairing; do not run workers with different provider settings on the same Temporal task queue. Run and export metadata record both choices, plus the effective Vercel timeout cap when applicable.
 
 ### Docker
 
@@ -71,85 +71,88 @@ Modal defaults to 20 concurrent worker activities. Discovery starts eight indepe
 
 ### Vercel Sandbox
 
-Vercel is a generation backend only; choose Docker or Modal for Harbor. The workflow includes authoring and repair stages with two-hour sandbox deadlines, so the owning Vercel scope must have an effective limit of at least two hours. Vercel currently documents a 45-minute Hobby maximum and a 24-hour Pro/Enterprise maximum. Sandbox use, VCR storage, memory, active CPU, and data transfer are metered by Vercel; configure Spend Management before unattended runs.
+Vercel is a generation backend only; choose Docker or Modal for Harbor. SelfBench supports both Vercel's 45-minute Hobby Sandbox ceiling and the longer paid-team ceiling. Discovery requests 45 minutes, review requests 15 minutes, and authoring and repair request two hours; setup detects the selected project's effective capability and caps every Vercel stage centrally when necessary. Sandbox use, VCR storage, memory, active CPU, and data transfer are metered by Vercel; configure Spend Management before unattended runs. Vercel Hobby use is intended for personal, non-commercial work.
 
-#### 1. Create a project and access token
+#### Interactive local setup
 
-Create or select a project in the team that should own both the sandboxes and their runtime image. The project does not need a deployment. Create a short-lived, project-scoped [Vercel access token](https://vercel.com/docs/accounts/access-tokens) for that project and record the team and project IDs from Vercel settings.
-
-The Vercel SDK can use ambient OIDC when code runs on Vercel infrastructure. SelfBench worker configuration instead requires explicit `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, and `VERCEL_PROJECT_ID` values. Vercel CLI login authenticates only the image-publication workflow; its session is not passed to the worker.
-
-#### 2. Publish the runtime image
-
-SelfBench requires its pinned Node, Pi, Codex, GitHub CLI, and `/work` runtime, so rolling Vercel managed images are not used. Publish `Dockerfile.sandbox` to the same project's [Vercel Container Registry](https://vercel.com/docs/container-registry/getting-started) as `linux/amd64`. Install the current [Vercel CLI](https://vercel.com/docs/cli) on the operator machine first:
+Install the current Vercel CLI and make sure Docker is available for the runtime-image build:
 
 ```bash
-npm install --global vercel
-vercel login
-
-export VERCEL_PROJECT_ID=prj_...
-IMAGE_TAG="$(git rev-parse --short HEAD)"
-
-vercel vcr login --project "$VERCEL_PROJECT_ID" docker
-vercel vcr build \
-  --project "$VERCEL_PROJECT_ID" \
-  --platform linux/amd64 \
-  --push \
-  docker . "selfbench-sandbox:$IMAGE_TAG" \
-  -- --file Dockerfile.sandbox
-
-vercel vcr tag inspect \
-  --project "$VERCEL_PROJECT_ID" \
-  --format json \
-  selfbench-sandbox "$IMAGE_TAG"
+npm install --global vercel@latest
+self-bench setup vercel
 ```
 
-Wait for VCR to report the image as `Ready`, then copy its immutable `sha256:...` digest. Configure the project-relative form so team and project slugs are not embedded in exported run metadata:
+Interactive setup keeps long-running publication and capability checks compact, with a live elapsed timer that freezes when each step completes. Use `self-bench setup vercel --verbose` to stream the underlying Vercel CLI and Docker build output; compact mode reveals retained command output automatically when a step fails.
+
+Setup uses Vercel CLI browser login for control-plane selection and VCR publication. It then:
+
+1. shows a searchable team or personal-scope picker;
+2. offers a searchable existing-project picker or creation of a dedicated project;
+3. asks for a project name, defaulting to `selfbench-sandbox`, and retries rather than silently suffixing an unavailable name;
+4. publishes the pinned `Dockerfile.sandbox` runtime to the project's `selfbench-runtime` VCR repository;
+5. prints the Vercel token page and asks for a manually created access token restricted to the selected project, with terminal echo disabled;
+6. creates and immediately deletes a one-vCPU, nonpersistent probe sandbox to verify the token, image, command execution, cleanup, and effective duration ceiling;
+7. activates the profile only after every required check succeeds.
+
+The project does not need a deployment. Its metered use is billed to its owning Vercel scope. CLI login and worker configuration are deliberately separate: CLI login selects and provisions resources, while the project-scoped token plus team and project IDs configure the SelfBench worker. Although the Vercel SDK supports ambient OIDC on Vercel infrastructure, SelfBench does not use it.
+
+Profiles live in `~/.selfbench/config.json`; tokens live separately in `~/.selfbench/credentials.json`. The directory is mode `0700`, both files are mode `0600`, writes are atomic, and displayed setup output never includes the token. Override the directory with `SELFBENCH_CONFIG_DIR` when isolation is needed. To maintain more than one project profile:
 
 ```bash
-export SELFBENCH_VERCEL_IMAGE='selfbench-sandbox@sha256:...'
+self-bench setup vercel --profile secondary
+self-bench up --backend vercel --vercel-profile secondary --harbor-environment modal
 ```
 
-Tags and rolling aliases are rejected. VCR repositories are project-scoped by default; a sandbox in another project cannot use the image unless the repository is explicitly shared. Keeping the token, project ID, and image in the same project is the simplest configuration.
+Without `--vercel-profile`, `self-bench up` uses the active profile most recently saved by setup. Rerunning setup revalidates the existing project and token by default. It fingerprints the exact Dockerfile—including its digest-pinned base and pinned tool defaults—plus the fingerprint schema and target platform; if the matching immutable VCR image is already ready, publication is skipped. A changed runtime produces a new content-derived tag and digest. The final image reference is always digest-pinned, and existing digests are not deleted automatically. If the default VCR repository contains unrelated images, setup leaves it untouched and asks for another name.
 
-#### 3. Start the worker
+When rerunning setup for a named profile, the available actions are:
+
+- **Revalidate** keeps the saved team, project, and token. It verifies current access, reuses a compatible ready image, republishes only if the runtime fingerprint changed, reruns the temporary Sandbox capability probe, and refreshes the saved image digest and timeout cap.
+- **Replace the access token** keeps the saved team and project, requests a new project-scoped token, and activates it only after verification succeeds. It replaces only the locally stored credential; revoke the old token separately in Vercel if necessary.
+- **Choose another team or project** repoints the same local profile name after the new project, image, and token pass verification. It does not delete the previous Vercel project or images. Use a different `--profile` name instead when both configurations should remain available.
+
+If setup is interrupted after creating a project or VCR repository, it reports the failure and leaves the durable resource in place; rerun setup to continue. It never activates a partial profile. Vercel projects and VCR images are reusable across SelfBench runs and persist after `self-bench down`.
+
+#### Start the local worker
+
+```bash
+self-bench up --backend vercel --harbor-environment modal
+# self-bench up --backend vercel --harbor-environment docker
+```
+
+Modal Harbor also needs the Modal profile or token pair. Vercel control credentials are removed from the Harbor child process for both Harbor environments. `self-bench up` resolves the profile, then validates the complete credential triple, digest-pinned image, and timeout cap before starting Compose.
+
+The setup probe records a two-hour effective SelfBench ceiling when the requested two-hour sandbox is accepted. If Vercel returns its exact 45-minute limit response, setup verifies a 45-minute sandbox, explains the impact, and asks before saving that cap. Longer authoring and repair requests then run for at most 45 minutes and return exit 124 on timeout, so only the affected candidate is rejected. Discovery and review retain their shorter requested limits. The effective cap is included in run and export metadata.
+
+#### Environment-only and unattended workers
+
+`self-bench setup vercel` is intentionally interactive. CI and long-running workers can provide the same resolved values through environment variables or a secret manager:
 
 ```bash
 export VERCEL_TOKEN=...
 export VERCEL_TEAM_ID=team_...
 export VERCEL_PROJECT_ID=prj_...
-export SELFBENCH_VERCEL_IMAGE='selfbench-sandbox@sha256:...'
+export SELFBENCH_VERCEL_IMAGE='selfbench-runtime@sha256:...'
+export SELFBENCH_VERCEL_TIMEOUT_CAP=2h  # use 45m when that is the verified ceiling
 
-# Choose exactly one Harbor environment.
 self-bench up --backend vercel --harbor-environment modal
-# self-bench up --backend vercel --harbor-environment docker
 ```
 
-Modal Harbor also needs the Modal profile or token pair. Vercel control credentials are removed from the Harbor child process for both Harbor environments. `self-bench up` validates the complete credential triple and digest-pinned image before starting Compose.
+The image must already have been published from `Dockerfile.sandbox` to the same project's VCR as `linux/amd64`. Use the bare repository-plus-digest form shown above; tags and rolling aliases are rejected. VCR repositories are project-scoped by default, so a sandbox in another project cannot use the image unless the repository is explicitly shared. Explicit token and image values take precedence over profile values, and a lower timeout cap may be supplied; an override cannot exceed the profile's verified ceiling. Supplying a complete credential/image environment requires no local profile; partial team or project overrides are rejected rather than combined across scopes.
 
 Vercel defaults to four concurrent worker activities. A standard SelfBench sandbox requests 4 vCPUs, which Vercel pairs with 8 GB of memory, plus 32 GB of ephemeral disk. Unsupported CPU/memory combinations are rejected before allocation. Raise `SELFBENCH_ACTIVITY_CONCURRENCY` only after considering the team's allocation limits and budget. Lower it—often to `1`—when using Docker Harbor on a smaller local machine, because the Vercel-oriented default does not account for local Harbor capacity.
 
 Each sandbox run uses a fresh nonpersistent sandbox (`persistent: false`). SelfBench does not create snapshots or resume stopped sandboxes, and it attempts to delete every sandbox when the run ends. If deletion cannot be confirmed, the activity fails so the cleanup problem remains visible. If the worker crashes before cleanup, compute may continue until the provider timeout; Vercel then discards the filesystem, although the stopped sandbox record may remain for up to 14 days unless manually deleted.
 
-For manual inventory, install and authenticate Vercel's separate [Sandbox CLI](https://vercel.com/docs/sandbox/cli-reference), then include stopped records in the listing:
-
-```bash
-npm install --global sandbox
-sandbox login
-sandbox list --all
-sandbox snapshots list
-sandbox remove UNEXPECTED_SANDBOX_NAME
-```
-
-Cancel active workflows and let cleanup finish before stopping the stack. The project dashboard provides the same inspection and removal boundary.
+Cancel active workflows and let cleanup finish before stopping the stack.
 
 Common failures:
 
-- `timeout should be <= 45m` means Vercel is applying the Hobby duration ceiling. Verify the token, team/project ownership, and effective paid plan; after a new paid plan starts, entitlement propagation may lag. Retry a cheap, short-lived create at the intended timeout later before contacting Vercel Support if a correctly scoped Pro/Enterprise project still receives it.
+- A newly changed paid plan may take time to propagate its longer timeout entitlement. Rerun `self-bench setup vercel` to repeat the short-lived capability probe and update the saved cap; if a correctly scoped paid project continues to detect 45 minutes, verify team/project ownership before contacting Vercel Support.
 - `not_found` on create usually means the image belongs to another project or is private and unshared. Prefer the same project and a bare digest reference.
 - `image_not_ready` means VCR has not finished optimizing the `linux/amd64` image.
 - Repeated HTTP 429 allocation failures indicate project/team allocation pressure. The executor honors bounded `Retry-After` retries; reduce activity concurrency if pressure continues.
-- Cleanup errors fail the activity rather than silently leaving reusable state. Inspect and remove the exact `selfbench-...` sandbox before retrying.
+- Cleanup errors fail the activity rather than silently leaving reusable state and include the exact `selfbench-...` sandbox name for diagnosis.
 
 ## CLI behavior
 
@@ -217,10 +220,12 @@ SelfBench has no remote deletion route. Delete local artifact-volume data or GCS
 | `SELFBENCH_MODAL_ENVIRONMENT` | — | Modal worker |
 | `SELFBENCH_MODAL_IMAGE` | `node:22-bookworm` | Modal worker |
 | `SELFBENCH_MODAL_CONFIG_PATH` | `/dev/null` | Compose host mount; set by `self-bench up --modal-config` locally |
-| `SELFBENCH_VERCEL_IMAGE` | — | Required digest-pinned VCR image for Vercel execution |
-| `VERCEL_TOKEN` | — | Vercel worker; explicit access token |
-| `VERCEL_TEAM_ID` | — | Vercel worker |
-| `VERCEL_PROJECT_ID` | — | Vercel worker; must be able to resolve the configured image |
+| `SELFBENCH_VERCEL_IMAGE` | profile or — | Required digest-pinned VCR image for Vercel execution |
+| `SELFBENCH_VERCEL_TIMEOUT_CAP` | `2h` | Vercel worker and API; accepts integer milliseconds or `ms`, `s`, `m`, `h` units |
+| `SELFBENCH_CONFIG_DIR` | `~/.selfbench` | Local CLI profile directory; not needed with a complete Vercel environment |
+| `VERCEL_TOKEN` | profile or unset | Vercel worker; explicit project-scoped access token |
+| `VERCEL_TEAM_ID` | profile or unset | Vercel worker |
+| `VERCEL_PROJECT_ID` | profile or unset | Vercel worker; must be able to resolve the configured image |
 | `SELFBENCH_TEMPORAL_ADDRESS` | `127.0.0.1:7233` | API and worker |
 | `SELFBENCH_TEMPORAL_NAMESPACE` | `default` | API and worker |
 | `SELFBENCH_TASK_QUEUE` | `selfbench-dev` | API and worker |
@@ -264,13 +269,14 @@ For Vercel generation, replace the execution settings above with:
 ```text
 SELFBENCH_EXECUTION_BACKEND=vercel
 SELFBENCH_HARBOR_ENVIRONMENT=modal  # or docker
-SELFBENCH_VERCEL_IMAGE=selfbench-sandbox@sha256:...
+SELFBENCH_VERCEL_IMAGE=selfbench-runtime@sha256:...
+SELFBENCH_VERCEL_TIMEOUT_CAP=2h     # or the verified 45m ceiling
 VERCEL_TOKEN=...
 VERCEL_TEAM_ID=team_...
 VERCEL_PROJECT_ID=prj_...
 ```
 
-Keep the Vercel credential triple on the worker only. A project-scoped token is sufficient when the runtime image belongs to that project. The API must also receive `SELFBENCH_EXECUTION_BACKEND`, `SELFBENCH_HARBOR_ENVIRONMENT`, and the non-secret `SELFBENCH_VERCEL_IMAGE` because it stamps the generation backend, Harbor environment, and image into each run manifest; it never needs the credential triple.
+Keep the Vercel credential triple on the worker only. A project-scoped token is sufficient when the runtime image belongs to that project. The API must also receive `SELFBENCH_EXECUTION_BACKEND`, `SELFBENCH_HARBOR_ENVIRONMENT`, `SELFBENCH_VERCEL_IMAGE`, and `SELFBENCH_VERCEL_TIMEOUT_CAP` because it stamps the generation backend, Harbor environment, image, and effective timeout cap into each run manifest; it never needs the credential triple.
 
 This repository defines the application boundary, not turnkey cloud infrastructure. Project, region, ingress, IAM, GCS, and Temporal provisioning remain deployment-specific.
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "validate": "bun run check && bun run test && bun run build && bun run verify:package"
   },
   "dependencies": {
+    "@clack/prompts": "1.7.0",
     "@google-cloud/storage": "^7.17.0",
     "@temporalio/activity": "^1.13.2",
     "@temporalio/client": "^1.13.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,9 +15,15 @@ import { runCommand } from "./process.js";
 import { collectGitHubPullRequestProvenance, collectRepositoryProvenance } from "./provenance.js";
 import { isExecutionBackend, isHarborEnvironment, matchingHarborEnvironment } from "./providers.js";
 import { type PolledRunStatus, waitForRun } from "./run-wait.js";
+import { SetupCanceledError } from "./terminal-prompts.js";
+import { applyVercelProfile } from "./vercel-profile.js";
+import { setupVercel } from "./vercel-setup.js";
 
 const [command, ...rest] = process.argv.slice(2);
 switch (command) {
+  case "setup":
+    await setup(rest);
+    break;
   case "up":
     await up(rest);
     break;
@@ -49,6 +55,33 @@ switch (command) {
     throw new Error(`unknown command: ${command}`);
 }
 
+async function setup(args: string[]): Promise<void> {
+  const [provider, ...providerArgs] = args;
+  if (provider !== "vercel") {
+    fail("setup currently supports only: self-bench setup vercel");
+  }
+  const parsed = parseArgs({
+    args: providerArgs,
+    options: {
+      profile: { type: "string", default: "default" },
+      verbose: { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+  try {
+    await setupVercel({
+      profileName: parsed.values.profile,
+      verbose: parsed.values.verbose,
+    });
+  } catch (error) {
+    if (error instanceof SetupCanceledError) {
+      process.exitCode = 130;
+      return;
+    }
+    throw error;
+  }
+}
+
 async function up(args: string[]): Promise<void> {
   const parsed = parseArgs({
     args,
@@ -56,6 +89,7 @@ async function up(args: string[]): Promise<void> {
       backend: { type: "string", default: "docker" },
       "harbor-environment": { type: "string" },
       "modal-config": { type: "string" },
+      "vercel-profile": { type: "string" },
     },
     strict: true,
   });
@@ -80,7 +114,10 @@ async function up(args: string[]): Promise<void> {
   if (!usesModal && parsed.values["modal-config"] !== undefined) {
     fail("--modal-config requires Modal generation or Harbor");
   }
-  const environment = {
+  if (backend !== "vercel" && parsed.values["vercel-profile"] !== undefined) {
+    fail("--vercel-profile requires Vercel generation");
+  }
+  let environment: NodeJS.ProcessEnv = {
     ...process.env,
     SELFBENCH_BUILD_COMMIT: await resolveSelfBenchCommit(),
     SELFBENCH_EXECUTION_BACKEND: backend,
@@ -94,6 +131,7 @@ async function up(args: string[]): Promise<void> {
       : {}),
   };
   if (backend === "vercel") {
+    environment = await applyVercelProfile(environment, parsed.values["vercel-profile"]);
     loadWorkerConfig(environment);
   }
 
@@ -359,8 +397,9 @@ function printHelp(): void {
   console.log(`SelfBench creates durable tiered Harbor evaluations.
 
 Usage:
+  self-bench setup vercel [--profile NAME] [--verbose]
   self-bench up [--backend docker|modal|vercel] [--harbor-environment docker|modal]
-                [--modal-config PATH]
+                [--modal-config PATH] [--vercel-profile NAME]
   self-bench down
   self-bench run --repo PATH [--easy-count N] [--medium-count N] [--hard-count N]
                   [--model MODEL] [--run-id ID] [--wait] [--output OUTPUT.tar.gz]
@@ -371,7 +410,8 @@ Usage:
 
 The up command starts the local stack. Docker and Modal default Harbor to the matching backend; Vercel
 requires --harbor-environment because Harbor does not support Vercel. Modal generation or Harbor uses
-~/.modal.toml unless --modal-config overrides it.
+~/.modal.toml unless --modal-config overrides it. Run self-bench setup vercel once to create or select a
+project, publish the pinned runtime image, verify access, and save an owner-only local profile.
 
 The tier counts are candidate authoring budgets, not accepted-task targets. Rejected candidates are not
 replaced, and the export contains only accepted tasks. The run command performs only repository metadata

--- a/src/process.ts
+++ b/src/process.ts
@@ -6,6 +6,8 @@ export interface CommandResult {
   readonly exitCode: number;
 }
 
+export type CommandOutputHandler = (stream: "stdout" | "stderr", chunk: Uint8Array) => void;
+
 export interface CommandOptions {
   readonly cwd?: string;
   readonly env?: NodeJS.ProcessEnv;
@@ -14,7 +16,7 @@ export interface CommandOptions {
   readonly inactivityTimeoutMs?: number;
   readonly allowFailure?: boolean;
   readonly signal?: AbortSignal;
-  readonly onOutput?: (stream: "stdout" | "stderr", chunk: Uint8Array) => void;
+  readonly onOutput?: CommandOutputHandler;
 }
 
 export class InactivityTimeoutError extends Error {

--- a/src/terminal-prompts.ts
+++ b/src/terminal-prompts.ts
@@ -1,0 +1,197 @@
+import {
+  autocomplete,
+  cancel as cancelPrompt,
+  confirm as confirmPrompt,
+  isCancel,
+  password,
+  select as selectPrompt,
+  text as textPrompt,
+} from "@clack/prompts";
+
+export class SetupCanceledError extends Error {
+  constructor(message = "Setup canceled") {
+    super(message);
+    this.name = "SetupCanceledError";
+  }
+}
+
+export interface PromptChoice {
+  readonly value: string;
+  readonly label: string;
+  readonly hint?: string;
+}
+
+export interface SetupPrompter {
+  select(message: string, choices: readonly PromptChoice[], defaultValue?: string): Promise<string>;
+  search(message: string, choices: readonly PromptChoice[], defaultValue?: string): Promise<string>;
+  text(message: string, defaultValue?: string): Promise<string>;
+  secret(message: string): Promise<string>;
+  confirm(message: string, defaultValue: boolean): Promise<boolean>;
+}
+
+export class TerminalPrompter implements SetupPrompter {
+  readonly #input: NodeJS.ReadStream;
+  readonly #output: NodeJS.WriteStream;
+
+  constructor(
+    input: NodeJS.ReadStream = process.stdin,
+    output: NodeJS.WriteStream = process.stdout,
+  ) {
+    this.#input = input;
+    this.#output = output;
+  }
+
+  async select(
+    message: string,
+    choices: readonly PromptChoice[],
+    defaultValue?: string,
+  ): Promise<string> {
+    this.#assertChoices(message, choices);
+    return await this.#run((signal) =>
+      selectPrompt<string>({
+        message,
+        options: choices.map(toPromptOption),
+        maxItems: this.#visibleItemCount(),
+        showInstructions: true,
+        ...(defaultValue !== undefined && choices.some(({ value }) => value === defaultValue)
+          ? { initialValue: defaultValue }
+          : {}),
+        input: this.#input,
+        output: this.#output,
+        signal,
+      }),
+    );
+  }
+
+  async search(
+    message: string,
+    choices: readonly PromptChoice[],
+    defaultValue?: string,
+  ): Promise<string> {
+    this.#assertChoices(message, choices);
+    return await this.#run((signal) =>
+      autocomplete<string>({
+        message,
+        options: choices.map(toPromptOption),
+        placeholder: "Type to filter…",
+        maxItems: this.#visibleItemCount(),
+        filter: (query, option) =>
+          `${option.label ?? ""}\n${option.hint ?? ""}\n${option.value}`
+            .toLowerCase()
+            .includes(query.toLowerCase()),
+        ...(defaultValue !== undefined && choices.some(({ value }) => value === defaultValue)
+          ? { initialValue: defaultValue }
+          : {}),
+        input: this.#input,
+        output: this.#output,
+        signal,
+      }),
+    );
+  }
+
+  async text(message: string, defaultValue?: string): Promise<string> {
+    return await this.#run((signal) =>
+      textPrompt({
+        message,
+        ...(defaultValue === undefined ? {} : { placeholder: defaultValue, defaultValue }),
+        input: this.#input,
+        output: this.#output,
+        signal,
+      }),
+    );
+  }
+
+  async secret(message: string): Promise<string> {
+    if (!this.#input.isTTY || !this.#input.setRawMode) {
+      throw new Error("secure token input requires an interactive terminal");
+    }
+    return await this.#run((signal) =>
+      password({
+        message,
+        // An empty mask keeps both the token and its length out of terminal output.
+        mask: "",
+        validate: (value) => (value?.trim() ? undefined : "Enter a project-scoped token."),
+        input: this.#input,
+        output: this.#output,
+        signal,
+      }),
+    );
+  }
+
+  async confirm(message: string, defaultValue: boolean): Promise<boolean> {
+    return await this.#run((signal) =>
+      confirmPrompt({
+        message,
+        initialValue: defaultValue,
+        input: this.#input,
+        output: this.#output,
+        signal,
+      }),
+    );
+  }
+
+  async #run<T>(prompt: (signal: AbortSignal) => Promise<T | symbol>): Promise<T> {
+    const controller = new AbortController();
+    const wasRaw = this.#input.isRaw;
+    const wasFlowing = this.#input.readableFlowing;
+    let inputFailure: Error | undefined;
+    const abort = (error: Error): void => {
+      inputFailure = error;
+      controller.abort(error);
+    };
+    const onEnd = (): void => abort(new SetupCanceledError("Setup canceled at end of input"));
+    const onError = (error: Error): void => abort(error);
+    this.#input.once("end", onEnd);
+    this.#input.once("error", onError);
+    if (this.#input.readableEnded) {
+      onEnd();
+    }
+
+    try {
+      const result = await prompt(controller.signal);
+      if (isCancel(result)) {
+        const error = inputFailure ?? new SetupCanceledError();
+        if (error instanceof SetupCanceledError) {
+          cancelPrompt("Setup canceled.", { output: this.#output, withGuide: true });
+        }
+        throw error;
+      }
+      return result;
+    } finally {
+      this.#input.off("end", onEnd);
+      this.#input.off("error", onError);
+      if (this.#input.isTTY && this.#input.setRawMode && this.#input.isRaw !== wasRaw) {
+        this.#input.setRawMode(Boolean(wasRaw));
+      }
+      if (wasFlowing !== true) {
+        this.#input.pause();
+      }
+    }
+  }
+
+  #assertChoices(message: string, choices: readonly PromptChoice[]): void {
+    if (choices.length === 0) {
+      throw new Error(`${message} has no available choices`);
+    }
+  }
+
+  #visibleItemCount(): number {
+    return Math.max(3, Math.min(8, (this.#output.rows ?? 20) - 6));
+  }
+}
+
+export function isInteractiveTerminal(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+function toPromptOption(choice: PromptChoice): {
+  readonly value: string;
+  readonly label: string;
+  readonly hint?: string;
+} {
+  return {
+    value: choice.value,
+    label: choice.label,
+    ...(choice.hint ? { hint: choice.hint } : {}),
+  };
+}

--- a/src/terminal-reporter.ts
+++ b/src/terminal-reporter.ts
@@ -1,0 +1,126 @@
+import type { Writable } from "node:stream";
+import { stripVTControlCharacters } from "node:util";
+import { cancel as cancelPrompt, intro, log, outro, spinner } from "@clack/prompts";
+import { type CommandOutputHandler, RollingOutput } from "./process.js";
+import { SetupCanceledError } from "./terminal-prompts.js";
+
+export interface SetupTaskLabels {
+  readonly pending: string;
+  readonly success: string;
+  readonly failure: string;
+}
+
+export interface SetupReporter {
+  intro(title: string): void;
+  message(message: string): void;
+  warn(message: string): void;
+  cancel(message: string): void;
+  task<T>(
+    labels: SetupTaskLabels,
+    operation: (onOutput: CommandOutputHandler) => Promise<T>,
+  ): Promise<T>;
+  finish(title: string, details: readonly string[]): void;
+}
+
+export class TerminalSetupReporter implements SetupReporter {
+  readonly #output: Writable;
+  readonly #errorOutput: Writable;
+  readonly #verbose: boolean;
+
+  constructor(
+    options: {
+      readonly output?: Writable;
+      readonly errorOutput?: Writable;
+      readonly verbose?: boolean;
+    } = {},
+  ) {
+    this.#output = options.output ?? process.stdout;
+    this.#errorOutput = options.errorOutput ?? process.stderr;
+    this.#verbose = options.verbose ?? false;
+  }
+
+  intro(title: string): void {
+    intro(title, { output: this.#output, withGuide: true });
+  }
+
+  message(message: string): void {
+    log.message(message, { output: this.#output, withGuide: true });
+  }
+
+  warn(message: string): void {
+    log.warn(message, { output: this.#output, withGuide: true });
+  }
+
+  cancel(message: string): void {
+    cancelPrompt(message, { output: this.#output, withGuide: true });
+  }
+
+  async task<T>(
+    labels: SetupTaskLabels,
+    operation: (onOutput: CommandOutputHandler) => Promise<T>,
+  ): Promise<T> {
+    const captured = new RollingOutput();
+    const onOutput: CommandOutputHandler = (stream, chunk) => {
+      captured.push(Buffer.from(chunk));
+      if (this.#verbose) {
+        (stream === "stderr" ? this.#errorOutput : this.#output).write(chunk);
+      }
+    };
+
+    if (this.#verbose) {
+      log.step(labels.pending, { output: this.#output, withGuide: true });
+      try {
+        const result = await operation(onOutput);
+        log.success(labels.success, { output: this.#output, withGuide: true });
+        return result;
+      } catch (error) {
+        if (error instanceof SetupCanceledError) {
+          this.cancel("Setup canceled.");
+          throw error;
+        }
+        log.error(labels.failure, { output: this.#output, withGuide: true });
+        throw error;
+      }
+    }
+
+    const progress = spinner({ indicator: "timer", output: this.#output, withGuide: true });
+    progress.start(labels.pending);
+    try {
+      const result = await operation(onOutput);
+      progress.stop(labels.success);
+      return result;
+    } catch (error) {
+      if (error instanceof SetupCanceledError) {
+        progress.cancel("Setup canceled.");
+        throw error;
+      }
+      progress.error(labels.failure);
+      this.#showFailureOutput(captured.text());
+      throw error;
+    }
+  }
+
+  finish(title: string, details: readonly string[]): void {
+    log.success(title, { output: this.#output, withGuide: true });
+    log.message([...details], {
+      output: this.#output,
+      spacing: 0,
+      withGuide: true,
+    });
+    outro("Vercel Sandbox is ready.", { output: this.#output, withGuide: true });
+  }
+
+  #showFailureOutput(value: string): void {
+    const cleaned = stripVTControlCharacters(value)
+      .replace(/\r(?!\n)/g, "\n")
+      .trim();
+    if (!cleaned) {
+      return;
+    }
+    log.message(["Command output:", ...cleaned.split("\n")], {
+      output: this.#output,
+      spacing: 0,
+      withGuide: true,
+    });
+  }
+}

--- a/src/vercel-cli.ts
+++ b/src/vercel-cli.ts
@@ -1,0 +1,403 @@
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { z } from "zod";
+import { type CommandOutputHandler, type CommandResult, runCommand } from "./process.js";
+
+const MINIMUM_CLI_VERSION = [59, 1, 3] as const;
+const PAGE_SIZE = "100";
+
+const teamSchema = z.object({
+  id: z.string().min(1),
+  slug: z.string().min(1),
+  name: z.string().min(1),
+  current: z.boolean().optional(),
+});
+
+const projectSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+});
+
+const vcrTagSchema = z.object({
+  tag: z.string().min(1),
+  manifestDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/i),
+  kind: z.enum(["manifest", "index"]).optional(),
+  status: z.string().min(1).nullable(),
+});
+
+export type VercelTeam = z.infer<typeof teamSchema>;
+export type VercelProject = z.infer<typeof projectSchema>;
+export type VcrTag = z.infer<typeof vcrTagSchema>;
+
+export interface VercelCommandRunner {
+  capture(
+    args: readonly string[],
+    options?: { readonly onOutput?: CommandOutputHandler },
+  ): Promise<CommandResult>;
+  interactive(args: readonly string[]): Promise<void>;
+}
+
+export class VercelCli {
+  readonly #runner: VercelCommandRunner;
+
+  constructor(runner: VercelCommandRunner = new ProcessVercelCommandRunner()) {
+    this.#runner = runner;
+  }
+
+  async ensureAvailable(): Promise<void> {
+    let result: CommandResult;
+    try {
+      result = await this.#runner.capture(["--version"]);
+    } catch (error) {
+      throw new Error(
+        "Vercel CLI 59.1.3 or newer is required. Install it with: npm install --global vercel@latest",
+        { cause: error },
+      );
+    }
+    const version = parseCliVersion(`${result.stdout}\n${result.stderr}`);
+    if (result.exitCode !== 0 || !version || compareVersion(version, MINIMUM_CLI_VERSION) < 0) {
+      throw new Error(
+        "Vercel CLI 59.1.3 or newer is required. Install or update it with: npm install --global vercel@latest",
+      );
+    }
+  }
+
+  async ensureLoggedIn(): Promise<void> {
+    const status = await this.#runner.capture(["whoami", "--json", "--non-interactive"]);
+    if (status.exitCode === 0 && parseLoggedIn(status.stdout)) {
+      return;
+    }
+    await this.#runner.interactive(["login"]);
+    const verified = await this.#runner.capture(["whoami", "--json", "--non-interactive"]);
+    if (verified.exitCode !== 0 || !parseLoggedIn(verified.stdout)) {
+      throw new Error("Vercel CLI login did not complete; run vercel login and retry setup");
+    }
+  }
+
+  async listTeams(): Promise<readonly VercelTeam[]> {
+    const teams: VercelTeam[] = [];
+    const seenPages = new Set<string>();
+    let next: string | undefined;
+    do {
+      const pageKey = next ?? "first";
+      if (seenPages.has(pageKey)) {
+        throw new Error("Vercel CLI returned a repeated teams pagination cursor");
+      }
+      seenPages.add(pageKey);
+      const args = ["teams", "list", "--json", "--limit", PAGE_SIZE, "--non-interactive"];
+      if (next) {
+        args.push("--next", next);
+      }
+      const result = await this.#runJson(args);
+      const parsed = z
+        .object({
+          teams: z.array(teamSchema),
+          pagination: z.object({ next: z.union([z.string(), z.number()]).nullable().optional() }),
+        })
+        .parse(result);
+      teams.push(...parsed.teams);
+      next = paginationValue(parsed.pagination.next);
+    } while (next);
+    return uniqueById(teams);
+  }
+
+  async listProjects(teamSlug: string): Promise<readonly VercelProject[]> {
+    const projects: VercelProject[] = [];
+    const seenPages = new Set<string>();
+    let next: string | undefined;
+    do {
+      const pageKey = next ?? "first";
+      if (seenPages.has(pageKey)) {
+        throw new Error("Vercel CLI returned a repeated projects pagination cursor");
+      }
+      seenPages.add(pageKey);
+      const args = [
+        "project",
+        "list",
+        "--scope",
+        teamSlug,
+        "--json",
+        "--limit",
+        PAGE_SIZE,
+        "--non-interactive",
+      ];
+      if (next) {
+        args.push("--next", next);
+      }
+      const result = await this.#runJson(args);
+      const parsed = z
+        .object({
+          projects: z.array(projectSchema),
+          pagination: z.object({ next: z.union([z.string(), z.number()]).nullable().optional() }),
+        })
+        .parse(result);
+      projects.push(...parsed.projects);
+      next = paginationValue(parsed.pagination.next);
+    } while (next);
+    return uniqueById(projects);
+  }
+
+  async createProject(teamSlug: string, projectName: string): Promise<VercelProject> {
+    const result = await this.#runner.capture([
+      "project",
+      "add",
+      projectName,
+      "--scope",
+      teamSlug,
+      "--non-interactive",
+    ]);
+    if (result.exitCode !== 0) {
+      throw commandFailure("create Vercel project", result);
+    }
+    const project = (await this.listProjects(teamSlug)).find(
+      ({ name }) => name.toLowerCase() === projectName.toLowerCase(),
+    );
+    if (!project) {
+      throw new Error(
+        `Vercel created project ${projectName}, but it was not returned by project list`,
+      );
+    }
+    return project;
+  }
+
+  async repositoryExists(input: VcrScope & { readonly repository: string }): Promise<boolean> {
+    const result = await this.#runner.capture(
+      this.#vcrArgs(
+        ["vcr", "inspect", input.repository, "--json"],
+        input.teamSlug,
+        input.projectId,
+      ),
+    );
+    if (result.exitCode === 0) {
+      return true;
+    }
+    if (isNotFound(result)) {
+      return false;
+    }
+    throw commandFailure("inspect VCR repository", result);
+  }
+
+  async createRepository(input: VcrScope & { readonly repository: string }): Promise<void> {
+    const result = await this.#runner.capture(
+      this.#vcrArgs(["vcr", "add", input.repository, "--json"], input.teamSlug, input.projectId),
+    );
+    if (result.exitCode !== 0) {
+      throw commandFailure("create VCR repository", result);
+    }
+  }
+
+  async listTags(input: VcrScope & { readonly repository: string }): Promise<readonly VcrTag[]> {
+    const tags: VcrTag[] = [];
+    const seenPages = new Set<string>();
+    let next: string | undefined;
+    do {
+      const pageKey = next ?? "first";
+      if (seenPages.has(pageKey)) {
+        throw new Error("Vercel CLI returned a repeated VCR pagination cursor");
+      }
+      seenPages.add(pageKey);
+      const args = this.#vcrArgs(
+        ["vcr", "tag", "list", input.repository, "--json", "--limit", PAGE_SIZE],
+        input.teamSlug,
+        input.projectId,
+      );
+      if (next) {
+        args.push("--next", next);
+      }
+      const result = await this.#runJson(args);
+      const parsed = z
+        .object({
+          tags: z.array(vcrTagSchema),
+          nextCursor: z.string().nullable().optional(),
+        })
+        .parse(result);
+      tags.push(...parsed.tags);
+      next = parsed.nextCursor ?? undefined;
+    } while (next);
+    return tags;
+  }
+
+  async inspectTag(
+    input: VcrScope & { readonly repository: string; readonly tag: string },
+  ): Promise<VcrTag | undefined> {
+    const result = await this.#runner.capture(
+      this.#vcrArgs(
+        ["vcr", "tag", "inspect", input.repository, input.tag, "--json"],
+        input.teamSlug,
+        input.projectId,
+      ),
+    );
+    if (result.exitCode === 0) {
+      return vcrTagSchema.parse(parseJson(result.stdout, "VCR tag inspect"));
+    }
+    if (isNotFound(result)) {
+      return undefined;
+    }
+    throw commandFailure("inspect VCR tag", result);
+  }
+
+  async buildImage(
+    input: VcrScope & {
+      readonly repository: string;
+      readonly tag: string;
+      readonly projectRoot: string;
+      readonly onOutput?: CommandOutputHandler;
+    },
+  ): Promise<void> {
+    await this.#run(
+      [
+        "vcr",
+        "login",
+        "docker",
+        "--project",
+        input.projectId,
+        "--scope",
+        input.teamSlug,
+        "--non-interactive",
+      ],
+      "authenticate Docker with VCR",
+      input.onOutput,
+    );
+    await this.#run(
+      [
+        "vcr",
+        "build",
+        "docker",
+        input.projectRoot,
+        `${input.repository}:${input.tag}`,
+        "--project",
+        input.projectId,
+        "--platform",
+        "linux/amd64",
+        "--push",
+        "--scope",
+        input.teamSlug,
+        "--non-interactive",
+        "--",
+        "--file",
+        resolve(input.projectRoot, "Dockerfile.sandbox"),
+        // Buildx provenance attestations turn this into an OCI index. Vercel
+        // Sandbox accepts the single linux/amd64 manifest produced without them.
+        "--provenance=false",
+      ],
+      "build and publish the VCR image",
+      input.onOutput,
+    );
+  }
+
+  async #runJson(args: readonly string[]): Promise<unknown> {
+    const result = await this.#runner.capture(args);
+    if (result.exitCode !== 0) {
+      throw commandFailure(`run vercel ${args.slice(0, 2).join(" ")}`, result);
+    }
+    return parseJson(result.stdout, `vercel ${args.slice(0, 2).join(" ")}`);
+  }
+
+  async #run(
+    args: readonly string[],
+    action: string,
+    onOutput?: CommandOutputHandler,
+  ): Promise<void> {
+    const result = await this.#runner.capture(args, onOutput ? { onOutput } : undefined);
+    if (result.exitCode !== 0) {
+      throw commandFailure(action, result);
+    }
+  }
+
+  #vcrArgs(args: string[], teamSlug: string, projectId: string): string[] {
+    return [...args, "--project", projectId, "--scope", teamSlug, "--non-interactive"];
+  }
+}
+
+interface VcrScope {
+  readonly teamSlug: string;
+  readonly projectId: string;
+}
+
+class ProcessVercelCommandRunner implements VercelCommandRunner {
+  async capture(
+    args: readonly string[],
+    options?: { readonly onOutput?: CommandOutputHandler },
+  ): Promise<CommandResult> {
+    return await runCommand("vercel", args, {
+      allowFailure: true,
+      ...(options?.onOutput ? { onOutput: options.onOutput } : {}),
+    });
+  }
+
+  async interactive(args: readonly string[]): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn("vercel", args, { stdio: "inherit" });
+      child.once("error", reject);
+      child.once("exit", (code, signal) => {
+        if (code === 0) {
+          resolve();
+          return;
+        }
+        reject(
+          new Error(
+            `vercel ${args.slice(0, 2).join(" ")} exited ${code ?? `after ${signal ?? "signal"}`}`,
+          ),
+        );
+      });
+    });
+  }
+}
+
+function parseCliVersion(value: string): readonly [number, number, number] | undefined {
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(value);
+  if (!match?.[1] || !match[2] || !match[3]) {
+    return undefined;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersion(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number],
+): number {
+  for (let index = 0; index < left.length; index += 1) {
+    const difference = (left[index] ?? 0) - (right[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return 0;
+}
+
+function parseLoggedIn(value: string): boolean {
+  try {
+    const parsed = z
+      .object({ loggedIn: z.boolean().optional() })
+      .passthrough()
+      .parse(JSON.parse(value));
+    return parsed.loggedIn ?? true;
+  } catch {
+    return false;
+  }
+}
+
+function parseJson(value: string, context: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new Error(`${context} returned invalid JSON`, { cause: error });
+  }
+}
+
+function paginationValue(value: string | number | null | undefined): string | undefined {
+  return value === undefined || value === null ? undefined : String(value);
+}
+
+function uniqueById<T extends { readonly id: string }>(values: readonly T[]): readonly T[] {
+  return [...new Map(values.map((value) => [value.id, value])).values()];
+}
+
+function isNotFound(result: CommandResult): boolean {
+  return /(?:not[_ -]?found|does not exist|\b404\b)/i.test(`${result.stdout}\n${result.stderr}`);
+}
+
+function commandFailure(action: string, result: CommandResult): Error {
+  const detail = (result.stderr.trim() || result.stdout.trim()).slice(0, 1_000);
+  return new Error(`${action} failed with exit ${result.exitCode}${detail ? `: ${detail}` : ""}`);
+}

--- a/src/vercel-profile.ts
+++ b/src/vercel-profile.ts
@@ -1,0 +1,319 @@
+import { randomUUID } from "node:crypto";
+import type { Stats } from "node:fs";
+import { chmod, lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { z } from "zod";
+import { parseSandboxTimeoutCapText, STANDARD_VERCEL_TIMEOUT_CAP_MS } from "./sandbox-timeout.js";
+
+const CONFIG_FILE = "config.json";
+const CREDENTIALS_FILE = "credentials.json";
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+
+const profileNameSchema = z
+  .string()
+  .trim()
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/, {
+    error: "Vercel profile name must use 1-64 letters, digits, dots, underscores, or hyphens",
+  });
+
+const digestPinnedImageSchema = z
+  .string()
+  .regex(/^[^@\s]+@sha256:[0-9a-f]{64}$/i, "expected a digest-pinned VCR image");
+
+export const vercelProfileSchema = z
+  .object({
+    teamId: z.string().trim().min(1),
+    teamSlug: z.string().trim().min(1),
+    teamName: z.string().trim().min(1),
+    projectId: z.string().trim().min(1),
+    projectName: z.string().trim().min(1),
+    vcrRepository: z.string().trim().min(1),
+    image: digestPinnedImageSchema,
+    runtimeFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+    timeoutCapMs: z.number().int().min(100).max(STANDARD_VERCEL_TIMEOUT_CAP_MS),
+    capabilityCheckedAt: z.iso.datetime(),
+  })
+  .strict();
+
+export type VercelProfile = z.infer<typeof vercelProfileSchema>;
+
+const configSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    activeVercelProfile: profileNameSchema.optional(),
+    vercelProfiles: z.record(profileNameSchema, vercelProfileSchema),
+  })
+  .strict();
+
+const credentialsSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    vercelProfiles: z.record(
+      profileNameSchema,
+      z.object({ token: z.string().trim().min(1) }).strict(),
+    ),
+  })
+  .strict();
+
+export interface VercelProfileData {
+  readonly activeVercelProfile?: string;
+  readonly profiles: Readonly<Record<string, VercelProfile>>;
+  readonly tokens: Readonly<Record<string, string>>;
+}
+
+interface MutableProfileData {
+  activeVercelProfile?: string;
+  profiles: Record<string, VercelProfile>;
+  tokens: Record<string, string>;
+}
+
+export function selfBenchConfigDirectory(environment: NodeJS.ProcessEnv = process.env): string {
+  const override = environment.SELFBENCH_CONFIG_DIR?.trim();
+  return resolve(override || join(homedir(), ".selfbench"));
+}
+
+export function validateVercelProfileName(value: string): string {
+  return profileNameSchema.parse(value);
+}
+
+export async function loadVercelProfileData(
+  directory = selfBenchConfigDirectory(),
+): Promise<VercelProfileData> {
+  const mutable = await loadMutableProfileData(directory);
+  return {
+    ...(mutable.activeVercelProfile ? { activeVercelProfile: mutable.activeVercelProfile } : {}),
+    profiles: mutable.profiles,
+    tokens: mutable.tokens,
+  };
+}
+
+export async function saveVercelProfile(input: {
+  readonly directory?: string;
+  readonly profileName: string;
+  readonly profile: VercelProfile;
+  readonly token: string;
+}): Promise<void> {
+  const directory = resolve(input.directory ?? selfBenchConfigDirectory());
+  const profileName = validateVercelProfileName(input.profileName);
+  const token = input.token.trim();
+  if (!token) {
+    throw new Error("Vercel access token must not be blank");
+  }
+  const profile = vercelProfileSchema.parse(input.profile);
+  await ensurePrivateDirectory(directory);
+  const existing = await loadMutableProfileData(directory);
+  const nextCredentials = credentialsSchema.parse({
+    schemaVersion: 1,
+    vercelProfiles: {
+      ...Object.fromEntries(
+        Object.entries(existing.tokens).map(([name, existingToken]) => [
+          name,
+          { token: existingToken },
+        ]),
+      ),
+      [profileName]: { token },
+    },
+  });
+  const nextConfig = configSchema.parse({
+    schemaVersion: 1,
+    activeVercelProfile: profileName,
+    vercelProfiles: { ...existing.profiles, [profileName]: profile },
+  });
+
+  // Credentials are written first. A crash can leave an unreferenced token, but
+  // never an active profile whose credential has not reached disk.
+  await writePrivateJson(join(directory, CREDENTIALS_FILE), nextCredentials);
+  await writePrivateJson(join(directory, CONFIG_FILE), nextConfig);
+}
+
+export async function applyVercelProfile(
+  environment: NodeJS.ProcessEnv,
+  requestedProfile?: string,
+): Promise<NodeJS.ProcessEnv> {
+  const result = { ...environment };
+  const hasCompleteEnvironment = requiredEnvironmentKeys.every((key) => result[key]?.trim());
+  if (hasCompleteEnvironment && requestedProfile === undefined) {
+    return result;
+  }
+
+  const data = await loadVercelProfileData(selfBenchConfigDirectory(environment));
+  const profileName = selectProfileName(data, requestedProfile);
+  const profile = data.profiles[profileName];
+  const token = data.tokens[profileName];
+  if (!profile || !token) {
+    throw new Error(
+      `Vercel profile "${profileName}" is incomplete; rerun self-bench setup vercel --profile ${profileName}`,
+    );
+  }
+  assertCompatibleOverride("VERCEL_TEAM_ID", result.VERCEL_TEAM_ID, profile.teamId);
+  assertCompatibleOverride("VERCEL_PROJECT_ID", result.VERCEL_PROJECT_ID, profile.projectId);
+
+  result.VERCEL_TOKEN = result.VERCEL_TOKEN?.trim() || token;
+  result.VERCEL_TEAM_ID = result.VERCEL_TEAM_ID?.trim() || profile.teamId;
+  result.VERCEL_PROJECT_ID = result.VERCEL_PROJECT_ID?.trim() || profile.projectId;
+  result.SELFBENCH_VERCEL_IMAGE = result.SELFBENCH_VERCEL_IMAGE?.trim() || profile.image;
+  result.SELFBENCH_VERCEL_TIMEOUT_CAP = resolveProfileTimeoutCap(
+    result.SELFBENCH_VERCEL_TIMEOUT_CAP,
+    profile.timeoutCapMs,
+  );
+  return result;
+}
+
+export function profileFilePaths(directory = selfBenchConfigDirectory()): {
+  readonly config: string;
+  readonly credentials: string;
+} {
+  return {
+    config: join(directory, CONFIG_FILE),
+    credentials: join(directory, CREDENTIALS_FILE),
+  };
+}
+
+const requiredEnvironmentKeys = [
+  "VERCEL_TOKEN",
+  "VERCEL_TEAM_ID",
+  "VERCEL_PROJECT_ID",
+  "SELFBENCH_VERCEL_IMAGE",
+] as const;
+
+function selectProfileName(data: VercelProfileData, requestedProfile?: string): string {
+  if (requestedProfile !== undefined) {
+    return validateVercelProfileName(requestedProfile);
+  }
+  if (data.activeVercelProfile) {
+    return data.activeVercelProfile;
+  }
+  const names = Object.keys(data.profiles);
+  if (names.length === 1 && names[0]) {
+    return names[0];
+  }
+  throw new Error(
+    "Vercel is not configured; run self-bench setup vercel or provide VERCEL_TOKEN, VERCEL_TEAM_ID, VERCEL_PROJECT_ID, and SELFBENCH_VERCEL_IMAGE",
+  );
+}
+
+function resolveProfileTimeoutCap(value: string | undefined, verifiedCapMs: number): string {
+  const override = value?.trim();
+  if (!override) {
+    return `${verifiedCapMs}ms`;
+  }
+  const parsed = parseSandboxTimeoutCapText(override);
+  if (parsed === undefined || !Number.isInteger(parsed) || parsed < 100 || parsed > verifiedCapMs) {
+    throw new Error(
+      `SELFBENCH_VERCEL_TIMEOUT_CAP must be between 100ms and the selected profile's verified ${verifiedCapMs}ms ceiling`,
+    );
+  }
+  return override;
+}
+
+function assertCompatibleOverride(key: string, value: string | undefined, expected: string): void {
+  const override = value?.trim();
+  if (override && override !== expected) {
+    throw new Error(
+      `${key} does not match the selected Vercel profile; provide the complete Vercel environment instead of mixing project scopes`,
+    );
+  }
+}
+
+async function loadMutableProfileData(directory: string): Promise<MutableProfileData> {
+  await assertDirectoryIfPresent(directory);
+  const paths = profileFilePaths(directory);
+  const [rawConfig, rawCredentials] = await Promise.all([
+    readPrivateJson(paths.config),
+    readPrivateJson(paths.credentials),
+  ]);
+  const config = parseProfileDocument(paths.config, rawConfig, configSchema);
+  const credentials = parseProfileDocument(paths.credentials, rawCredentials, credentialsSchema);
+  return {
+    ...(config?.activeVercelProfile ? { activeVercelProfile: config.activeVercelProfile } : {}),
+    profiles: { ...(config?.vercelProfiles ?? {}) },
+    tokens: Object.fromEntries(
+      Object.entries(credentials?.vercelProfiles ?? {}).map(([name, value]) => [name, value.token]),
+    ),
+  };
+}
+
+function parseProfileDocument<T>(
+  path: string,
+  value: unknown | undefined,
+  schema: z.ZodType<T>,
+): T | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    return schema.parse(value);
+  } catch (error) {
+    throw new Error(
+      `SelfBench profile file has an incompatible format: ${path}. Move the file or set SELFBENCH_CONFIG_DIR to another directory.`,
+      { cause: error },
+    );
+  }
+}
+
+async function assertDirectoryIfPresent(directory: string): Promise<void> {
+  let stats: Stats;
+  try {
+    stats = await lstat(directory);
+  } catch (error) {
+    if (isFileNotFound(error)) {
+      return;
+    }
+    throw error;
+  }
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(
+      `SelfBench config path must be a directory, not a file or symlink: ${directory}`,
+    );
+  }
+}
+
+async function ensurePrivateDirectory(directory: string): Promise<void> {
+  await assertDirectoryIfPresent(directory);
+  await mkdir(directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  await chmod(directory, PRIVATE_DIRECTORY_MODE);
+}
+
+async function readPrivateJson(path: string): Promise<unknown | undefined> {
+  let stats: Stats;
+  try {
+    stats = await lstat(path);
+  } catch (error) {
+    if (isFileNotFound(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new Error(`SelfBench profile path must be a regular file: ${path}`);
+  }
+  if ((stats.mode & 0o077) !== 0) {
+    throw new Error(`SelfBench profile file must be owner-only; run chmod 600 ${path}`);
+  }
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch (error) {
+    throw new Error(`Unable to parse SelfBench profile file ${path}`, { cause: error });
+  }
+}
+
+async function writePrivateJson(path: string, value: unknown): Promise<void> {
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: PRIVATE_FILE_MODE,
+    });
+    await rename(temporary, path);
+    await chmod(path, PRIVATE_FILE_MODE);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/src/vercel-runtime-image.ts
+++ b/src/vercel-runtime-image.ts
@@ -1,0 +1,204 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { sha256 } from "./hash.js";
+import type { CommandOutputHandler } from "./process.js";
+import type { SetupPrompter } from "./terminal-prompts.js";
+import type { SetupReporter } from "./terminal-reporter.js";
+import type { VcrTag } from "./vercel-cli.js";
+
+export const DEFAULT_VCR_REPOSITORY = "selfbench-runtime";
+
+const IMAGE_TAG_PREFIX = "selfbench-";
+const IMAGE_PLATFORM = "linux/amd64";
+const IMAGE_READINESS_TIMEOUT_MS = 15 * 60 * 1_000;
+const IMAGE_POLL_INTERVAL_MS = 5_000;
+
+interface VcrScope {
+  readonly teamSlug: string;
+  readonly projectId: string;
+}
+
+export interface VercelRuntimeImageCli {
+  repositoryExists(input: VcrScope & { readonly repository: string }): Promise<boolean>;
+  createRepository(input: VcrScope & { readonly repository: string }): Promise<void>;
+  listTags(input: VcrScope & { readonly repository: string }): Promise<readonly VcrTag[]>;
+  inspectTag(
+    input: VcrScope & { readonly repository: string; readonly tag: string },
+  ): Promise<VcrTag | undefined>;
+  buildImage(
+    input: VcrScope & {
+      readonly repository: string;
+      readonly tag: string;
+      readonly projectRoot: string;
+      readonly onOutput?: CommandOutputHandler;
+    },
+  ): Promise<void>;
+}
+
+interface RuntimeImageServices {
+  readonly cli: VercelRuntimeImageCli;
+  readonly prompter: SetupPrompter;
+  readonly reporter: SetupReporter;
+  readonly sleep: (delayMs: number) => Promise<void>;
+}
+
+export interface VercelRuntimeImage {
+  readonly repository: string;
+  readonly image: string;
+  readonly published: boolean;
+}
+
+export async function ensureVercelRuntimeImage(input: {
+  readonly services: RuntimeImageServices;
+  readonly scope: VcrScope;
+  readonly projectRoot: string;
+  readonly fingerprint: string;
+  readonly preferredRepository: string;
+}): Promise<VercelRuntimeImage> {
+  const { services, scope, projectRoot, fingerprint } = input;
+  const tag = `${IMAGE_TAG_PREFIX}${fingerprint}`;
+  let repository = input.preferredRepository;
+
+  for (;;) {
+    if (!isValidVcrRepositoryName(repository)) {
+      throw new Error(`Invalid VCR repository name in saved profile: ${repository}`);
+    }
+    const exists = await services.cli.repositoryExists({ ...scope, repository });
+    if (!exists) {
+      try {
+        await services.cli.createRepository({ ...scope, repository });
+        break;
+      } catch (error) {
+        // A concurrent setup or a lost success response can leave the repository
+        // present. Re-inspect it before treating the operation as failed.
+        if (await services.cli.repositoryExists({ ...scope, repository })) {
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    const tags = await services.cli.listTags({ ...scope, repository });
+    const matching = tags.find((candidate) => candidate.tag === tag);
+    if (matching) {
+      if (
+        matching.kind !== "index" &&
+        (matching.status === null || ["ready", "preparing"].includes(matching.status))
+      ) {
+        const ready = await services.reporter.task(
+          {
+            pending: "Checking the existing runtime image",
+            success: "Runtime image ready",
+            failure: "Runtime image check failed",
+          },
+          async () => await waitForReadyTag(services, { ...scope, repository, tag }, matching),
+        );
+        return {
+          repository,
+          image: `${repository}@${ready.manifestDigest}`,
+          published: false,
+        };
+      }
+      services.reporter.warn(
+        `Existing SelfBench image ${repository}:${tag} is ${tagState(matching)}; rebuilding it.`,
+      );
+      break;
+    }
+
+    const compatible =
+      tags.length === 0 || tags.some((candidate) => candidate.tag.startsWith(IMAGE_TAG_PREFIX));
+    if (compatible) {
+      break;
+    }
+    services.reporter.warn(
+      `VCR repository "${repository}" contains unrelated images. SelfBench will not modify it.`,
+    );
+    repository = await requestVcrRepositoryName(services);
+  }
+
+  const ready = await services.reporter.task(
+    {
+      pending: `Building and publishing the ${IMAGE_PLATFORM} runtime image`,
+      success: "Runtime image published",
+      failure: "Runtime image publication failed",
+    },
+    async (onOutput) => {
+      await services.cli.buildImage({ ...scope, repository, tag, projectRoot, onOutput });
+      return await waitForReadyTag(services, { ...scope, repository, tag });
+    },
+  );
+  return {
+    repository,
+    image: `${repository}@${ready.manifestDigest}`,
+    published: true,
+  };
+}
+
+export async function vercelRuntimeFingerprint(projectRoot: string): Promise<string> {
+  const dockerfile = await readFile(resolve(projectRoot, "Dockerfile.sandbox"), "utf8");
+  if (/^\s*(?:ADD|COPY)\s/imu.test(dockerfile)) {
+    throw new Error(
+      "Dockerfile.sandbox now copies local files; update the VCR fingerprint inputs before publishing",
+    );
+  }
+  return sha256(
+    JSON.stringify({
+      schemaVersion: 2,
+      buildProvenance: false,
+      platform: IMAGE_PLATFORM,
+      dockerfile,
+    }),
+  );
+}
+
+async function waitForReadyTag(
+  services: RuntimeImageServices,
+  input: VcrScope & { readonly repository: string; readonly tag: string },
+  initial?: VcrTag,
+): Promise<VcrTag> {
+  const startedAt = Date.now();
+  let candidate = initial ?? (await services.cli.inspectTag(input));
+  for (;;) {
+    if (candidate?.kind === "index") {
+      throw new Error(
+        `VCR image ${input.repository}:${input.tag} is an OCI index; expected one linux/amd64 manifest`,
+      );
+    }
+    if (candidate?.status === "ready") {
+      return candidate;
+    }
+    if (candidate && candidate.status !== null && candidate.status !== "preparing") {
+      throw new Error(
+        `VCR image ${input.repository}:${input.tag} entered status ${candidate.status}`,
+      );
+    }
+    if (Date.now() - startedAt >= IMAGE_READINESS_TIMEOUT_MS) {
+      throw new Error(`VCR image ${input.repository}:${input.tag} was not ready within 15 minutes`);
+    }
+    await services.sleep(IMAGE_POLL_INTERVAL_MS);
+    candidate = await services.cli.inspectTag(input);
+  }
+}
+
+function tagState(tag: VcrTag): string {
+  if (tag.kind === "index") {
+    return "an unsupported OCI index";
+  }
+  return tag.status ?? "not yet classified by VCR";
+}
+
+function isValidVcrRepositoryName(value: string): boolean {
+  return /^[a-z0-9]+(?:(?:\.|_|__|-+)[a-z0-9]+)*$/.test(value);
+}
+
+async function requestVcrRepositoryName(services: RuntimeImageServices): Promise<string> {
+  for (;;) {
+    const value = (await services.prompter.text("Choose another VCR repository name")).trim();
+    if (isValidVcrRepositoryName(value)) {
+      return value;
+    }
+    services.reporter.warn(
+      "VCR repository names require lowercase letters or digits separated by dots, underscores, or hyphens.",
+    );
+  }
+}

--- a/src/vercel-runtime-image.ts
+++ b/src/vercel-runtime-image.ts
@@ -79,6 +79,15 @@ export async function ensureVercelRuntimeImage(input: {
     }
 
     const tags = await services.cli.listTags({ ...scope, repository });
+    const compatible = tags.every((candidate) => candidate.tag.startsWith(IMAGE_TAG_PREFIX));
+    if (!compatible) {
+      services.reporter.warn(
+        `VCR repository "${repository}" contains unrelated images. SelfBench will not modify it.`,
+      );
+      repository = await requestVcrRepositoryName(services);
+      continue;
+    }
+
     const matching = tags.find((candidate) => candidate.tag === tag);
     if (matching) {
       if (
@@ -104,16 +113,7 @@ export async function ensureVercelRuntimeImage(input: {
       );
       break;
     }
-
-    const compatible =
-      tags.length === 0 || tags.some((candidate) => candidate.tag.startsWith(IMAGE_TAG_PREFIX));
-    if (compatible) {
-      break;
-    }
-    services.reporter.warn(
-      `VCR repository "${repository}" contains unrelated images. SelfBench will not modify it.`,
-    );
-    repository = await requestVcrRepositoryName(services);
+    break;
   }
 
   const ready = await services.reporter.task(

--- a/src/vercel-setup-probe.ts
+++ b/src/vercel-setup-probe.ts
@@ -1,0 +1,229 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { APIError, Sandbox } from "@vercel/sandbox";
+import type { VercelCredentials } from "./config.js";
+import { HOBBY_VERCEL_TIMEOUT_CAP_MS, STANDARD_VERCEL_TIMEOUT_CAP_MS } from "./sandbox-timeout.js";
+
+const PROBE_COMMAND_TIMEOUT_MS = 15_000;
+const CLEANUP_TIMEOUT_MS = 60_000;
+const ABSENCE_RETRIES = 3;
+
+export interface VercelCapability {
+  readonly timeoutCapMs: number;
+  readonly timeoutClass: "45m" | "standard";
+  readonly checkedAt: string;
+}
+
+interface ProbeSandbox {
+  readonly name: string;
+  runCommand(
+    command: string,
+    args: string[],
+    options: { readonly signal?: AbortSignal; readonly timeoutMs?: number },
+  ): Promise<{ readonly exitCode: number }>;
+  delete(options: { readonly signal?: AbortSignal }): Promise<void>;
+}
+
+export interface VercelSandboxProbeApi {
+  create(input: {
+    readonly token: string;
+    readonly teamId: string;
+    readonly projectId: string;
+    readonly image: string;
+    readonly name: string;
+    readonly persistent: false;
+    readonly resources: { readonly vcpus: 1 };
+    readonly signal?: AbortSignal;
+    readonly tags: Readonly<Record<string, string>>;
+    readonly timeout: number;
+  }): Promise<ProbeSandbox>;
+  get(input: {
+    readonly token: string;
+    readonly teamId: string;
+    readonly projectId: string;
+    readonly name: string;
+    readonly resume: false;
+    readonly signal?: AbortSignal;
+  }): Promise<ProbeSandbox>;
+}
+
+export async function probeVercelCapability(
+  input: {
+    readonly credentials: VercelCredentials;
+    readonly image: string;
+    readonly signal?: AbortSignal;
+  },
+  api: VercelSandboxProbeApi = vercelSandboxProbeApi,
+): Promise<VercelCapability> {
+  try {
+    await runProbe(input, STANDARD_VERCEL_TIMEOUT_CAP_MS, api);
+    return {
+      timeoutCapMs: STANDARD_VERCEL_TIMEOUT_CAP_MS,
+      timeoutClass: "standard",
+      checkedAt: new Date().toISOString(),
+    };
+  } catch (error) {
+    if (!isFortyFiveMinuteLimit(error)) {
+      throw sanitizeError(error, input.credentials.token);
+    }
+  }
+
+  try {
+    await runProbe(input, HOBBY_VERCEL_TIMEOUT_CAP_MS, api);
+  } catch (error) {
+    throw sanitizeError(error, input.credentials.token);
+  }
+  return {
+    timeoutCapMs: HOBBY_VERCEL_TIMEOUT_CAP_MS,
+    timeoutClass: "45m",
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+const vercelSandboxProbeApi: VercelSandboxProbeApi = {
+  async create(input) {
+    return await Sandbox.create(input);
+  },
+  async get(input) {
+    return await Sandbox.get(input);
+  },
+};
+
+async function runProbe(
+  input: {
+    readonly credentials: VercelCredentials;
+    readonly image: string;
+    readonly signal?: AbortSignal;
+  },
+  timeoutMs: number,
+  api: VercelSandboxProbeApi,
+): Promise<void> {
+  input.signal?.throwIfAborted();
+  const name = `selfbench-setup-${crypto.randomUUID().replaceAll("-", "").slice(0, 20)}`;
+  let sandbox: ProbeSandbox | undefined;
+  let primaryError: unknown;
+  try {
+    sandbox = await api.create({
+      ...input.credentials,
+      image: input.image,
+      name,
+      persistent: false,
+      resources: { vcpus: 1 },
+      ...(input.signal ? { signal: input.signal } : {}),
+      tags: { selfbench_stage: "setup-probe" },
+      timeout: timeoutMs,
+    });
+    const result = await sandbox.runCommand("true", [], {
+      ...(input.signal ? { signal: input.signal } : {}),
+      timeoutMs: PROBE_COMMAND_TIMEOUT_MS,
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(`Vercel setup probe exited ${result.exitCode}`);
+    }
+  } catch (error) {
+    primaryError = error;
+  }
+
+  let cleanupError: unknown;
+  const status = httpStatus(primaryError);
+  const recoverMissingHandle =
+    sandbox === undefined && primaryError !== undefined && (status === undefined || status >= 500);
+  try {
+    await cleanupProbe(name, sandbox, recoverMissingHandle, input.credentials, api);
+  } catch (error) {
+    cleanupError = error;
+  }
+  if (cleanupError !== undefined) {
+    throw new AggregateError(
+      primaryError === undefined ? [cleanupError] : [primaryError, cleanupError],
+      `Vercel setup probe ${name} could not be deleted cleanly`,
+    );
+  }
+  if (primaryError !== undefined) {
+    throw primaryError;
+  }
+}
+
+async function cleanupProbe(
+  name: string,
+  sandbox: ProbeSandbox | undefined,
+  recoverMissingHandle: boolean,
+  credentials: VercelCredentials,
+  api: VercelSandboxProbeApi,
+): Promise<void> {
+  let directDeleteError: unknown;
+  if (sandbox) {
+    try {
+      await sandbox.delete({ signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS) });
+      await confirmAbsent(name, credentials, api);
+      return;
+    } catch (error) {
+      directDeleteError = error;
+    }
+  } else if (!recoverMissingHandle) {
+    return;
+  }
+
+  try {
+    await confirmAbsent(name, credentials, api);
+  } catch (recoveryError) {
+    throw new AggregateError(
+      directDeleteError === undefined ? [recoveryError] : [directDeleteError, recoveryError],
+      `failed to recover Vercel setup probe ${name} by exact name`,
+    );
+  }
+}
+
+async function confirmAbsent(
+  name: string,
+  credentials: VercelCredentials,
+  api: VercelSandboxProbeApi,
+): Promise<void> {
+  for (let attempt = 0; attempt < ABSENCE_RETRIES; attempt += 1) {
+    try {
+      const recovered = await api.get({
+        ...credentials,
+        name,
+        resume: false,
+        signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS),
+      });
+      await recovered.delete({ signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS) });
+    } catch (error) {
+      if (httpStatus(error) === 404) {
+        return;
+      }
+      throw error;
+    }
+    await delay(250 * (attempt + 1));
+  }
+  throw new Error(`Vercel setup probe ${name} still exists after deletion`);
+}
+
+function isFortyFiveMinuteLimit(error: unknown): boolean {
+  return (
+    httpStatus(error) === 400 &&
+    /`?timeout`?.*(?:should be|must be).*<=\s*45m/i.test(errorDetail(error))
+  );
+}
+
+function httpStatus(error: unknown): number | undefined {
+  if (error instanceof APIError) {
+    return error.response.status;
+  }
+  if (error && typeof error === "object" && "status" in error && typeof error.status === "number") {
+    return error.status;
+  }
+  return undefined;
+}
+
+function errorDetail(error: unknown): string {
+  if (error instanceof APIError) {
+    return [error.message, error.text, JSON.stringify(error.json)].filter(Boolean).join(" ");
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sanitizeError(error: unknown, token: string): Error {
+  const sanitized = new Error(errorDetail(error).replaceAll(token, "[redacted]").slice(0, 2_000));
+  sanitized.name = error instanceof Error ? error.name : "VercelSetupError";
+  return sanitized;
+}

--- a/src/vercel-setup.ts
+++ b/src/vercel-setup.ts
@@ -1,0 +1,419 @@
+import { dirname, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import type { VercelCredentials } from "./config.js";
+import {
+  isInteractiveTerminal,
+  SetupCanceledError,
+  type SetupPrompter,
+  TerminalPrompter,
+} from "./terminal-prompts.js";
+import { type SetupReporter, TerminalSetupReporter } from "./terminal-reporter.js";
+import { VercelCli, type VercelProject, type VercelTeam } from "./vercel-cli.js";
+import {
+  loadVercelProfileData,
+  saveVercelProfile,
+  selfBenchConfigDirectory,
+  type VercelProfile,
+  type VercelProfileData,
+  validateVercelProfileName,
+} from "./vercel-profile.js";
+import {
+  DEFAULT_VCR_REPOSITORY,
+  ensureVercelRuntimeImage,
+  type VercelRuntimeImageCli,
+  vercelRuntimeFingerprint,
+} from "./vercel-runtime-image.js";
+import { probeVercelCapability, type VercelCapability } from "./vercel-setup-probe.js";
+
+const DEFAULT_PROFILE_NAME = "default";
+const DEFAULT_PROJECT_NAME = "selfbench-sandbox";
+
+export interface VercelSetupCli extends VercelRuntimeImageCli {
+  ensureAvailable(): Promise<void>;
+  ensureLoggedIn(): Promise<void>;
+  listTeams(): Promise<readonly VercelTeam[]>;
+  listProjects(teamSlug: string): Promise<readonly VercelProject[]>;
+  createProject(teamSlug: string, projectName: string): Promise<VercelProject>;
+}
+
+export interface VercelSetupServices {
+  readonly cli: VercelSetupCli;
+  readonly prompter: SetupPrompter;
+  readonly reporter: SetupReporter;
+  readonly interactive: boolean;
+  readonly loadProfiles: (directory: string) => Promise<VercelProfileData>;
+  readonly saveProfile: typeof saveVercelProfile;
+  readonly probe: (input: {
+    readonly credentials: VercelCredentials;
+    readonly image: string;
+    readonly signal?: AbortSignal;
+  }) => Promise<VercelCapability>;
+  readonly sleep: (delayMs: number) => Promise<void>;
+}
+
+export interface VercelSetupResult {
+  readonly profileName: string;
+  readonly profile: VercelProfile;
+  readonly configDirectory: string;
+  readonly projectCreated: boolean;
+  readonly imagePublished: boolean;
+}
+
+export async function setupVercel(
+  options: {
+    readonly profileName?: string;
+    readonly environment?: NodeJS.ProcessEnv;
+    readonly projectRoot?: string;
+    readonly verbose?: boolean;
+  } = {},
+  providedServices?: VercelSetupServices,
+): Promise<VercelSetupResult> {
+  const services = providedServices ?? defaultServices(options.verbose ?? false);
+  if (!services.interactive) {
+    throw new Error(
+      "self-bench setup vercel requires an interactive terminal; unattended environments should set VERCEL_TOKEN, VERCEL_TEAM_ID, VERCEL_PROJECT_ID, SELFBENCH_VERCEL_IMAGE, and optionally SELFBENCH_VERCEL_TIMEOUT_CAP",
+    );
+  }
+  services.reporter.intro("Configure Vercel Sandbox");
+  const profileName = validateVercelProfileName(options.profileName ?? DEFAULT_PROFILE_NAME);
+  const environment = options.environment ?? process.env;
+  const configDirectory = selfBenchConfigDirectory(environment);
+  const projectRoot = resolve(options.projectRoot ?? defaultProjectRoot());
+  const existingData = await services.loadProfiles(configDirectory);
+  const existingProfile = existingData.profiles[profileName];
+  const existingToken = existingData.tokens[profileName];
+  const action = await chooseSetupAction(services.prompter, existingProfile, existingToken);
+
+  await services.cli.ensureAvailable();
+  await services.cli.ensureLoggedIn();
+
+  const teams = await services.cli.listTeams();
+  if (teams.length === 0) {
+    throw new Error("The Vercel account has no accessible team or personal scope");
+  }
+  let selected: SelectedProject;
+  let projectCreated = false;
+  if (action === "change-project" || !existingProfile) {
+    const team = await chooseTeam(services.prompter, teams);
+    const projectSelection = await chooseProject(services, team);
+    selected = { team, project: projectSelection.project };
+    projectCreated = projectSelection.created;
+  } else {
+    selected = await resolveExistingSelection(services.cli, teams, existingProfile);
+  }
+
+  const fingerprint = await vercelRuntimeFingerprint(projectRoot);
+  const imageResult = await ensureVercelRuntimeImage({
+    services: {
+      cli: services.cli,
+      prompter: services.prompter,
+      reporter: services.reporter,
+      sleep: services.sleep,
+    },
+    scope: { teamSlug: selected.team.slug, projectId: selected.project.id },
+    projectRoot,
+    fingerprint,
+    preferredRepository:
+      action === "change-project" || !existingProfile
+        ? DEFAULT_VCR_REPOSITORY
+        : existingProfile.vcrRepository,
+  });
+
+  const token =
+    action === "revalidate" && existingToken
+      ? existingToken
+      : await requestProjectToken(services, selected);
+  const credentials = {
+    token,
+    teamId: selected.team.id,
+    projectId: selected.project.id,
+  };
+  const controller = new AbortController();
+  const interrupt = (): void => controller.abort(new SetupCanceledError());
+  process.once("SIGINT", interrupt);
+  let capability: VercelCapability;
+  try {
+    capability = await services.reporter.task(
+      {
+        pending: "Verifying Sandbox access and detecting the timeout cap",
+        success: "Sandbox access verified",
+        failure: "Sandbox verification failed",
+      },
+      async () => {
+        try {
+          return await services.probe({
+            credentials,
+            image: imageResult.image,
+            signal: controller.signal,
+          });
+        } catch (error) {
+          if (controller.signal.aborted) {
+            throw controller.signal.reason;
+          }
+          throw error;
+        }
+      },
+    );
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw controller.signal.reason;
+    }
+    throw new Error(
+      `Vercel Sandbox verification failed: ${errorMessage(error)}. If the access token expired or has the wrong project scope, rerun setup and paste a new project-scoped token; choose Replace the access token when revalidating an existing profile.`,
+      { cause: error },
+    );
+  } finally {
+    process.removeListener("SIGINT", interrupt);
+  }
+
+  if (capability.timeoutClass === "45m") {
+    services.reporter.warn(
+      "This Vercel scope enforces a 45-minute Sandbox limit. SelfBench will cap longer authoring and repair stages at 45 minutes; accepted tasks remain fully validated, but slow candidates may time out and be rejected.",
+    );
+    services.reporter.warn(
+      "Vercel Hobby usage is intended for personal, non-commercial work. Use a paid team for commercial SelfBench runs.",
+    );
+    if (
+      !(await services.prompter.confirm("Continue with the 45-minute compatibility cap?", true))
+    ) {
+      services.reporter.cancel("Vercel setup canceled before profile activation.");
+      throw new SetupCanceledError("Vercel setup canceled before profile activation");
+    }
+  }
+
+  const profile: VercelProfile = {
+    teamId: selected.team.id,
+    teamSlug: selected.team.slug,
+    teamName: selected.team.name,
+    projectId: selected.project.id,
+    projectName: selected.project.name,
+    vcrRepository: imageResult.repository,
+    image: imageResult.image,
+    runtimeFingerprint: fingerprint,
+    timeoutCapMs: capability.timeoutCapMs,
+    capabilityCheckedAt: capability.checkedAt,
+  };
+  await services.saveProfile({ directory: configDirectory, profileName, profile, token });
+  services.reporter.finish(`Saved Vercel profile "${profileName}"`, [
+    `Location: ${configDirectory}`,
+    `Project: ${profile.teamSlug}/${profile.projectName}`,
+    `Runtime image: ${imageRepository(profile.image)}`,
+    "Digest:",
+    `  ${imageDigest(profile.image)}`,
+    `Vercel tier: ${timeoutTier(capability.timeoutClass)}`,
+    `Timeout cap: ${formatDuration(profile.timeoutCapMs)}`,
+    "Resources: Project and runtime image remain reusable after self-bench down.",
+  ]);
+
+  return {
+    profileName,
+    profile,
+    configDirectory,
+    projectCreated,
+    imagePublished: imageResult.published,
+  };
+}
+
+function defaultServices(verbose: boolean): VercelSetupServices {
+  const reporter = new TerminalSetupReporter({ verbose });
+  return {
+    cli: new VercelCli(),
+    prompter: new TerminalPrompter(),
+    reporter,
+    interactive: isInteractiveTerminal(),
+    loadProfiles: loadVercelProfileData,
+    saveProfile: saveVercelProfile,
+    probe: probeVercelCapability,
+    sleep: async (delayMs) => await delay(delayMs),
+  };
+}
+
+type SetupAction = "revalidate" | "replace-token" | "change-project";
+
+async function chooseSetupAction(
+  prompter: SetupPrompter,
+  profile: VercelProfile | undefined,
+  token: string | undefined,
+): Promise<SetupAction> {
+  if (!profile) {
+    return "change-project";
+  }
+  const choices = [
+    ...(token
+      ? [
+          {
+            value: "revalidate",
+            label: `Revalidate ${profile.teamSlug}/${profile.projectName}`,
+            hint: "Recommended",
+          },
+        ]
+      : []),
+    { value: "replace-token", label: "Replace the access token" },
+    { value: "change-project", label: "Choose another team or project" },
+  ];
+  const selected = await prompter.select(
+    `Vercel profile is already configured for ${profile.teamSlug}/${profile.projectName}`,
+    choices,
+    token ? "revalidate" : "replace-token",
+  );
+  if (selected !== "revalidate" && selected !== "replace-token" && selected !== "change-project") {
+    throw new Error(`Unsupported Vercel setup action: ${selected}`);
+  }
+  return selected;
+}
+
+async function chooseTeam(
+  prompter: SetupPrompter,
+  teams: readonly VercelTeam[],
+): Promise<VercelTeam> {
+  const selectedId = await prompter.search(
+    "Choose a Vercel team or personal scope",
+    teams.map((team) => ({
+      value: team.id,
+      label: team.name,
+      hint: [
+        team.slug,
+        team.id.startsWith("team_") ? undefined : "personal scope",
+        team.current ? "current" : undefined,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+    })),
+    teams.find(({ current }) => current)?.id,
+  );
+  return teams.find(({ id }) => id === selectedId) ?? fail("selected Vercel team disappeared");
+}
+
+async function chooseProject(
+  services: VercelSetupServices,
+  team: VercelTeam,
+): Promise<{ readonly project: VercelProject; readonly created: boolean }> {
+  let projects = await services.cli.listProjects(team.slug);
+  const modes = [
+    ...(projects.length > 0 ? [{ value: "existing", label: "Select an existing project" }] : []),
+    { value: "create", label: "Create a dedicated project", hint: "Recommended" },
+  ];
+  const mode = await services.prompter.select(
+    "Choose how to configure the Vercel project",
+    modes,
+    "create",
+  );
+  if (mode === "existing") {
+    const projectId = await services.prompter.search(
+      "Choose an existing project",
+      projects.map((project) => ({
+        value: project.id,
+        label: project.name,
+        hint: project.id,
+      })),
+    );
+    return {
+      project:
+        projects.find(({ id }) => id === projectId) ?? fail("selected Vercel project disappeared"),
+      created: false,
+    };
+  }
+
+  for (;;) {
+    const name = (await services.prompter.text("New project name", DEFAULT_PROJECT_NAME)).trim();
+    if (!isValidProjectName(name)) {
+      services.reporter.warn(
+        "Project names must use 1-100 lowercase letters, digits, dots, underscores, or hyphens and cannot contain three consecutive hyphens.",
+      );
+      continue;
+    }
+    if (projects.some((project) => project.name.toLowerCase() === name.toLowerCase())) {
+      services.reporter.warn(`Project name "${name}" is already in use. Choose another name.`);
+      continue;
+    }
+    try {
+      return { project: await services.cli.createProject(team.slug, name), created: true };
+    } catch (error) {
+      projects = await services.cli.listProjects(team.slug);
+      if (projects.some((project) => project.name.toLowerCase() === name.toLowerCase())) {
+        services.reporter.warn(`Project name "${name}" became unavailable. Choose another name.`);
+        continue;
+      }
+      throw new Error(`Unable to create project "${name}": ${errorMessage(error)}`, {
+        cause: error,
+      });
+    }
+  }
+}
+
+async function resolveExistingSelection(
+  cli: VercelSetupCli,
+  teams: readonly VercelTeam[],
+  profile: VercelProfile,
+): Promise<SelectedProject> {
+  const team = teams.find(({ id }) => id === profile.teamId);
+  if (!team) {
+    throw new Error(
+      `Saved Vercel team ${profile.teamSlug} is no longer accessible; rerun setup and choose another team`,
+    );
+  }
+  const project = (await cli.listProjects(team.slug)).find(({ id }) => id === profile.projectId);
+  if (!project) {
+    throw new Error(
+      `Saved Vercel project ${profile.projectName} is no longer accessible; rerun setup and choose another project`,
+    );
+  }
+  return { team, project };
+}
+
+async function requestProjectToken(
+  services: VercelSetupServices,
+  selected: SelectedProject,
+): Promise<string> {
+  services.reporter.message("");
+  services.reporter.message(
+    `Create a Vercel access token for team ${selected.team.name} and restrict it to project ${selected.project.name}:`,
+  );
+  services.reporter.message("https://vercel.com/account/settings/tokens");
+  services.reporter.message('A descriptive token name such as "selfbench-local" is recommended.');
+  const token = (await services.prompter.secret("Paste the project-scoped access token")).trim();
+  if (!token) {
+    throw new Error("Vercel access token must not be blank");
+  }
+  return token;
+}
+
+function isValidProjectName(value: string): boolean {
+  return /^[a-z0-9._-]{1,100}$/.test(value) && !value.includes("---");
+}
+
+function formatDuration(timeoutMs: number): string {
+  return timeoutMs % (60 * 60 * 1_000) === 0
+    ? `${timeoutMs / (60 * 60 * 1_000)}h`
+    : `${timeoutMs / (60 * 1_000)}m`;
+}
+
+function timeoutTier(timeoutClass: VercelCapability["timeoutClass"]): string {
+  return timeoutClass === "45m" ? "Hobby-compatible" : "Pro/Enterprise-compatible";
+}
+
+function imageRepository(image: string): string {
+  return image.slice(0, image.lastIndexOf("@"));
+}
+
+function imageDigest(image: string): string {
+  return image.slice(image.lastIndexOf("@") + 1);
+}
+
+function defaultProjectRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+interface SelectedProject {
+  readonly team: VercelTeam;
+  readonly project: VercelProject;
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { sha256 } from "../src/hash.js";
 import { runCommand } from "../src/process.js";
+import { saveVercelProfile } from "../src/vercel-profile.js";
 
 const roots: string[] = [];
 
@@ -12,6 +13,20 @@ afterEach(async () => {
 });
 
 describe("SelfBench CLI", () => {
+  test("setup vercel fails before external work when no interactive terminal is attached", async () => {
+    const child = Bun.spawn([process.execPath, "src/cli.ts", "setup", "vercel", "--verbose"], {
+      cwd: join(import.meta.dir, ".."),
+      env: process.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("requires an interactive terminal");
+    expect(stderr).toContain("VERCEL_TOKEN");
+  });
+
   test("up translates backend flags into stack configuration", async () => {
     const root = await mkdtemp(join(tmpdir(), "selfbench-cli-up-"));
     roots.push(root);
@@ -68,6 +83,114 @@ printf '%s|%s|%s|%s|%s\\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBO
 
     expect(exitCode).not.toBe(0);
     expect(stderr).toContain("--harbor-environment is required with --backend vercel");
+  });
+
+  test("explains how to configure Vercel when no profile or complete environment exists", async () => {
+    const root = await mkdtemp(join(tmpdir(), "selfbench-cli-missing-vercel-profile-"));
+    roots.push(root);
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        "src/cli.ts",
+        "up",
+        "--backend",
+        "vercel",
+        "--harbor-environment",
+        "docker",
+      ],
+      {
+        cwd: join(import.meta.dir, ".."),
+        env: {
+          ...process.env,
+          SELFBENCH_CONFIG_DIR: join(root, ".selfbench"),
+          SELFBENCH_VERCEL_IMAGE: "",
+          VERCEL_TOKEN: "",
+          VERCEL_TEAM_ID: "",
+          VERCEL_PROJECT_ID: "",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("run self-bench setup vercel");
+    expect(stderr).toContain("VERCEL_TOKEN");
+  });
+
+  test("up resolves a saved Vercel profile without requiring exported credentials", async () => {
+    const root = await mkdtemp(join(tmpdir(), "selfbench-cli-vercel-profile-"));
+    roots.push(root);
+    const binaryDirectory = join(root, "bin");
+    const configDirectory = join(root, ".selfbench");
+    const calls = join(root, "docker-calls");
+    await mkdir(binaryDirectory);
+    await saveVercelProfile({
+      directory: configDirectory,
+      profileName: "default",
+      token: "stored-vercel-token",
+      profile: {
+        teamId: "team_saved",
+        teamSlug: "saved-team",
+        teamName: "Saved Team",
+        projectId: "prj_saved",
+        projectName: "saved-project",
+        vcrRepository: "selfbench-runtime",
+        image: `selfbench-runtime@sha256:${"b".repeat(64)}`,
+        runtimeFingerprint: "c".repeat(64),
+        timeoutCapMs: 45 * 60 * 1_000,
+        capabilityCheckedAt: "2026-08-16T12:00:00.000Z",
+      },
+    });
+    const docker = join(binaryDirectory, "docker");
+    await writeFile(
+      docker,
+      `#!/bin/sh
+printf '%s|%s|%s|%s|%s\n' "$*" "$VERCEL_TEAM_ID" "$VERCEL_PROJECT_ID" "$SELFBENCH_VERCEL_IMAGE" "$SELFBENCH_VERCEL_TIMEOUT_CAP" >> "$DOCKER_CALLS"
+`,
+    );
+    await chmod(docker, 0o755);
+
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        "src/cli.ts",
+        "up",
+        "--backend",
+        "vercel",
+        "--harbor-environment",
+        "docker",
+      ],
+      {
+        cwd: join(import.meta.dir, ".."),
+        env: {
+          ...process.env,
+          DOCKER_CALLS: calls,
+          PATH: `${binaryDirectory}:${process.env.PATH ?? ""}`,
+          SELFBENCH_CONFIG_DIR: configDirectory,
+          SELFBENCH_VERCEL_IMAGE: "",
+          VERCEL_TOKEN: "",
+          VERCEL_TEAM_ID: "",
+          VERCEL_PROJECT_ID: "",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+
+    expect(exitCode, stderr).toBe(0);
+    expect(stdout).toContain("vercel generation and docker Harbor");
+    const invocation = await readFile(calls, "utf8");
+    expect(invocation).toContain("|team_saved|prj_saved|");
+    expect(invocation).toContain(`selfbench-runtime@sha256:${"b".repeat(64)}`);
+    expect(invocation).toContain("|2700000ms\n");
+    expect(invocation).not.toContain("stored-vercel-token");
   });
 
   test("configures every supported mixed generation and Harbor provider pair", async () => {

--- a/tests/terminal-prompts.test.ts
+++ b/tests/terminal-prompts.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { PassThrough } from "node:stream";
+import { stripVTControlCharacters } from "node:util";
+import { SetupCanceledError, TerminalPrompter } from "../src/terminal-prompts.js";
+
+describe("TerminalPrompter", () => {
+  test("live-filters searchable choices by label, hint, or value", async () => {
+    const { input, output, prompter } = fixture();
+    const selection = prompter.search("Choose a project", [
+      { value: "prj_alpha", label: "alpha" },
+      { value: "prj_paid", label: "paid validation", hint: "production project" },
+      { value: "prj_other", label: "other" },
+    ]);
+
+    send(input, "production\r");
+
+    expect(await selection).toBe("prj_paid");
+    const rendered = plainOutput(output);
+    expect(rendered).toContain("Choose a project");
+    expect(rendered).toContain("Type to filter");
+    expect(rendered).toContain("paid validation");
+  });
+
+  test("supports arrow-key navigation through a scrollable choice window", async () => {
+    const { input, output, prompter } = fixture();
+    const choices = Array.from({ length: 12 }, (_, index) => ({
+      value: `option-${index + 1}`,
+      label: `Option ${index + 1}`,
+    }));
+    const selection = prompter.select("Choose an option", choices);
+
+    send(input, `${"\u001b[B".repeat(9)}\r`);
+
+    expect(await selection).toBe("option-10");
+    expect(plainOutput(output)).toContain("Option 10");
+  });
+
+  test("accepts the configured default without moving the cursor", async () => {
+    const { input, prompter } = fixture();
+    const selection = prompter.select(
+      "Choose an option",
+      [
+        { value: "first", label: "First" },
+        { value: "recommended", label: "Recommended" },
+      ],
+      "recommended",
+    );
+
+    send(input, "\r");
+
+    expect(await selection).toBe("recommended");
+  });
+
+  test("keeps text defaults and confirmation choices interactive", async () => {
+    const textFixture = fixture();
+    const projectName = textFixture.prompter.text("Project name", "selfbench-sandbox");
+    send(textFixture.input, "\r");
+    expect(await projectName).toBe("selfbench-sandbox");
+
+    const confirmFixture = fixture();
+    const confirmed = confirmFixture.prompter.confirm("Continue?", true);
+    send(confirmFixture.input, "n\r");
+    expect(await confirmed).toBe(false);
+  });
+
+  test("reads a secret without exposing its value or length and restores terminal state", async () => {
+    const { input, output, prompter, rawModes } = fixture();
+    input.pause();
+    const secret = prompter.secret("Token");
+
+    send(input, "vcp_secret\r");
+
+    expect(await secret).toBe("vcp_secret");
+    const rendered = plainOutput(output);
+    expect(rendered).toContain("Token");
+    expect(rendered).not.toContain("vcp_secret");
+    expect(rendered).not.toContain("••••");
+    expect(rawModes[0]).toBe(true);
+    expect(rawModes.at(-1)).toBe(false);
+    expect(input.isPaused()).toBe(true);
+  });
+
+  test("treats terminal EOF as cancellation and restores terminal state", async () => {
+    const { input, prompter, rawModes } = fixture();
+    const secret = prompter.secret("Token");
+
+    setTimeout(() => input.end(), 0);
+
+    await expect(secret).rejects.toBeInstanceOf(SetupCanceledError);
+    expect(rawModes[0]).toBe(true);
+    expect(rawModes.at(-1)).toBe(false);
+  });
+
+  test("treats Ctrl-C as setup cancellation", async () => {
+    const { input, output, prompter, rawModes } = fixture();
+    const selection = prompter.select("Choose", [{ value: "one", label: "One" }]);
+
+    send(input, "\u0003");
+
+    await expect(selection).rejects.toBeInstanceOf(SetupCanceledError);
+    expect(plainOutput(output)).toContain("Setup canceled.");
+    expect(rawModes.at(-1)).toBe(false);
+  });
+
+  test("treats Escape as setup cancellation", async () => {
+    const { input, output, prompter, rawModes } = fixture();
+    const selection = prompter.select("Choose", [{ value: "one", label: "One" }]);
+
+    send(input, "\u001b");
+
+    await expect(selection).rejects.toBeInstanceOf(SetupCanceledError);
+    expect(plainOutput(output)).toContain("Setup canceled.");
+    expect(rawModes.at(-1)).toBe(false);
+  });
+
+  test("rejects an empty choice set before touching the terminal", async () => {
+    const { prompter, rawModes } = fixture();
+
+    await expect(prompter.search("Choose", [])).rejects.toThrow("has no available choices");
+    expect(rawModes).toEqual([]);
+  });
+});
+
+function fixture(): {
+  readonly input: PassThrough;
+  readonly output: PassThrough;
+  readonly prompter: TerminalPrompter;
+  readonly rawModes: boolean[];
+} {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const rawModes: boolean[] = [];
+  const ttyInput = Object.assign(input, {
+    isTTY: true,
+    isRaw: false,
+    setRawMode(value: boolean) {
+      this.isRaw = value;
+      rawModes.push(value);
+      return this;
+    },
+  });
+  const ttyOutput = Object.assign(output, {
+    isTTY: true,
+    columns: 80,
+    rows: 12,
+  });
+  return {
+    input,
+    output,
+    prompter: new TerminalPrompter(
+      ttyInput as unknown as NodeJS.ReadStream,
+      ttyOutput as unknown as NodeJS.WriteStream,
+    ),
+    rawModes,
+  };
+}
+
+function send(input: PassThrough, keys: string): void {
+  setTimeout(() => input.write(keys), 0);
+}
+
+function plainOutput(output: PassThrough): string {
+  return stripVTControlCharacters(output.read()?.toString() ?? "");
+}

--- a/tests/terminal-reporter.test.ts
+++ b/tests/terminal-reporter.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { PassThrough } from "node:stream";
+import { stripVTControlCharacters } from "node:util";
+import { SetupCanceledError } from "../src/terminal-prompts.js";
+import { TerminalSetupReporter } from "../src/terminal-reporter.js";
+
+describe("TerminalSetupReporter", () => {
+  test("shows a live timer and collapses successful command output", async () => {
+    const output = terminalOutput();
+    const reporter = new TerminalSetupReporter({ output });
+
+    await reporter.task(
+      {
+        pending: "Publishing runtime image",
+        success: "Runtime image published",
+        failure: "Runtime image publication failed",
+      },
+      async (onOutput) => {
+        onOutput("stdout", Buffer.from("hidden build output\n"));
+        await Bun.sleep(100);
+      },
+    );
+
+    const rendered = plainOutput(output);
+    // Clack deliberately replaces animated timer frames with an ellipsis in CI.
+    // The completed line still freezes the elapsed time in both render modes.
+    if (process.env.CI === "true") {
+      expect(rendered).toContain("Publishing runtime image...");
+    } else {
+      expect(rendered).toContain("Publishing runtime image [0s]");
+    }
+    expect(rendered).toContain("Runtime image published [0s]");
+    expect(rendered).not.toContain("hidden build output");
+  });
+
+  test("reveals retained command output when a compact task fails", async () => {
+    const output = terminalOutput();
+    const reporter = new TerminalSetupReporter({ output });
+
+    await expect(
+      reporter.task(
+        {
+          pending: "Publishing runtime image",
+          success: "Runtime image published",
+          failure: "Runtime image publication failed",
+        },
+        async (onOutput) => {
+          onOutput("stderr", Buffer.from("provider failure detail\n"));
+          throw new Error("publication failed");
+        },
+      ),
+    ).rejects.toThrow("publication failed");
+
+    const rendered = plainOutput(output);
+    expect(rendered).toContain("Runtime image publication failed [0s]");
+    expect(rendered).toContain("Command output:");
+    expect(rendered).toContain("provider failure detail");
+  });
+
+  test("streams subprocess output unchanged in verbose mode", async () => {
+    const output = terminalOutput();
+    const errorOutput = terminalOutput();
+    const reporter = new TerminalSetupReporter({ output, errorOutput, verbose: true });
+
+    await reporter.task(
+      {
+        pending: "Publishing runtime image",
+        success: "Runtime image published",
+        failure: "Runtime image publication failed",
+      },
+      async (onOutput) => {
+        onOutput("stdout", Buffer.from("build stdout\n"));
+        onOutput("stderr", Buffer.from("build stderr\n"));
+      },
+    );
+
+    expect(plainOutput(output)).toContain("build stdout");
+    expect(plainOutput(errorOutput)).toBe("build stderr\n");
+    expect(plainOutput(output)).not.toContain("[0s]");
+  });
+
+  test("renders task cancellation without presenting it as a failure", async () => {
+    const output = terminalOutput();
+    const reporter = new TerminalSetupReporter({ output });
+
+    await expect(
+      reporter.task(
+        {
+          pending: "Verifying Sandbox access",
+          success: "Sandbox access verified",
+          failure: "Sandbox verification failed",
+        },
+        async () => {
+          throw new SetupCanceledError();
+        },
+      ),
+    ).rejects.toBeInstanceOf(SetupCanceledError);
+
+    const rendered = plainOutput(output);
+    expect(rendered).toContain("Setup canceled.");
+    expect(rendered).not.toContain("Sandbox verification failed");
+  });
+});
+
+function terminalOutput(): PassThrough {
+  return Object.assign(new PassThrough(), {
+    isTTY: true,
+    columns: 100,
+    rows: 20,
+  });
+}
+
+function plainOutput(output: PassThrough): string {
+  return stripVTControlCharacters(output.read()?.toString() ?? "");
+}

--- a/tests/vercel-cli.test.ts
+++ b/tests/vercel-cli.test.ts
@@ -99,6 +99,55 @@ describe("VercelCli", () => {
     expect(runner.captured[2]).toContain("a");
   });
 
+  test("continues VCR tag listings with the CLI next cursor", async () => {
+    const runner = new FakeRunner();
+    runner.enqueueJson({
+      tags: [
+        {
+          tag: "first",
+          manifestDigest: `sha256:${"a".repeat(64)}`,
+          status: "ready",
+        },
+      ],
+      nextCursor: "cursor-2",
+    });
+    runner.enqueueJson({
+      tags: [
+        {
+          tag: "second",
+          manifestDigest: `sha256:${"b".repeat(64)}`,
+          status: "ready",
+        },
+      ],
+      nextCursor: null,
+    });
+    const cli = new VercelCli(runner);
+
+    expect(
+      await cli.listTags({
+        teamSlug: "test-team",
+        projectId: "prj_test",
+        repository: "selfbench-runtime",
+      }),
+    ).toHaveLength(2);
+    expect(runner.captured[1]).toEqual([
+      "vcr",
+      "tag",
+      "list",
+      "selfbench-runtime",
+      "--json",
+      "--limit",
+      "100",
+      "--project",
+      "prj_test",
+      "--scope",
+      "test-team",
+      "--non-interactive",
+      "--next",
+      "cursor-2",
+    ]);
+  });
+
   test("keeps VCR lookup project-scoped and publishes the exact sandbox Dockerfile", async () => {
     const runner = new FakeRunner();
     runner.enqueueText("", 1, '{"error":{"code":"not_found"}}');

--- a/tests/vercel-cli.test.ts
+++ b/tests/vercel-cli.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import type { CommandOutputHandler, CommandResult } from "../src/process.js";
+import { VercelCli, type VercelCommandRunner } from "../src/vercel-cli.js";
+
+class FakeRunner implements VercelCommandRunner {
+  readonly captured: string[][] = [];
+  readonly interactiveCalls: string[][] = [];
+  readonly results: CommandResult[] = [];
+  onInteractive: (() => void) | undefined;
+
+  async capture(
+    args: readonly string[],
+    options?: { readonly onOutput?: CommandOutputHandler },
+  ): Promise<CommandResult> {
+    this.captured.push([...args]);
+    const result = this.results.shift();
+    if (!result) {
+      throw new Error(`unexpected capture: ${args.join(" ")}`);
+    }
+    if (result.stdout) {
+      options?.onOutput?.("stdout", Buffer.from(result.stdout));
+    }
+    if (result.stderr) {
+      options?.onOutput?.("stderr", Buffer.from(result.stderr));
+    }
+    return result;
+  }
+
+  async interactive(args: readonly string[]): Promise<void> {
+    this.interactiveCalls.push([...args]);
+    this.onInteractive?.();
+  }
+
+  enqueueJson(value: unknown, exitCode = 0): void {
+    this.results.push({ stdout: JSON.stringify(value), stderr: "", exitCode });
+  }
+
+  enqueueText(stdout: string, exitCode = 0, stderr = ""): void {
+    this.results.push({ stdout, stderr, exitCode });
+  }
+}
+
+describe("VercelCli", () => {
+  test("requires the audited CLI version and completes browser login when needed", async () => {
+    const runner = new FakeRunner();
+    runner.enqueueText("Vercel CLI 59.1.3\n");
+    runner.enqueueJson({ loggedIn: false }, 1);
+    runner.enqueueJson({ loggedIn: true, user: { username: "test" } });
+    const cli = new VercelCli(runner);
+
+    await cli.ensureAvailable();
+    await cli.ensureLoggedIn();
+
+    expect(runner.interactiveCalls).toEqual([["login"]]);
+    expect(runner.captured[0]).toEqual(["--version"]);
+    expect(runner.captured[1]).toContain("--non-interactive");
+  });
+
+  test("rejects missing or outdated CLI versions with an exact install command", async () => {
+    const runner = new FakeRunner();
+    runner.enqueueText("Vercel CLI 58.9.0\n");
+
+    await expect(new VercelCli(runner).ensureAvailable()).rejects.toThrow(
+      "npm install --global vercel@latest",
+    );
+  });
+
+  test("paginates and deduplicates team and project listings", async () => {
+    const runner = new FakeRunner();
+    runner.enqueueJson({
+      teams: [{ id: "team_a", slug: "a", name: "A", current: true }],
+      pagination: { next: 123 },
+    });
+    runner.enqueueJson({
+      teams: [
+        { id: "team_a", slug: "a", name: "A", current: true },
+        { id: "team_b", slug: "b", name: "B" },
+      ],
+      pagination: { next: null },
+    });
+    runner.enqueueJson({
+      projects: [{ id: "prj_a", name: "first" }],
+      pagination: { next: "456" },
+    });
+    runner.enqueueJson({
+      projects: [{ id: "prj_b", name: "second" }],
+      pagination: { next: null },
+    });
+    const cli = new VercelCli(runner);
+
+    expect(await cli.listTeams()).toHaveLength(2);
+    expect(await cli.listProjects("a")).toEqual([
+      { id: "prj_a", name: "first" },
+      { id: "prj_b", name: "second" },
+    ]);
+    expect(runner.captured[1]).toContain("123");
+    expect(runner.captured[3]).toContain("456");
+    expect(runner.captured[2]).toContain("--scope");
+    expect(runner.captured[2]).toContain("a");
+  });
+
+  test("keeps VCR lookup project-scoped and publishes the exact sandbox Dockerfile", async () => {
+    const runner = new FakeRunner();
+    runner.enqueueText("", 1, '{"error":{"code":"not_found"}}');
+    runner.enqueueJson({ repository: { id: "repo", name: "selfbench-runtime" } });
+    runner.enqueueJson({
+      tags: [
+        {
+          tag: "selfbench-abc",
+          manifestDigest: `sha256:${"a".repeat(64)}`,
+          status: "ready",
+        },
+      ],
+      nextCursor: null,
+    });
+    runner.enqueueText("registry login\n");
+    runner.enqueueText("build output\n", 0, "build warning\n");
+    const cli = new VercelCli(runner);
+    const scope = {
+      teamSlug: "test-team",
+      projectId: "prj_test",
+      repository: "selfbench-runtime",
+    };
+
+    expect(await cli.repositoryExists(scope)).toBe(false);
+    await cli.createRepository(scope);
+    expect(await cli.listTags(scope)).toHaveLength(1);
+    const output: string[] = [];
+    await cli.buildImage({
+      ...scope,
+      tag: "selfbench-abc",
+      projectRoot: "/repo",
+      onOutput: (stream, chunk) => output.push(`${stream}:${Buffer.from(chunk).toString()}`),
+    });
+
+    for (const args of runner.captured) {
+      expect(args).toContain("--project");
+      expect(args).toContain("prj_test");
+      expect(args).toContain("--scope");
+      expect(args).toContain("test-team");
+    }
+    expect(runner.interactiveCalls).toEqual([]);
+    expect(runner.captured.at(-2)).toEqual([
+      "vcr",
+      "login",
+      "docker",
+      "--project",
+      "prj_test",
+      "--scope",
+      "test-team",
+      "--non-interactive",
+    ]);
+    expect(runner.captured.at(-1)).toEqual([
+      "vcr",
+      "build",
+      "docker",
+      "/repo",
+      "selfbench-runtime:selfbench-abc",
+      "--project",
+      "prj_test",
+      "--platform",
+      "linux/amd64",
+      "--push",
+      "--scope",
+      "test-team",
+      "--non-interactive",
+      "--",
+      "--file",
+      "/repo/Dockerfile.sandbox",
+      "--provenance=false",
+    ]);
+    expect(output).toEqual([
+      "stdout:registry login\n",
+      "stdout:build output\n",
+      "stderr:build warning\n",
+    ]);
+  });
+});

--- a/tests/vercel-profile.test.ts
+++ b/tests/vercel-profile.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HOBBY_VERCEL_TIMEOUT_CAP_MS } from "../src/sandbox-timeout.js";
+import {
+  applyVercelProfile,
+  loadVercelProfileData,
+  profileFilePaths,
+  saveVercelProfile,
+  type VercelProfile,
+} from "../src/vercel-profile.js";
+
+const roots: string[] = [];
+const image = `selfbench-runtime@sha256:${"a".repeat(64)}`;
+const profile: VercelProfile = {
+  teamId: "team_test",
+  teamSlug: "test-team",
+  teamName: "Test Team",
+  projectId: "prj_test",
+  projectName: "selfbench-sandbox",
+  vcrRepository: "selfbench-runtime",
+  image,
+  runtimeFingerprint: "b".repeat(64),
+  timeoutCapMs: HOBBY_VERCEL_TIMEOUT_CAP_MS,
+  capabilityCheckedAt: "2026-08-16T12:00:00.000Z",
+};
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("Vercel profiles", () => {
+  test("stores profile metadata and credentials atomically with owner-only permissions", async () => {
+    const parent = await temporaryDirectory();
+    const directory = join(parent, ".selfbench");
+
+    await saveVercelProfile({
+      directory,
+      profileName: "default",
+      profile,
+      token: "vcp_secret_token",
+    });
+
+    const paths = profileFilePaths(directory);
+    const [data, directoryStats, configStats, credentialsStats, configText, credentialsText] =
+      await Promise.all([
+        loadVercelProfileData(directory),
+        lstat(directory),
+        lstat(paths.config),
+        lstat(paths.credentials),
+        readFile(paths.config, "utf8"),
+        readFile(paths.credentials, "utf8"),
+      ]);
+    expect(data.activeVercelProfile).toBe("default");
+    expect(data.profiles.default).toEqual(profile);
+    expect(data.tokens.default).toBe("vcp_secret_token");
+    expect(directoryStats.mode & 0o777).toBe(0o700);
+    expect(configStats.mode & 0o777).toBe(0o600);
+    expect(credentialsStats.mode & 0o777).toBe(0o600);
+    expect(configText).not.toContain("vcp_secret_token");
+    expect(credentialsText).toContain("vcp_secret_token");
+    expect((await lstat(directory)).isDirectory()).toBe(true);
+  });
+
+  test("resolves the active profile while preserving explicit token and image overrides", async () => {
+    const parent = await temporaryDirectory();
+    const directory = join(parent, ".selfbench");
+    await saveVercelProfile({
+      directory,
+      profileName: "default",
+      profile,
+      token: "stored-token",
+    });
+
+    const environment = await applyVercelProfile({
+      SELFBENCH_CONFIG_DIR: directory,
+      VERCEL_TOKEN: "replacement-token",
+      SELFBENCH_VERCEL_IMAGE: `alternate@sha256:${"c".repeat(64)}`,
+    });
+
+    expect(environment).toMatchObject({
+      VERCEL_TOKEN: "replacement-token",
+      VERCEL_TEAM_ID: profile.teamId,
+      VERCEL_PROJECT_ID: profile.projectId,
+      SELFBENCH_VERCEL_IMAGE: `alternate@sha256:${"c".repeat(64)}`,
+      SELFBENCH_VERCEL_TIMEOUT_CAP: `${HOBBY_VERCEL_TIMEOUT_CAP_MS}ms`,
+    });
+  });
+
+  test("never combines a profile with a different explicit team or project", async () => {
+    const parent = await temporaryDirectory();
+    const directory = join(parent, ".selfbench");
+    await saveVercelProfile({ directory, profileName: "default", profile, token: "token" });
+
+    await expect(
+      applyVercelProfile({ SELFBENCH_CONFIG_DIR: directory, VERCEL_TEAM_ID: "team_other" }),
+    ).rejects.toThrow("does not match the selected Vercel profile");
+    await expect(
+      applyVercelProfile({ SELFBENCH_CONFIG_DIR: directory, VERCEL_PROJECT_ID: "prj_other" }),
+    ).rejects.toThrow("does not match the selected Vercel profile");
+  });
+
+  test("allows a stricter timeout override but never exceeds the profile's verified ceiling", async () => {
+    const parent = await temporaryDirectory();
+    const directory = join(parent, ".selfbench");
+    await saveVercelProfile({ directory, profileName: "default", profile, token: "token" });
+
+    expect(
+      await applyVercelProfile({
+        SELFBENCH_CONFIG_DIR: directory,
+        SELFBENCH_VERCEL_TIMEOUT_CAP: "30m",
+      }),
+    ).toMatchObject({ SELFBENCH_VERCEL_TIMEOUT_CAP: "30m" });
+    await expect(
+      applyVercelProfile({
+        SELFBENCH_CONFIG_DIR: directory,
+        SELFBENCH_VERCEL_TIMEOUT_CAP: "2h",
+      }),
+    ).rejects.toThrow("selected profile's verified");
+    await expect(
+      applyVercelProfile({
+        SELFBENCH_CONFIG_DIR: directory,
+        SELFBENCH_VERCEL_TIMEOUT_CAP: "invalid",
+      }),
+    ).rejects.toThrow("selected profile's verified");
+  });
+
+  test("supports multiple named profiles and makes the most recently configured one active", async () => {
+    const parent = await temporaryDirectory();
+    const directory = join(parent, ".selfbench");
+    await saveVercelProfile({
+      directory,
+      profileName: "first",
+      profile,
+      token: "first-token",
+    });
+    await saveVercelProfile({
+      directory,
+      profileName: "second",
+      profile: {
+        ...profile,
+        teamId: "team_second",
+        teamSlug: "second-team",
+        teamName: "Second Team",
+        projectId: "prj_second",
+        projectName: "second-project",
+      },
+      token: "second-token",
+    });
+
+    expect(await applyVercelProfile({ SELFBENCH_CONFIG_DIR: directory })).toMatchObject({
+      VERCEL_TOKEN: "second-token",
+      VERCEL_PROJECT_ID: "prj_second",
+    });
+    expect(await applyVercelProfile({ SELFBENCH_CONFIG_DIR: directory }, "first")).toMatchObject({
+      VERCEL_TOKEN: "first-token",
+      VERCEL_PROJECT_ID: profile.projectId,
+    });
+  });
+
+  test("keeps complete environment-only deployments independent of local profiles", async () => {
+    const parent = await temporaryDirectory();
+    const invalidConfigPath = join(parent, "not-a-directory");
+    await writeFile(invalidConfigPath, "unrelated");
+    const environment = {
+      SELFBENCH_CONFIG_DIR: invalidConfigPath,
+      VERCEL_TOKEN: "token",
+      VERCEL_TEAM_ID: "team",
+      VERCEL_PROJECT_ID: "project",
+      SELFBENCH_VERCEL_IMAGE: image,
+    };
+
+    expect(await applyVercelProfile(environment)).toEqual(environment);
+  });
+
+  test("rejects conflicting paths and profile files with exposed permissions", async () => {
+    const parent = await temporaryDirectory();
+    const fileInsteadOfDirectory = join(parent, "file");
+    await writeFile(fileInsteadOfDirectory, "not a directory");
+    await expect(loadVercelProfileData(fileInsteadOfDirectory)).rejects.toThrow(
+      "must be a directory",
+    );
+
+    const directory = join(parent, ".selfbench");
+    await saveVercelProfile({ directory, profileName: "default", profile, token: "token" });
+    await chmod(profileFilePaths(directory).credentials, 0o644);
+    await expect(loadVercelProfileData(directory)).rejects.toThrow("chmod 600");
+
+    const occupiedDirectory = join(parent, "occupied");
+    await mkdir(occupiedDirectory, { mode: 0o700 });
+    const occupiedConfig = profileFilePaths(occupiedDirectory).config;
+    await writeFile(occupiedConfig, '{"belongsToAnotherTool":true}\n', { mode: 0o600 });
+    await expect(loadVercelProfileData(occupiedDirectory)).rejects.toThrow(
+      "set SELFBENCH_CONFIG_DIR to another directory",
+    );
+  });
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "selfbench-profile-"));
+  roots.push(root);
+  return root;
+}

--- a/tests/vercel-setup-probe.test.ts
+++ b/tests/vercel-setup-probe.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import {
+  HOBBY_VERCEL_TIMEOUT_CAP_MS,
+  STANDARD_VERCEL_TIMEOUT_CAP_MS,
+} from "../src/sandbox-timeout.js";
+import { probeVercelCapability, type VercelSandboxProbeApi } from "../src/vercel-setup-probe.js";
+
+const credentials = {
+  token: "vcp_super_secret",
+  teamId: "team_test",
+  projectId: "prj_test",
+};
+const image = `selfbench-runtime@sha256:${"a".repeat(64)}`;
+
+class FakeProbeApi implements VercelSandboxProbeApi {
+  readonly createTimeouts: number[] = [];
+  deleteCount = 0;
+  getCount = 0;
+  firstCreateError: Error | undefined;
+  commandExitCode = 0;
+  deleteError: Error | undefined;
+  getError: Error | undefined;
+  recoveredSandboxExists = false;
+
+  async create(input: Parameters<VercelSandboxProbeApi["create"]>[0]) {
+    this.createTimeouts.push(input.timeout);
+    if (this.firstCreateError) {
+      const error = this.firstCreateError;
+      this.firstCreateError = undefined;
+      throw error;
+    }
+    return {
+      name: input.name,
+      runCommand: async () => ({ exitCode: this.commandExitCode }),
+      delete: async () => {
+        this.deleteCount += 1;
+        if (this.deleteError) {
+          throw this.deleteError;
+        }
+      },
+    };
+  }
+
+  get(
+    _input: Parameters<VercelSandboxProbeApi["get"]>[0],
+  ): ReturnType<VercelSandboxProbeApi["get"]> {
+    this.getCount += 1;
+    if (this.getError) {
+      return Promise.reject(this.getError);
+    }
+    if (this.recoveredSandboxExists) {
+      return Promise.resolve({
+        name: "recovered",
+        runCommand: async () => ({ exitCode: 0 }),
+        delete: async () => {
+          this.deleteCount += 1;
+          this.recoveredSandboxExists = false;
+        },
+      });
+    }
+    return Promise.reject(Object.assign(new Error("not found"), { status: 404 }));
+  }
+}
+
+describe("Vercel setup capability probe", () => {
+  test("verifies command execution and terminal deletion at the standard SelfBench ceiling", async () => {
+    const api = new FakeProbeApi();
+
+    const result = await probeVercelCapability({ credentials, image }, api);
+
+    expect(result).toMatchObject({
+      timeoutCapMs: STANDARD_VERCEL_TIMEOUT_CAP_MS,
+      timeoutClass: "standard",
+    });
+    expect(api.createTimeouts).toEqual([STANDARD_VERCEL_TIMEOUT_CAP_MS]);
+    expect(api.deleteCount).toBe(1);
+    expect(api.getCount).toBe(1);
+    expect(new Date(result.checkedAt).toISOString()).toBe(result.checkedAt);
+  });
+
+  test("detects the provider's exact 45-minute response and verifies that ceiling", async () => {
+    const api = new FakeProbeApi();
+    api.firstCreateError = Object.assign(
+      new Error("Vercel Sandbox API error: `timeout` should be <= 45m"),
+      { status: 400 },
+    );
+
+    const result = await probeVercelCapability({ credentials, image }, api);
+
+    expect(result.timeoutClass).toBe("45m");
+    expect(result.timeoutCapMs).toBe(HOBBY_VERCEL_TIMEOUT_CAP_MS);
+    expect(api.createTimeouts).toEqual([
+      STANDARD_VERCEL_TIMEOUT_CAP_MS,
+      HOBBY_VERCEL_TIMEOUT_CAP_MS,
+    ]);
+    expect(api.deleteCount).toBe(1);
+  });
+
+  test("does not misclassify other failures and redacts the access token", async () => {
+    const api = new FakeProbeApi();
+    api.firstCreateError = Object.assign(new Error(`unauthorized ${credentials.token}`), {
+      status: 401,
+    });
+
+    const failure = probeVercelCapability({ credentials, image }, api);
+
+    await expect(failure).rejects.toThrow("unauthorized [redacted]");
+    await expect(failure).rejects.not.toThrow(credentials.token);
+    expect(api.createTimeouts).toEqual([STANDARD_VERCEL_TIMEOUT_CAP_MS]);
+  });
+
+  test("recovers a lost delete response when exact-name lookup confirms absence", async () => {
+    const api = new FakeProbeApi();
+    api.deleteError = new Error("delete unavailable");
+
+    await expect(probeVercelCapability({ credentials, image }, api)).resolves.toMatchObject({
+      timeoutClass: "standard",
+    });
+    expect(api.getCount).toBe(1);
+  });
+
+  test("recovers an exact-name allocation after losing the create response", async () => {
+    const api = new FakeProbeApi();
+    api.firstCreateError = new Error("connection lost after allocation");
+    api.recoveredSandboxExists = true;
+
+    await expect(probeVercelCapability({ credentials, image }, api)).rejects.toThrow(
+      "connection lost after allocation",
+    );
+    expect(api.deleteCount).toBe(1);
+    expect(api.recoveredSandboxExists).toBe(false);
+    expect(api.getCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("fails setup when its temporary sandbox cannot be cleaned up or recovered", async () => {
+    const api = new FakeProbeApi();
+    api.deleteError = new Error("delete unavailable");
+    api.getError = Object.assign(new Error("recovery unavailable"), { status: 503 });
+
+    await expect(probeVercelCapability({ credentials, image }, api)).rejects.toThrow(
+      "could not be deleted cleanly",
+    );
+  });
+});

--- a/tests/vercel-setup.test.ts
+++ b/tests/vercel-setup.test.ts
@@ -270,13 +270,19 @@ describe("self-bench setup vercel", () => {
     expect(observedToken).toBe("stored-token");
   });
 
-  test("protects an unrelated VCR repository and accepts an explicit replacement name", async () => {
+  test("protects a mixed VCR repository and accepts an explicit replacement name", async () => {
     const directory = await configDirectory();
+    const fingerprint = await vercelRuntimeFingerprint(repositoryRoot);
     const cli = new FakeCli();
     cli.projects.push({ id: "prj_existing", name: "existing" });
     cli.repositories.add("selfbench-runtime");
     cli.tags.set("selfbench-runtime", [
       { tag: "production", manifestDigest: `sha256:${"d".repeat(64)}`, status: "ready" },
+      {
+        tag: `selfbench-${fingerprint}`,
+        manifestDigest: `sha256:${"e".repeat(64)}`,
+        status: "ready",
+      },
     ]);
     const prompter = new FakePrompter();
     prompter.selections.push(team.id, "existing", "prj_existing");
@@ -289,7 +295,7 @@ describe("self-bench setup vercel", () => {
     );
 
     expect(result.profile.vcrRepository).toBe("selfbench-runtime-2");
-    expect(cli.tags.get("selfbench-runtime")).toHaveLength(1);
+    expect(cli.tags.get("selfbench-runtime")).toHaveLength(2);
     expect(cli.builds).toEqual([
       {
         repository: "selfbench-runtime-2",

--- a/tests/vercel-setup.test.ts
+++ b/tests/vercel-setup.test.ts
@@ -1,0 +1,547 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CommandOutputHandler } from "../src/process.js";
+import {
+  HOBBY_VERCEL_TIMEOUT_CAP_MS,
+  STANDARD_VERCEL_TIMEOUT_CAP_MS,
+} from "../src/sandbox-timeout.js";
+import type { PromptChoice, SetupPrompter } from "../src/terminal-prompts.js";
+import type { SetupReporter, SetupTaskLabels } from "../src/terminal-reporter.js";
+import type { VcrTag, VercelProject, VercelTeam } from "../src/vercel-cli.js";
+import { loadVercelProfileData, saveVercelProfile } from "../src/vercel-profile.js";
+import { vercelRuntimeFingerprint } from "../src/vercel-runtime-image.js";
+import { setupVercel, type VercelSetupCli, type VercelSetupServices } from "../src/vercel-setup.js";
+
+const roots: string[] = [];
+const repositoryRoot = join(import.meta.dir, "..");
+const digest = `sha256:${"c".repeat(64)}`;
+const team: VercelTeam = {
+  id: "team_test",
+  slug: "test-team",
+  name: "Test Team",
+  current: true,
+};
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+class FakePrompter implements SetupPrompter {
+  readonly selections: string[] = [];
+  readonly texts: string[] = [];
+  readonly secrets: string[] = [];
+  readonly confirmations: boolean[] = [];
+  secretPrompts = 0;
+
+  async select(
+    _message: string,
+    choices: readonly PromptChoice[],
+    defaultValue?: string,
+  ): Promise<string> {
+    const selected = this.selections.shift() ?? defaultValue ?? choices[0]?.value;
+    if (!selected || !choices.some(({ value }) => value === selected)) {
+      throw new Error(`invalid fake selection ${selected}`);
+    }
+    return selected;
+  }
+
+  async search(
+    message: string,
+    choices: readonly PromptChoice[],
+    defaultValue?: string,
+  ): Promise<string> {
+    return await this.select(message, choices, defaultValue);
+  }
+
+  async text(_message: string, defaultValue?: string): Promise<string> {
+    const value = this.texts.shift();
+    return value === undefined || value === "" ? (defaultValue ?? "") : value;
+  }
+
+  async secret(_message: string): Promise<string> {
+    this.secretPrompts += 1;
+    return this.secrets.shift() ?? "vcp_project_secret";
+  }
+
+  async confirm(_message: string, defaultValue: boolean): Promise<boolean> {
+    return this.confirmations.shift() ?? defaultValue;
+  }
+}
+
+class FakeReporter implements SetupReporter {
+  constructor(readonly logs: string[]) {}
+
+  intro(title: string): void {
+    this.logs.push(title);
+  }
+
+  message(message: string): void {
+    this.logs.push(message);
+  }
+
+  warn(message: string): void {
+    this.logs.push(message);
+  }
+
+  cancel(message: string): void {
+    this.logs.push(message);
+  }
+
+  async task<T>(
+    labels: SetupTaskLabels,
+    operation: (onOutput: CommandOutputHandler) => Promise<T>,
+  ): Promise<T> {
+    this.logs.push(labels.pending);
+    const result = await operation(() => undefined);
+    this.logs.push(labels.success);
+    return result;
+  }
+
+  finish(title: string, details: readonly string[]): void {
+    this.logs.push(title, ...details);
+  }
+}
+
+class FakeCli implements VercelSetupCli {
+  readonly teams: VercelTeam[] = [team];
+  readonly projects: VercelProject[] = [];
+  readonly repositories = new Set<string>();
+  readonly tags = new Map<string, VcrTag[]>();
+  readonly inspectResults: Array<VcrTag | undefined> = [];
+  readonly builds: Array<{ repository: string; tag: string }> = [];
+  availableChecks = 0;
+  loginChecks = 0;
+  createProjectError: Error | undefined;
+  createRepositoryErrorAfterCreate: Error | undefined;
+
+  async ensureAvailable(): Promise<void> {
+    this.availableChecks += 1;
+  }
+
+  async ensureLoggedIn(): Promise<void> {
+    this.loginChecks += 1;
+  }
+
+  async listTeams(): Promise<readonly VercelTeam[]> {
+    return this.teams;
+  }
+
+  async listProjects(_teamSlug: string): Promise<readonly VercelProject[]> {
+    return this.projects;
+  }
+
+  async createProject(_teamSlug: string, projectName: string): Promise<VercelProject> {
+    if (this.createProjectError) {
+      throw this.createProjectError;
+    }
+    const project = { id: `prj_${projectName}`, name: projectName };
+    this.projects.push(project);
+    return project;
+  }
+
+  async repositoryExists(input: { readonly repository: string }): Promise<boolean> {
+    return this.repositories.has(input.repository);
+  }
+
+  async createRepository(input: { readonly repository: string }): Promise<void> {
+    this.repositories.add(input.repository);
+    this.tags.set(input.repository, []);
+    if (this.createRepositoryErrorAfterCreate) {
+      const error = this.createRepositoryErrorAfterCreate;
+      this.createRepositoryErrorAfterCreate = undefined;
+      throw error;
+    }
+  }
+
+  async listTags(input: { readonly repository: string }): Promise<readonly VcrTag[]> {
+    return this.tags.get(input.repository) ?? [];
+  }
+
+  async inspectTag(input: {
+    readonly repository: string;
+    readonly tag: string;
+  }): Promise<VcrTag | undefined> {
+    if (this.inspectResults.length > 0) {
+      return this.inspectResults.shift();
+    }
+    return this.tags.get(input.repository)?.find(({ tag }) => tag === input.tag);
+  }
+
+  async buildImage(input: { readonly repository: string; readonly tag: string }): Promise<void> {
+    this.builds.push({ repository: input.repository, tag: input.tag });
+    this.tags.set(input.repository, [{ tag: input.tag, manifestDigest: digest, status: "ready" }]);
+  }
+}
+
+describe("self-bench setup vercel", () => {
+  test("creates a dedicated project, publishes the runtime once, probes, and activates securely", async () => {
+    const directory = await configDirectory();
+    const cli = new FakeCli();
+    const prompter = new FakePrompter();
+    const logs: string[] = [];
+    const probeTokens: string[] = [];
+    const services = makeServices(cli, prompter, logs, async ({ credentials }) => {
+      probeTokens.push(credentials.token);
+      return standardCapability();
+    });
+
+    const result = await setupVercel(
+      {
+        environment: { SELFBENCH_CONFIG_DIR: directory },
+        projectRoot: repositoryRoot,
+      },
+      services,
+    );
+
+    expect(result.projectCreated).toBe(true);
+    expect(result.imagePublished).toBe(true);
+    expect(result.profile.projectName).toBe("selfbench-sandbox");
+    expect(result.profile.vcrRepository).toBe("selfbench-runtime");
+    expect(result.profile.image).toBe(`selfbench-runtime@${digest}`);
+    expect(result.profile.timeoutCapMs).toBe(STANDARD_VERCEL_TIMEOUT_CAP_MS);
+    expect(cli.builds).toHaveLength(1);
+    expect(cli.availableChecks).toBe(1);
+    expect(cli.loginChecks).toBe(1);
+    expect(probeTokens).toEqual(["vcp_project_secret"]);
+    expect(logs).toContain("https://vercel.com/account/settings/tokens");
+    expect(logs.join("\n")).not.toContain("/~/settings/tokens");
+    expect(logs).toContain("Timeout cap: 2h");
+    expect(logs).toContain("Vercel tier: Pro/Enterprise-compatible");
+    expect(logs.some((line) => line.startsWith("Reason:"))).toBe(false);
+    expect(logs).toContain("Runtime image: selfbench-runtime");
+    expect(logs).toContain(`  ${digest}`);
+
+    const stored = await loadVercelProfileData(directory);
+    expect(stored.activeVercelProfile).toBe("default");
+    expect(stored.profiles.default).toEqual(result.profile);
+    expect(stored.tokens.default).toBe("vcp_project_secret");
+    expect(logs.join("\n")).not.toContain("vcp_project_secret");
+  });
+
+  test("revalidates an existing profile without republishing or asking for its token", async () => {
+    const directory = await configDirectory();
+    const fingerprint = await vercelRuntimeFingerprint(repositoryRoot);
+    const cli = new FakeCli();
+    cli.projects.push({ id: "prj_existing", name: "existing" });
+    cli.repositories.add("selfbench-runtime");
+    cli.tags.set("selfbench-runtime", [
+      {
+        tag: `selfbench-${fingerprint}`,
+        manifestDigest: digest,
+        status: "ready",
+      },
+    ]);
+    await saveVercelProfile({
+      directory,
+      profileName: "default",
+      token: "stored-token",
+      profile: {
+        teamId: team.id,
+        teamSlug: team.slug,
+        teamName: team.name,
+        projectId: "prj_existing",
+        projectName: "old-name",
+        vcrRepository: "selfbench-runtime",
+        image: `selfbench-runtime@${digest}`,
+        runtimeFingerprint: fingerprint,
+        timeoutCapMs: STANDARD_VERCEL_TIMEOUT_CAP_MS,
+        capabilityCheckedAt: "2026-08-16T12:00:00.000Z",
+      },
+    });
+    const prompter = new FakePrompter();
+    prompter.selections.push("revalidate");
+    let observedToken = "";
+    const services = makeServices(cli, prompter, [], async ({ credentials }) => {
+      observedToken = credentials.token;
+      return standardCapability();
+    });
+
+    const result = await setupVercel(
+      { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+      services,
+    );
+
+    expect(result.imagePublished).toBe(false);
+    expect(result.profile.projectName).toBe("existing");
+    expect(cli.builds).toHaveLength(0);
+    expect(prompter.secretPrompts).toBe(0);
+    expect(observedToken).toBe("stored-token");
+  });
+
+  test("protects an unrelated VCR repository and accepts an explicit replacement name", async () => {
+    const directory = await configDirectory();
+    const cli = new FakeCli();
+    cli.projects.push({ id: "prj_existing", name: "existing" });
+    cli.repositories.add("selfbench-runtime");
+    cli.tags.set("selfbench-runtime", [
+      { tag: "production", manifestDigest: `sha256:${"d".repeat(64)}`, status: "ready" },
+    ]);
+    const prompter = new FakePrompter();
+    prompter.selections.push(team.id, "existing", "prj_existing");
+    prompter.texts.push("Invalid/Repository", "selfbench-runtime-2");
+    const logs: string[] = [];
+
+    const result = await setupVercel(
+      { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+      makeServices(cli, prompter, logs),
+    );
+
+    expect(result.profile.vcrRepository).toBe("selfbench-runtime-2");
+    expect(cli.tags.get("selfbench-runtime")).toHaveLength(1);
+    expect(cli.builds).toEqual([
+      {
+        repository: "selfbench-runtime-2",
+        tag: `selfbench-${result.profile.runtimeFingerprint}`,
+      },
+    ]);
+    expect(logs.join("\n")).toContain("contains unrelated images");
+    expect(logs.join("\n")).toContain("VCR repository names require");
+  });
+
+  test("recovers when VCR repository creation succeeds but its response is lost", async () => {
+    const directory = await configDirectory();
+    const cli = new FakeCli();
+    cli.createRepositoryErrorAfterCreate = new Error("connection lost after create");
+
+    const result = await setupVercel(
+      { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+      makeServices(cli, new FakePrompter(), []),
+    );
+
+    expect(result.imagePublished).toBe(true);
+    expect(cli.builds).toHaveLength(1);
+    expect(cli.repositories.has("selfbench-runtime")).toBe(true);
+  });
+
+  test("rebuilds an unusable OCI index instead of saving its digest", async () => {
+    const directory = await configDirectory();
+    const fingerprint = await vercelRuntimeFingerprint(repositoryRoot);
+    const cli = new FakeCli();
+    cli.repositories.add("selfbench-runtime");
+    cli.tags.set("selfbench-runtime", [
+      {
+        tag: `selfbench-${fingerprint}`,
+        manifestDigest: `sha256:${"e".repeat(64)}`,
+        kind: "index",
+        status: null,
+      },
+    ]);
+    const logs: string[] = [];
+
+    const result = await setupVercel(
+      { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+      makeServices(cli, new FakePrompter(), logs),
+    );
+
+    expect(result.imagePublished).toBe(true);
+    expect(result.profile.image).toBe(`selfbench-runtime@${digest}`);
+    expect(cli.builds).toHaveLength(1);
+    expect(logs.join("\n")).toContain("unsupported OCI index");
+  });
+
+  test("rebuilds an unoptimized manifest instead of treating it as Sandbox-ready", async () => {
+    const directory = await configDirectory();
+    const fingerprint = await vercelRuntimeFingerprint(repositoryRoot);
+    const cli = new FakeCli();
+    cli.repositories.add("selfbench-runtime");
+    cli.tags.set("selfbench-runtime", [
+      {
+        tag: `selfbench-${fingerprint}`,
+        manifestDigest: `sha256:${"e".repeat(64)}`,
+        kind: "manifest",
+        status: "unoptimized",
+      },
+    ]);
+    const logs: string[] = [];
+
+    const result = await setupVercel(
+      { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+      makeServices(cli, new FakePrompter(), logs),
+    );
+
+    expect(result.imagePublished).toBe(true);
+    expect(result.profile.image).toBe(`selfbench-runtime@${digest}`);
+    expect(cli.builds).toHaveLength(1);
+    expect(logs.join("\n")).toContain("unoptimized");
+  });
+
+  test("waits for an unclassified manifest instead of rebuilding its immutable tag", async () => {
+    const directory = await configDirectory();
+    const fingerprint = await vercelRuntimeFingerprint(repositoryRoot);
+    const cli = new FakeCli();
+    const tag = `selfbench-${fingerprint}`;
+    cli.repositories.add("selfbench-runtime");
+    cli.tags.set("selfbench-runtime", [
+      {
+        tag,
+        manifestDigest: digest,
+        kind: "manifest",
+        status: null,
+      },
+    ]);
+    cli.inspectResults.push({ tag, manifestDigest: digest, kind: "manifest", status: "ready" });
+
+    const result = await setupVercel(
+      { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+      makeServices(cli, new FakePrompter(), []),
+    );
+
+    expect(result.imagePublished).toBe(false);
+    expect(cli.builds).toHaveLength(0);
+  });
+
+  test("re-prompts for an unavailable project name but surfaces unrelated creation failures", async () => {
+    const directory = await configDirectory();
+    const cli = new FakeCli();
+    cli.projects.push({ id: "prj_taken", name: "selfbench-sandbox" });
+    const prompter = new FakePrompter();
+    prompter.texts.push("bad---name", "", "selfbench-custom");
+    const logs: string[] = [];
+
+    const result = await setupVercel(
+      { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+      makeServices(cli, prompter, logs),
+    );
+
+    expect(result.profile.projectName).toBe("selfbench-custom");
+    expect(logs.join("\n")).toContain("cannot contain three consecutive hyphens");
+    expect(logs.join("\n")).toContain("already in use");
+
+    const failedDirectory = await configDirectory();
+    const failingCli = new FakeCli();
+    failingCli.createProjectError = new Error("billing disabled");
+    await expect(
+      setupVercel(
+        {
+          environment: { SELFBENCH_CONFIG_DIR: failedDirectory },
+          projectRoot: repositoryRoot,
+        },
+        makeServices(failingCli, new FakePrompter(), []),
+      ),
+    ).rejects.toThrow('Unable to create project "selfbench-sandbox": billing disabled');
+  });
+
+  test("records the 45-minute cap only after explicit confirmation", async () => {
+    const directory = await configDirectory();
+    const cli = new FakeCli();
+    const prompter = new FakePrompter();
+    prompter.confirmations.push(true);
+    const logs: string[] = [];
+    const capability = {
+      timeoutCapMs: HOBBY_VERCEL_TIMEOUT_CAP_MS,
+      timeoutClass: "45m" as const,
+      checkedAt: "2026-08-16T13:00:00.000Z",
+    };
+
+    const result = await setupVercel(
+      { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+      makeServices(cli, prompter, logs, async () => capability),
+    );
+
+    expect(result.profile.timeoutCapMs).toBe(HOBBY_VERCEL_TIMEOUT_CAP_MS);
+    expect((await loadVercelProfileData(directory)).profiles.default?.timeoutCapMs).toBe(
+      HOBBY_VERCEL_TIMEOUT_CAP_MS,
+    );
+    expect(logs.join("\n")).toContain("45-minute Sandbox limit");
+    expect(logs.join("\n")).toContain("personal, non-commercial");
+    expect(logs).toContain("Timeout cap: 45m");
+    expect(logs).toContain("Vercel tier: Hobby-compatible");
+  });
+
+  test("does not activate a profile when capability confirmation is declined", async () => {
+    const directory = await configDirectory();
+    const cli = new FakeCli();
+    const prompter = new FakePrompter();
+    prompter.confirmations.push(false);
+
+    await expect(
+      setupVercel(
+        { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+        makeServices(cli, prompter, [], async () => ({
+          timeoutCapMs: HOBBY_VERCEL_TIMEOUT_CAP_MS,
+          timeoutClass: "45m",
+          checkedAt: "2026-08-16T13:00:00.000Z",
+        })),
+      ),
+    ).rejects.toThrow("canceled before profile activation");
+
+    expect((await loadVercelProfileData(directory)).profiles).toEqual({});
+  });
+
+  test("does not activate a profile when token verification fails and explains replacement", async () => {
+    const directory = await configDirectory();
+
+    await expect(
+      setupVercel(
+        { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+        makeServices(new FakeCli(), new FakePrompter(), [], async () => {
+          throw new Error("401 unauthorized");
+        }),
+      ),
+    ).rejects.toThrow("paste a new project-scoped token");
+
+    expect((await loadVercelProfileData(directory)).profiles).toEqual({});
+  });
+
+  test("fails before external work outside a TTY and explains environment-only setup", async () => {
+    const directory = await configDirectory();
+    const cli = new FakeCli();
+    const services = { ...makeServices(cli, new FakePrompter(), []), interactive: false };
+
+    await expect(
+      setupVercel(
+        { environment: { SELFBENCH_CONFIG_DIR: directory }, projectRoot: repositoryRoot },
+        services,
+      ),
+    ).rejects.toThrow("requires an interactive terminal");
+    expect(cli.availableChecks).toBe(0);
+  });
+
+  test("fingerprints every current image input and refuses to ignore future local copies", async () => {
+    const first = await vercelRuntimeFingerprint(repositoryRoot);
+    const second = await vercelRuntimeFingerprint(repositoryRoot);
+    expect(first).toBe(second);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+
+    const root = await mkdtemp(join(tmpdir(), "selfbench-vcr-fingerprint-"));
+    roots.push(root);
+    await writeFile(join(root, "Dockerfile.sandbox"), "FROM node:22\nCOPY package.json /work/\n");
+    await expect(vercelRuntimeFingerprint(root)).rejects.toThrow(
+      "update the VCR fingerprint inputs",
+    );
+  });
+});
+
+function makeServices(
+  cli: FakeCli,
+  prompter: FakePrompter,
+  logs: string[],
+  probe: VercelSetupServices["probe"] = async () => standardCapability(),
+): VercelSetupServices {
+  return {
+    cli,
+    prompter,
+    reporter: new FakeReporter(logs),
+    interactive: true,
+    loadProfiles: loadVercelProfileData,
+    saveProfile: saveVercelProfile,
+    probe,
+    sleep: async () => undefined,
+  };
+}
+
+function standardCapability() {
+  return {
+    timeoutCapMs: STANDARD_VERCEL_TIMEOUT_CAP_MS,
+    timeoutClass: "standard" as const,
+    checkedAt: "2026-08-16T13:00:00.000Z",
+  };
+}
+
+async function configDirectory(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "selfbench-setup-"));
+  roots.push(root);
+  return join(root, ".selfbench");
+}


### PR DESCRIPTION
## Summary

- add an interactive `self-bench setup vercel` flow with searchable team and project selection
- create or select a project, publish or reuse the pinned runtime in Vercel Container Registry, and verify image readiness
- securely save named local profiles with owner-only permissions and resolve them from `self-bench up --backend vercel`
- verify the project-scoped access token with a disposable live sandbox and detect the effective 45-minute or 2-hour ceiling
- add compact timed progress, optional verbose subprocess output, and graceful Ctrl-C or Escape cancellation
- preserve complete environment-only configuration for CI and unattended deployments

## Stack

Depends on #36. This PR contains only the guided setup, profile, VCR publication, terminal UX, and associated documentation layered on the core backend.

## Validation

- [x] Biome and both TypeScript projects
- [x] 165 unit and contract tests
- [x] production build and package verification
- [x] successful real setup for both the default profile and an isolated named profile
- [x] profile-resolved Next.js E2E with no ambient `VERCEL_*` variables: Vercel generation to Modal Harbor, one accepted task, verified export metadata and checksum
- [x] all ten E2E sandboxes deleted, zero snapshots remaining, and Modal Harbor returned to zero tasks

## User flow

The command uses the installed Vercel CLI login for team, project, and VCR operations, then asks the user to paste a project-scoped access token. Re-running setup can revalidate the saved profile, replace its token, or choose another team or project. Named profiles are selectable with `--vercel-profile`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 68d40850c3cfeee8a6b2840628d3241f7f2bc472. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->