### PR TITLE
Make the README sandbox-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 It finds completed requests from local coding sessions and merged GitHub pull requests, then reconstructs each task from the commit before the change. For every accepted task, self-bench creates hidden tests and a reference solution, proves that the task fails without a solution and passes with the original implementation, and exports a native task for [Harbor](https://harborframework.com/), a runner for coding-agent evaluations.
 
+SelfBench is sandbox-agnostic: run generation locally with Docker or on Modal or Vercel Sandbox. Generation and Harbor validation are configured independently, so Modal is optional.
+
 The result is a private `.tar.gz` benchmark that you can run against multiple models:
 
 ```text
@@ -24,22 +26,21 @@ gpt-5.6-luna vs gpt-5.6-terra vs gpt-5.6-sol
 
 ## Quickstart
 
-This path runs the self-bench API, worker, and [Temporal](https://temporal.io/) workflow state locally while using [Modal](https://modal.com/) for disposable task-generation and validation sandboxes.
+This path runs the self-bench API, worker, [Temporal](https://temporal.io/), and all generation and validation sandboxes locally with Docker. It does not require an account with a hosted sandbox provider.
 
 ### Prerequisites
 
 - [Bun](https://bun.sh/) 1.3.14 or newer
+- [uv](https://docs.astral.sh/uv/) for installing Harbor
 - Docker with Compose
-- [Modal](https://modal.com/) CLI, account, and token (`pip install modal`)
 - [`gh`](https://cli.github.com/), authenticated with read access to the repository
 - An OpenAI API key with access to `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
 - A Git checkout with a GitHub `origin` and completed work in its history
 
-Install self-bench and authenticate Modal and GitHub:
+Install self-bench and authenticate GitHub:
 
 ```bash
 bun add --global self-bench
-modal token new
 gh auth login
 ```
 
@@ -54,11 +55,11 @@ export SELFBENCH_API_TOKEN="$(openssl rand -hex 24)"
 ### 1. Start self-bench
 
 ```bash
-self-bench up --backend modal
+self-bench up --backend docker
 export SELFBENCH_API_URL=http://127.0.0.1:8080
 ```
 
-This starts Postgres, Temporal, the self-bench API, and a worker in Docker. The worker sends sandbox work to Modal; `SELFBENCH_API_URL` tells subsequent CLI commands where to reach the local API.
+This starts Postgres, Temporal, the self-bench API, and a worker. The worker creates disposable local Docker sandboxes; `SELFBENCH_API_URL` tells subsequent CLI commands where to reach the local API.
 
 ### 2. Build a benchmark
 
@@ -80,7 +81,7 @@ The repository must be a Git checkout with a GitHub `origin`. self-bench pins it
 Install Harbor and extract the generated tasks:
 
 ```bash
-uv tool install --python 3.12 'harbor[modal]==0.20.1.dev202608040148'
+uv tool install --python 3.12 'harbor==0.20.1.dev202608040148'
 
 mkdir -p ./self-bench-export ./self-bench-tasks
 tar -xzf ./self-bench-evals.tar.gz -C ./self-bench-export
@@ -102,9 +103,9 @@ harbor run \
   --model gpt-5.6-sol \
   --ak version=0.146.1 \
   --ak reasoning_effort=high \
-  --env modal \
+  --env docker \
   --jobs-dir ./harbor-jobs \
-  --n-concurrent 20 \
+  --n-concurrent 1 \
   --yes
 ```
 
@@ -131,15 +132,16 @@ self-bench down
 
 Named Docker volumes retain Temporal history and generated artifacts.
 
-## Other deployments
+## Choose a sandbox backend
 
-The quickstart is the recommended setup: a local stack with Modal sandboxes.
+The quickstart uses local Docker sandboxes so it works without a hosted sandbox account. For more concurrency or unattended runs, generation can use Modal or Vercel Sandbox instead:
 
-- **Local stack + Docker sandboxes:** use `self-bench up --backend docker` when you want all execution on your machine.
-- **Local stack + Vercel Sandbox:** run `self-bench setup vercel`, then explicitly choose Docker or Modal for Harbor validation.
+- **Docker:** `self-bench up --backend docker` keeps generation and validation on your machine.
+- **Modal:** authenticate with `modal token new`, then run `self-bench up --backend modal`.
+- **Vercel Sandbox:** run `self-bench setup vercel`, then choose Docker or Modal for Harbor validation.
 - **Temporal Cloud + Modal:** use this for persistent unattended workers and large repositories.
 
-See [Operations and deployment](docs/operations.md) for backend configuration, credentials, persistence, object storage, and the complete Temporal Cloud deployment.
+See [Operations and deployment](docs/operations.md) for provider setup, credentials, persistence, object storage, and Temporal Cloud deployment.
 
 Generation sandboxes and Harbor validation are independent choices. Docker and Modal retain their matching defaults; Vercel must name a Harbor environment because Harbor does not currently provide a Vercel environment:
 


### PR DESCRIPTION
## Summary
Make the default README path work without a hosted sandbox account and clearly describe SelfBench as sandbox-agnostic.

- Use local Docker for the quickstart and Harbor example.
- Present Docker, Modal, and Vercel Sandbox as explicit generation choices.

## Design
### Quickstart
- `README.md` — switches the default generation and Harbor validation path from Modal to Docker, removes Modal authentication from the prerequisites, and adds the previously implicit `uv` prerequisite.
- `README.md` — uses conservative single-trial Harbor concurrency for the local Docker example so the copy-paste path does not assume hosted capacity.

### Provider selection
- `README.md` — states near the top that generation can run on Docker, Modal, or Vercel Sandbox and that Modal is optional.
- `README.md` — replaces the deployment-centric section with a provider-choice section while preserving the boundary that Vercel generation currently pairs with Docker or Modal Harbor validation.

## Validation
- `bun run check` — passed (Biome, server TypeScript, and review-app TypeScript checks).
- `uvx --from 'harbor==0.20.1.dev202608040148' harbor run --help` — verified the pinned base Harbor package exposes Docker as the default environment.
- First-reader README comprehension review completed; the reviewer correctly identified the project, its purpose, and the Docker-first setup path.
