### PR TITLE
Fix npm application-image build context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,5 @@ jobs:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile
       - run: bun run validate
+      - name: Verify packed application build stage
+        run: bun run verify:package:docker

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,6 +32,8 @@ jobs:
 
       - run: bun install --frozen-lockfile
       - run: bun run validate
+      - name: Verify packed application build stage
+        run: bun run verify:package:docker
       - name: Verify tag matches package version
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "files": [
     "dist",
     "src",
+    "review",
     "docs",
     "compose.yaml",
     "Dockerfile",
@@ -47,6 +48,7 @@
     "prepack": "bun run build",
     "prepublishOnly": "bun run validate",
     "verify:package": "bun scripts/verify-package.ts",
+    "verify:package:docker": "bun scripts/verify-package.ts --docker-build",
     "check": "biome check . && tsc --noEmit -p tsconfig.json && bun run typecheck:review",
     "dev:api": "tsx src/api-main.ts",
     "dev:review": "vite --config review/vite.config.ts",

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -2,8 +2,14 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
+const options = process.argv.slice(2);
+const dockerBuild = options.length === 1 && options[0] === "--docker-build";
+if (options.length > 0 && !dockerBuild) {
+  throw new Error(`unknown verify-package argument: ${options.join(" ")}`);
+}
 const root = resolve(import.meta.dir, "..");
 const temporary = await mkdtemp(join(tmpdir(), "self-bench-package-"));
+
 async function run(command: string, args: string[], cwd = root): Promise<string> {
   const child = Bun.spawn([command, ...args], {
     cwd,
@@ -42,14 +48,32 @@ try {
   if (!help.includes("self-bench up")) {
     throw new Error("installed self-bench did not print the expected CLI help");
   }
-  for (const asset of ["compose.yaml", "Dockerfile", "Dockerfile.sandbox", "src/skills/selfbench/SKILL.md"]) {
-    await readFile(join(installRoot, "node_modules", packageJson.name, asset));
+  const installedRoot = join(installRoot, "node_modules", packageJson.name);
+  for (const asset of [
+    ".dockerignore",
+    "compose.yaml",
+    "Dockerfile",
+    "Dockerfile.sandbox",
+    "review/index.html",
+    "review/src/App.tsx",
+    "review/vite.config.ts",
+    "src/extensions/authoring.ts",
+    "src/skills/selfbench/SKILL.md",
+  ]) {
+    await readFile(join(installedRoot, asset));
   }
   const installedPackage = JSON.parse(
-    await readFile(join(installRoot, "node_modules", packageJson.name, "package.json"), "utf8"),
+    await readFile(join(installedRoot, "package.json"), "utf8"),
   ) as { name: string; version: string };
   if (installedPackage.name !== packageJson.name || installedPackage.version !== packageJson.version) {
     throw new Error("installed package metadata does not match the workspace package");
+  }
+  if (dockerBuild) {
+    await run(
+      "docker",
+      ["build", "--target", "build", "--file", join(installedRoot, "Dockerfile"), installedRoot],
+      installedRoot,
+    );
   }
   console.log(`verified ${installedPackage.name}@${installedPackage.version}`);
 } finally {


### PR DESCRIPTION
## Summary

- include the review UI source in the npm package so the shipped Dockerfile can build
- verify required application build inputs from the packed-and-installed artifact
- Docker-build the packed artifact's application builder stage in PR and publishing CI

## Regression

`self-bench up` resolves Compose and its Docker build context from the installed npm package. Since v0.3.3, the Dockerfile has copied `review/`, but the npm `files` allowlist omitted it. Repository builds passed while globally installed packages failed before any backend started.

## Validation

- `bun run verify:package`
- `bun run verify:package:docker`
- TypeScript checks for server and review UI
- 168/168 tests
- production build
- npm dry-run contains all nine `review/` source files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0fe7c10622b62ed39b577089bb97c9c694b48dd2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->