### PR TITLE
Preserve Modal diagnostics across sandbox failures

### DIFF
--- a/src/modal-executor.ts
+++ b/src/modal-executor.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from "node:timers/promises";
 import { type Image, ModalClient, type Secret } from "modal";
 import type { SelfBenchConfig } from "./config.js";
 import { InactivityTimeoutError, RollingOutput } from "./process.js";
@@ -8,6 +9,8 @@ import {
   type SandboxResult,
   type SandboxRunOptions,
 } from "./sandbox.js";
+
+const FAILURE_DRAIN_TIMEOUT_MS = 1_000;
 
 export class ModalSandboxExecutor implements SandboxExecutor {
   readonly #client: ModalClient;
@@ -42,7 +45,9 @@ export class ModalSandboxExecutor implements SandboxExecutor {
       tags: { run_id: request.runId, stage: request.stage },
     });
 
+    let notifyFailure = (): void => {};
     const abort = () => {
+      notifyFailure();
       void sandbox.terminate();
     };
     options.signal?.addEventListener("abort", abort, { once: true });
@@ -64,8 +69,12 @@ export class ModalSandboxExecutor implements SandboxExecutor {
       await process.closeStdin();
       const stdoutOutput = new RollingOutput();
       const stderrOutput = new RollingOutput();
+      const readers = new Set<ReadableStreamDefaultReader<string | Uint8Array>>();
       let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
       let inactivityError: InactivityTimeoutError | undefined;
+      const failure = new Promise<void>((resolve) => {
+        notifyFailure = resolve;
+      });
       const clearInactivityTimer = (): void => {
         if (inactivityTimer) {
           clearTimeout(inactivityTimer);
@@ -82,7 +91,7 @@ export class ModalSandboxExecutor implements SandboxExecutor {
             `Modal sandbox ${sandbox.sandboxId} stage ${request.stage}`,
             request.inactivityTimeoutMs ?? 0,
           );
-          void sandbox.terminate();
+          notifyFailure();
         }, request.inactivityTimeoutMs);
         inactivityTimer.unref();
       };
@@ -92,6 +101,7 @@ export class ModalSandboxExecutor implements SandboxExecutor {
         output: RollingOutput,
       ): Promise<void> => {
         const reader = stream.getReader();
+        readers.add(reader);
         try {
           while (true) {
             const { value, done } = await reader.read();
@@ -106,33 +116,39 @@ export class ModalSandboxExecutor implements SandboxExecutor {
             }
           }
         } finally {
+          readers.delete(reader);
           reader.releaseLock();
         }
       };
+      let exitCode: number | undefined;
+      let processError: unknown;
+      let streamError: unknown;
+      const captureFailure = (error: unknown): void => {
+        streamError ??= error;
+        notifyFailure();
+      };
       armInactivityTimer();
-      const settled = await Promise.allSettled([
-        process.wait().catch((error: unknown) => {
-          void sandbox.terminate();
-          throw error;
-        }),
-        consume("stdout", process.stdout, stdoutOutput).catch((error: unknown) => {
-          void sandbox.terminate();
-          throw error;
-        }),
-        consume("stderr", process.stderr, stderrOutput).catch((error: unknown) => {
-          void sandbox.terminate();
-          throw error;
-        }),
-      ]).finally(clearInactivityTimer);
-      const [processResult, ...streamResults] = settled;
-      const rejectedStream = streamResults.find(
-        (result): result is PromiseRejectedResult => result.status === "rejected",
+      const completion = Promise.all([
+        process.wait().then(
+          (value) => {
+            exitCode = value;
+            notifyFailure();
+          },
+          (error: unknown) => {
+            processError = error;
+            notifyFailure();
+          },
+        ),
+        consume("stdout", process.stdout, stdoutOutput).catch(captureFailure),
+        consume("stderr", process.stderr, stderrOutput).catch(captureFailure),
+      ]);
+      await Promise.race([completion, failure.then(() => delay(FAILURE_DRAIN_TIMEOUT_MS))]).finally(
+        clearInactivityTimer,
       );
-      const executionError =
-        inactivityError ??
-        (processResult.status === "rejected" ? processResult.reason : undefined) ??
-        rejectedStream?.reason;
-      const exitCode = processResult.status === "fulfilled" ? processResult.value : 1;
+      if (readers.size > 0) {
+        void Promise.allSettled([...readers].map((reader) => reader.cancel()));
+      }
+      const executionError = inactivityError ?? processError ?? streamError;
       const outputs: Record<string, Uint8Array> = {};
       for (const path of request.outputPaths ?? []) {
         try {
@@ -144,7 +160,7 @@ export class ModalSandboxExecutor implements SandboxExecutor {
       }
       const result = {
         sandboxId: sandbox.sandboxId,
-        exitCode,
+        exitCode: exitCode ?? 1,
         stdout: stdoutOutput.text(),
         stderr: stderrOutput.text(),
         outputs,

--- a/src/modal-executor.ts
+++ b/src/modal-executor.ts
@@ -1,11 +1,12 @@
 import { type Image, ModalClient, type Secret } from "modal";
 import type { SelfBenchConfig } from "./config.js";
 import { InactivityTimeoutError, RollingOutput } from "./process.js";
-import type {
-  SandboxExecutor,
-  SandboxRequest,
-  SandboxResult,
-  SandboxRunOptions,
+import {
+  SandboxExecutionError,
+  type SandboxExecutor,
+  type SandboxRequest,
+  type SandboxResult,
+  type SandboxRunOptions,
 } from "./sandbox.js";
 
 export class ModalSandboxExecutor implements SandboxExecutor {
@@ -22,10 +23,12 @@ export class ModalSandboxExecutor implements SandboxExecutor {
   }
 
   async run(request: SandboxRequest, options: SandboxRunOptions = {}): Promise<SandboxResult> {
+    options.signal?.throwIfAborted();
     const app = await this.#client.apps.fromName(this.#config.app, {
       createIfMissing: true,
       ...(this.#config.environment ? { environment: this.#config.environment } : {}),
     });
+    options.signal?.throwIfAborted();
     if (!this.#image) {
       this.#image = this.#buildImage();
     }
@@ -44,6 +47,7 @@ export class ModalSandboxExecutor implements SandboxExecutor {
     };
     options.signal?.addEventListener("abort", abort, { once: true });
     try {
+      options.signal?.throwIfAborted();
       for (const file of request.files ?? []) {
         if (typeof file.contents === "string") {
           await sandbox.filesystem.writeText(file.contents, file.path);
@@ -106,21 +110,29 @@ export class ModalSandboxExecutor implements SandboxExecutor {
         }
       };
       armInactivityTimer();
-      const [exitCode, stdout, stderr] = await Promise.all([
-        process.wait(),
-        consume("stdout", process.stdout, stdoutOutput),
-        consume("stderr", process.stderr, stderrOutput),
-      ])
-        .then(([exitCode]) => {
-          if (inactivityError) {
-            throw inactivityError;
-          }
-          return [exitCode, stdoutOutput.text(), stderrOutput.text()] as const;
-        })
-        .catch((error: unknown) => {
-          throw inactivityError ?? error;
-        })
-        .finally(clearInactivityTimer);
+      const settled = await Promise.allSettled([
+        process.wait().catch((error: unknown) => {
+          void sandbox.terminate();
+          throw error;
+        }),
+        consume("stdout", process.stdout, stdoutOutput).catch((error: unknown) => {
+          void sandbox.terminate();
+          throw error;
+        }),
+        consume("stderr", process.stderr, stderrOutput).catch((error: unknown) => {
+          void sandbox.terminate();
+          throw error;
+        }),
+      ]).finally(clearInactivityTimer);
+      const [processResult, ...streamResults] = settled;
+      const rejectedStream = streamResults.find(
+        (result): result is PromiseRejectedResult => result.status === "rejected",
+      );
+      const executionError =
+        inactivityError ??
+        (processResult.status === "rejected" ? processResult.reason : undefined) ??
+        rejectedStream?.reason;
+      const exitCode = processResult.status === "fulfilled" ? processResult.value : 1;
       const outputs: Record<string, Uint8Array> = {};
       for (const path of request.outputPaths ?? []) {
         try {
@@ -130,7 +142,21 @@ export class ModalSandboxExecutor implements SandboxExecutor {
           // absent output keeps the model or command failure diagnosable.
         }
       }
-      return { sandboxId: sandbox.sandboxId, exitCode, stdout, stderr, outputs };
+      const result = {
+        sandboxId: sandbox.sandboxId,
+        exitCode,
+        stdout: stdoutOutput.text(),
+        stderr: stderrOutput.text(),
+        outputs,
+      };
+      if (executionError) {
+        throw new SandboxExecutionError(
+          `${executionError instanceof Error ? executionError.message : String(executionError)}; sandbox ${sandbox.sandboxId}`,
+          result,
+          { cause: executionError },
+        );
+      }
+      return result;
     } finally {
       options.signal?.removeEventListener("abort", abort);
       await sandbox.terminate().catch(() => undefined);

--- a/src/modal-executor.ts
+++ b/src/modal-executor.ts
@@ -132,7 +132,6 @@ export class ModalSandboxExecutor implements SandboxExecutor {
         process.wait().then(
           (value) => {
             exitCode = value;
-            notifyFailure();
           },
           (error: unknown) => {
             processError = error;

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -41,6 +41,17 @@ export interface SandboxResult {
   readonly outputs: Readonly<Record<string, Uint8Array>>;
 }
 
+export class SandboxExecutionError extends Error {
+  constructor(
+    message: string,
+    readonly result: SandboxResult,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "SandboxExecutionError";
+  }
+}
+
 export interface SandboxExecutor {
   run(request: SandboxRequest, options?: SandboxRunOptions): Promise<SandboxResult>;
   close(): void;

--- a/src/temporal/activities.ts
+++ b/src/temporal/activities.ts
@@ -44,7 +44,13 @@ import { refreshHarborTask } from "../harbor-task.js";
 import { sha256 } from "../hash.js";
 import { runCommand } from "../process.js";
 import { assertProvenanceMatchesPullRequest, type ProvenanceMessage } from "../provenance.js";
-import { createSandboxExecutor, type SandboxExecutor, type SandboxRunOptions } from "../sandbox.js";
+import {
+  createSandboxExecutor,
+  SandboxExecutionError,
+  type SandboxExecutor,
+  type SandboxResult,
+  type SandboxRunOptions,
+} from "../sandbox.js";
 import { githubToken, loadCodexModelAuth, loadPiModelAuth } from "../subscription-auth.js";
 
 const HARBOR_INFRASTRUCTURE_FAILURE_TYPE = "HarborInfrastructureFailure";
@@ -180,36 +186,38 @@ async function discoverCandidateShard(
     Context.current().heartbeat(
       `starting discovery wave ${input.wave} shard ${input.shardIndex} over ${shard.length} messages`,
     );
-    const result = await withActivityHeartbeats(
-      `running discovery wave ${input.wave} shard ${input.shardIndex}`,
-      (options) =>
-        sandbox.run(
-          {
-            runId: run.runId,
-            stage: `discover-${input.wave}-${input.shardIndex}`,
-            timeoutMs: DISCOVERY_TIMEOUT_MS,
-            inactivityTimeoutMs: AGENT_INACTIVITY_TIMEOUT_MS,
-            files: [
-              { path: "/work/discovery.ts", contents: extension },
-              { path: "/work/provenance.jsonl", contents: shardBytes },
-              { path: "/work/prompt.txt", contents: discoveryShardPrompt(input, shard.length) },
-            ],
-            outputPaths: ["/work/discovery.json"],
-            secrets: {
-              ...(piAuth.apiKey ? { OPENAI_API_KEY: piAuth.apiKey } : {}),
-              ...(piAuth.authJson ? { SELFBENCH_PI_AUTH_JSON: piAuth.authJson } : {}),
-              ...(ghToken ? { GH_TOKEN: ghToken } : {}),
+    const result = await runSandboxWithFailureLog(store, `${attemptPrefix}/modal.log`, () =>
+      withActivityHeartbeats(
+        `running discovery wave ${input.wave} shard ${input.shardIndex}`,
+        (options) =>
+          sandbox.run(
+            {
+              runId: run.runId,
+              stage: `discover-${input.wave}-${input.shardIndex}`,
+              timeoutMs: DISCOVERY_TIMEOUT_MS,
+              inactivityTimeoutMs: AGENT_INACTIVITY_TIMEOUT_MS,
+              files: [
+                { path: "/work/discovery.ts", contents: extension },
+                { path: "/work/provenance.jsonl", contents: shardBytes },
+                { path: "/work/prompt.txt", contents: discoveryShardPrompt(input, shard.length) },
+              ],
+              outputPaths: ["/work/discovery.json"],
+              secrets: {
+                ...(piAuth.apiKey ? { OPENAI_API_KEY: piAuth.apiKey } : {}),
+                ...(piAuth.authJson ? { SELFBENCH_PI_AUTH_JSON: piAuth.authJson } : {}),
+                ...(ghToken ? { GH_TOKEN: ghToken } : {}),
+              },
+              environment: {
+                SOURCE_REPO_URL: run.repository.url,
+                SOURCE_COMMIT: run.repository.commit,
+                AUTHOR_MODEL: run.authoring.model,
+                SELFBENCH_DISCOVERY_OUTPUT: "/work/discovery.json",
+              },
+              command: ["bash", "-lc", modalAgentScript("discovery.ts", "submit_discovery")],
             },
-            environment: {
-              SOURCE_REPO_URL: run.repository.url,
-              SOURCE_COMMIT: run.repository.commit,
-              AUTHOR_MODEL: run.authoring.model,
-              SELFBENCH_DISCOVERY_OUTPUT: "/work/discovery.json",
-            },
-            command: ["bash", "-lc", modalAgentScript("discovery.ts", "submit_discovery")],
-          },
-          options,
-        ),
+            options,
+          ),
+      ),
     );
     planBytes = result.outputs["/work/discovery.json"];
     logs = await store.put(
@@ -357,9 +365,9 @@ async function authorCandidate(
     githubToken(),
   ]);
   const prompt = authoringPrompt(run, candidate);
-  const result = await withActivityHeartbeats(
-    `running author sandbox for ${candidate.candidateId}`,
-    (options) =>
+  const attemptLogKey = `runs/${run.runId}/authoring/${candidate.candidateId}/attempt-${Context.current().info.attempt}/modal.log`;
+  const result = await runSandboxWithFailureLog(store, attemptLogKey, () =>
+    withActivityHeartbeats(`running author sandbox for ${candidate.candidateId}`, (options) =>
       sandbox.run(
         {
           runId: run.runId,
@@ -389,9 +397,10 @@ async function authorCandidate(
         },
         options,
       ),
+    ),
   );
   const log = await store.put(
-    `runs/${run.runId}/authoring/${candidate.candidateId}/attempt-${Context.current().info.attempt}/modal.log`,
+    attemptLogKey,
     Buffer.from(`${result.stdout}\n${result.stderr}`),
     "text/plain",
   );
@@ -985,9 +994,9 @@ function modalAgentScript(extension: string, tool: string): string {
   return `${sandboxBootstrap()}
 clone_source
 cd /work/repo
-pi --print --mode json --no-session --no-approve --no-skills --no-prompt-templates --no-context-files --no-extensions \\
+run_with_heartbeat pi --print --mode json --no-session --no-approve --no-skills --no-prompt-templates --no-context-files --no-extensions \\
   --extension /work/${extension} --provider "$(model_provider)" --model "$AUTHOR_MODEL" --thinking high \\
-  --tools read,bash,grep,find,ls,${tool} "$(cat /work/prompt.txt)" 2>&1`;
+  --tools read,bash,grep,find,ls,${tool} "$(cat /work/prompt.txt)"`;
 }
 
 function authoringScript(): string {
@@ -995,10 +1004,10 @@ function authoringScript(): string {
 clone_source
 mkdir -p /work/tasks
 cd /work/repo
-pi --print --mode json --no-session --no-approve --no-prompt-templates --no-context-files --no-extensions \\
+run_with_heartbeat pi --print --mode json --no-session --no-approve --no-prompt-templates --no-context-files --no-extensions \\
   --skill /work/selfbench-skill --extension /work/authoring.ts \\
   --provider "$(model_provider)" --model "$AUTHOR_MODEL" --thinking high \\
-  --tools read,bash,grep,find,ls,submit_task "$(cat /work/prompt.txt)" 2>&1
+  --tools read,bash,grep,find,ls,submit_task "$(cat /work/prompt.txt)"
 node /work/sandbox-author.js /work/tasks /work/repo /work/harbor-task
 cp /work/tasks/*/definition.json /work/definition.json
 tar -czf /work/task.tar.gz -C /work harbor-task`;
@@ -1014,6 +1023,25 @@ fi
 printf '%s\n' '{"transport":"auto"}' > "$HOME/.pi/agent/settings.json"
 chmod 600 "$HOME/.pi/agent/settings.json"
 model_provider() { [ -n "\${OPENAI_API_KEY:-}" ] && printf openai || printf openai-codex; }
+run_with_heartbeat() {
+  "$@" 2>&1 &
+  local command_pid=$!
+  (
+    while sleep 60; do
+      printf '[selfbench] agent process %s still running at %s\n' "$command_pid" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >&2
+    done
+  ) &
+  local heartbeat_pid=$!
+  trap 'kill "$command_pid" "$heartbeat_pid" 2>/dev/null || true' TERM INT
+  set +e
+  wait "$command_pid"
+  local command_status=$?
+  set -e
+  kill "$heartbeat_pid" 2>/dev/null || true
+  wait "$heartbeat_pid" 2>/dev/null || true
+  trap - TERM INT
+  return "$command_status"
+}
 cleanup() { rm -f "$HOME/.pi/agent/auth.json" "$HOME/.pi/agent/settings.json" "$HOME/.git-credentials"; }
 trap cleanup EXIT
 clone_source() {
@@ -1135,6 +1163,26 @@ function boundedTail(value: string, maxBytes = 8_000): string {
   return buffer.length <= maxBytes
     ? value.trimEnd()
     : `[truncated ${buffer.length - maxBytes} bytes]\n${buffer.subarray(-maxBytes).toString("utf8").trimEnd()}`;
+}
+
+async function runSandboxWithFailureLog(
+  store: ArtifactStore,
+  logKey: string,
+  action: () => Promise<SandboxResult>,
+): Promise<SandboxResult> {
+  try {
+    return await action();
+  } catch (error) {
+    if (!(error instanceof SandboxExecutionError)) {
+      throw error;
+    }
+    const log = await store.put(
+      logKey,
+      Buffer.from(`${error.result.stdout}\n${error.result.stderr}`),
+      "text/plain",
+    );
+    throw new Error(`${error.message}; partial log: ${log.uri}`, { cause: error });
+  }
 }
 
 async function withActivityHeartbeats<T>(

--- a/src/temporal/workflow.ts
+++ b/src/temporal/workflow.ts
@@ -1,3 +1,4 @@
+import { RetryState } from "@temporalio/common";
 import {
   ActivityFailure,
   ApplicationFailure,
@@ -215,7 +216,7 @@ export async function executeRun(
               validation,
             } satisfies ValidationRepairTaskInput);
           } catch (error) {
-            if (isCancellation(error)) {
+            if (isCancellation(error) || !isExhaustedActivityFailure(error)) {
               throw error;
             }
             rejectProgress(progress, "validation repair failed after its single activity attempt");
@@ -264,7 +265,7 @@ export async function executeRun(
               review: review.report,
             } satisfies RepairTaskInput);
           } catch (error) {
-            if (isCancellation(error)) {
+            if (isCancellation(error) || !isExhaustedActivityFailure(error)) {
               throw error;
             }
             rejectProgress(progress, "test repair failed after activity retries");
@@ -314,7 +315,10 @@ export async function executeRun(
         acceptedTasks.push(task);
         setTasks(taskProgress);
       } catch (error) {
-        if (!isHarborInfrastructureFailure(error)) {
+        if (isCancellation(error)) {
+          throw error;
+        }
+        if (!isExhaustedActivityFailure(error) && !isHarborInfrastructureFailure(error)) {
           throw error;
         }
         progress.status = "infrastructure_failed";
@@ -403,10 +407,7 @@ async function discoverWave(
         reportProgress();
         return result;
       } catch (error) {
-        if (isCancellation(error)) {
-          throw error;
-        }
-        if (isNonRetryableActivityFailure(error)) {
+        if (isCancellation(error) || !isExhaustedActivityFailure(error)) {
           throw error;
         }
         failedShards += 1;
@@ -466,6 +467,12 @@ function candidatePoolExhausted(
   );
 }
 
+function isExhaustedActivityFailure(error: unknown): error is ActivityFailure {
+  return (
+    error instanceof ActivityFailure && error.retryState === RetryState.MAXIMUM_ATTEMPTS_REACHED
+  );
+}
+
 function infrastructureFailureMessage(error: unknown): string {
   let cause = error;
   let message = error instanceof Error ? error.message : String(error);
@@ -484,20 +491,6 @@ function isHarborInfrastructureFailure(error: unknown): boolean {
   while (cause instanceof Error) {
     if (cause instanceof ApplicationFailure && cause.type === "HarborInfrastructureFailure") {
       return true;
-    }
-    cause = cause.cause;
-  }
-  return false;
-}
-
-function isNonRetryableActivityFailure(error: unknown): boolean {
-  if (!(error instanceof ActivityFailure)) {
-    return false;
-  }
-  let cause: unknown = error.cause;
-  while (cause instanceof Error) {
-    if (cause instanceof ApplicationFailure) {
-      return cause.nonRetryable === true;
     }
     cause = cause.cause;
   }

--- a/tests/modal-executor.test.ts
+++ b/tests/modal-executor.test.ts
@@ -103,6 +103,57 @@ describe("ModalSandboxExecutor", () => {
     expect(allocations).toBe(0);
   });
 
+  test("drains successful output after the process reports completion", async () => {
+    const stdout = new ReadableStream<string>({
+      async start(controller) {
+        await Bun.sleep(20);
+        controller.enqueue("late output");
+        controller.close();
+      },
+    });
+    const emptyStream = () =>
+      new ReadableStream<string>({
+        start(controller) {
+          controller.close();
+        },
+      });
+    const sandbox = {
+      sandboxId: "sb-success",
+      filesystem: {
+        writeText: async () => undefined,
+        writeBytes: async () => undefined,
+        readBytes: async () => new Uint8Array(),
+      },
+      exec: async () => ({
+        closeStdin: async () => undefined,
+        stdout,
+        stderr: emptyStream(),
+        wait: async () => 0,
+      }),
+      terminate: async () => undefined,
+    };
+    const client = {
+      apps: { fromName: async () => ({}) },
+      images: { fromRegistry: () => ({ dockerfileCommands: () => ({}) }) },
+      sandboxes: { create: async () => sandbox },
+      secrets: { fromObject: async () => ({}) },
+      close: () => undefined,
+    } as unknown as ModalClient;
+    const executor = new ModalSandboxExecutor(
+      { kind: "modal", app: "selfbench", image: "node:22-bookworm" },
+      client,
+    );
+
+    const result = await executor.run({
+      runId: "modal-test",
+      stage: "success-probe",
+      timeoutMs: 1_000,
+      command: ["true"],
+    });
+
+    expect(result.stdout).toBe("late output");
+  });
+
   test("closes process stdin before waiting for completion", async () => {
     let stdinClosed = false;
     const emptyStream = () =>

--- a/tests/modal-executor.test.ts
+++ b/tests/modal-executor.test.ts
@@ -1,8 +1,104 @@
 import { describe, expect, test } from "bun:test";
 import type { ModalClient } from "modal";
 import { ModalSandboxExecutor } from "../src/modal-executor.js";
+import { SandboxExecutionError } from "../src/sandbox.js";
 
 describe("ModalSandboxExecutor", () => {
+  test("preserves partial output and sandbox identity when execution throws", async () => {
+    const stream = (value: string, delayedValue?: string) =>
+      new ReadableStream<string>({
+        async start(controller) {
+          controller.enqueue(value);
+          if (delayedValue) {
+            await Bun.sleep(10);
+            controller.enqueue(delayedValue);
+          }
+          controller.close();
+        },
+      });
+    const sandbox = {
+      sandboxId: "sb-failed",
+      filesystem: {
+        writeText: async () => undefined,
+        writeBytes: async () => undefined,
+        readBytes: async () => {
+          throw new Error("missing output");
+        },
+      },
+      exec: async () => ({
+        closeStdin: async () => undefined,
+        stdout: stream("partial stdout", " after failure"),
+        stderr: stream("partial stderr"),
+        wait: async () => {
+          throw new Error("transport failed");
+        },
+      }),
+      terminate: async () => undefined,
+    };
+    const client = {
+      apps: { fromName: async () => ({}) },
+      images: { fromRegistry: () => ({ dockerfileCommands: () => ({}) }) },
+      sandboxes: { create: async () => sandbox },
+      secrets: { fromObject: async () => ({}) },
+      close: () => undefined,
+    } as unknown as ModalClient;
+    const executor = new ModalSandboxExecutor(
+      { kind: "modal", app: "selfbench", image: "node:22-bookworm" },
+      client,
+    );
+
+    try {
+      await executor.run({
+        runId: "modal-test",
+        stage: "failed-probe",
+        timeoutMs: 1_000,
+        command: ["false"],
+      });
+      throw new Error("expected execution to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SandboxExecutionError);
+      const executionError = error as SandboxExecutionError;
+      expect(executionError.message).toContain("sandbox sb-failed");
+      expect(executionError.result).toEqual({
+        sandboxId: "sb-failed",
+        exitCode: 1,
+        stdout: "partial stdout after failure",
+        stderr: "partial stderr",
+        outputs: {},
+      });
+    }
+  });
+
+  test("does not allocate a sandbox when cancellation is already requested", async () => {
+    let allocations = 0;
+    const client = {
+      apps: { fromName: async () => ({}) },
+      images: { fromRegistry: () => ({ dockerfileCommands: () => ({}) }) },
+      sandboxes: {
+        create: async () => {
+          allocations += 1;
+          throw new Error("unexpected sandbox allocation");
+        },
+      },
+      secrets: { fromObject: async () => ({}) },
+      close: () => undefined,
+    } as unknown as ModalClient;
+    const executor = new ModalSandboxExecutor(
+      { kind: "modal", app: "selfbench", image: "node:22-bookworm" },
+      client,
+    );
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled before run"));
+
+    await expect(
+      executor.run(
+        { runId: "modal-test", stage: "cancelled-probe", timeoutMs: 1_000, command: ["false"] },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow("cancelled before run");
+    expect(allocations).toBe(0);
+  });
+
   test("closes process stdin before waiting for completion", async () => {
     let stdinClosed = false;
     const emptyStream = () =>

--- a/tests/modal-executor.test.ts
+++ b/tests/modal-executor.test.ts
@@ -5,7 +5,7 @@ import { SandboxExecutionError } from "../src/sandbox.js";
 
 describe("ModalSandboxExecutor", () => {
   test("preserves partial output and sandbox identity when execution throws", async () => {
-    const stream = (value: string, delayedValue?: string) =>
+    const stream = (value: string, delayedValue?: string, remainOpen = false) =>
       new ReadableStream<string>({
         async start(controller) {
           controller.enqueue(value);
@@ -13,7 +13,9 @@ describe("ModalSandboxExecutor", () => {
             await Bun.sleep(10);
             controller.enqueue(delayedValue);
           }
-          controller.close();
+          if (!remainOpen) {
+            controller.close();
+          }
         },
       });
     const sandbox = {
@@ -21,13 +23,14 @@ describe("ModalSandboxExecutor", () => {
       filesystem: {
         writeText: async () => undefined,
         writeBytes: async () => undefined,
-        readBytes: async () => {
-          throw new Error("missing output");
-        },
+        readBytes: async (path: string) =>
+          path === "/work/partial.json"
+            ? Buffer.from('{"status":"partial"}')
+            : Promise.reject(new Error("missing output")),
       },
       exec: async () => ({
         closeStdin: async () => undefined,
-        stdout: stream("partial stdout", " after failure"),
+        stdout: stream("partial stdout", " after failure", true),
         stderr: stream("partial stderr"),
         wait: async () => {
           throw new Error("transport failed");
@@ -53,6 +56,7 @@ describe("ModalSandboxExecutor", () => {
         stage: "failed-probe",
         timeoutMs: 1_000,
         command: ["false"],
+        outputPaths: ["/work/partial.json"],
       });
       throw new Error("expected execution to fail");
     } catch (error) {
@@ -64,7 +68,7 @@ describe("ModalSandboxExecutor", () => {
         exitCode: 1,
         stdout: "partial stdout after failure",
         stderr: "partial stderr",
-        outputs: {},
+        outputs: { "/work/partial.json": Buffer.from('{"status":"partial"}') },
       });
     }
   });

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -95,6 +95,51 @@ describe("SelfBench workflow", () => {
     expect(currentStatus?.().phase).toBe("cancelled");
   });
 
+  test("tolerates only retry-exhausted discovery shards", async () => {
+    const activities = acceptingActivities([]);
+    activities.discoverCandidateShard = async ({ shardIndex }) => {
+      if (shardIndex === 0) {
+        throw new ActivityFailure(
+          "Activity task failed",
+          "discoverCandidateShard",
+          "activity-id",
+          RetryState.MAXIMUM_ATTEMPTS_REACHED,
+          "worker",
+          new Error("discovery sandbox unavailable"),
+        );
+      }
+      return {
+        candidates: shardIndex === 1 ? [candidate("surviving-candidate", 1)] : [],
+        report: artifact,
+      };
+    };
+
+    const result = await executeRun(run, activities);
+
+    expect(result.acceptedTaskIds).toEqual(["surviving-candidate-task"]);
+  });
+
+  test("propagates deterministic discovery errors", async () => {
+    const activities = acceptingActivities([]);
+    activities.discoverCandidateShard = async ({ shardIndex }) => {
+      if (shardIndex === 0) {
+        throw new Error("invalid discovery implementation");
+      }
+      return {
+        candidates: [candidate(`candidate-${shardIndex}`, shardIndex + 1)],
+        report: artifact,
+      };
+    };
+    let currentStatus: (() => RunStatus) | undefined;
+
+    await expect(
+      executeRun(run, activities, (status) => {
+        currentStatus = status;
+      }),
+    ).rejects.toThrow("invalid discovery implementation");
+    expect(currentStatus?.().phase).toBe("failed");
+  });
+
   test("authors the exact mixed tier budgets and exports accepted tasks", async () => {
     const candidates = [
       candidate("easy-1", 1, "easy"),
@@ -215,6 +260,74 @@ describe("SelfBench workflow", () => {
     ]);
   });
 
+  test("isolates an exhausted authoring activity and completes successful siblings", async () => {
+    const activities = acceptingActivities([
+      candidate("timed-out", 1),
+      candidate("successful-sibling", 2),
+    ]);
+    const originalAuthor = activities.authorCandidate;
+    activities.authorCandidate = async (input) => {
+      if (input.candidate.candidateId === "timed-out") {
+        throw new ActivityFailure(
+          "Activity task failed",
+          "authorCandidate",
+          "activity-id",
+          RetryState.MAXIMUM_ATTEMPTS_REACHED,
+          "worker",
+          ApplicationFailure.retryable(
+            "author sandbox produced no output for 480000ms; partial log: file:///modal.log",
+            "Error",
+          ),
+        );
+      }
+      return await originalAuthor(input);
+    };
+    let currentStatus: (() => RunStatus) | undefined;
+
+    const result = await executeRun(
+      { ...run, candidateCounts: { easy: 0, medium: 0, hard: 2 } },
+      activities,
+      (status) => {
+        currentStatus = status;
+      },
+    );
+
+    expect(result.acceptedTaskIds).toEqual(["successful-sibling-task"]);
+    expect(currentStatus?.().phase).toBe("complete");
+    expect(currentStatus?.().tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          candidateId: "timed-out",
+          status: "infrastructure_failed",
+          reason: expect.stringContaining("partial log: file:///modal.log"),
+        }),
+        expect.objectContaining({ candidateId: "successful-sibling", status: "accepted" }),
+      ]),
+    );
+  });
+
+  test("propagates non-retryable candidate activity failures", async () => {
+    const activities = acceptingActivities([candidate("invalid", 1)]);
+    activities.authorCandidate = async () => {
+      throw new ActivityFailure(
+        "Activity task failed",
+        "authorCandidate",
+        "activity-id",
+        RetryState.NON_RETRYABLE_FAILURE,
+        "worker",
+        ApplicationFailure.nonRetryable("invalid task contract", "InvalidTask"),
+      );
+    };
+    let currentStatus: (() => RunStatus) | undefined;
+
+    await expect(
+      executeRun(run, activities, (status) => {
+        currentStatus = status;
+      }),
+    ).rejects.toBeInstanceOf(ActivityFailure);
+    expect(currentStatus?.().phase).toBe("failed");
+  });
+
   test("repairs a failed validation once and repeats audit and validation", async () => {
     const calls: string[] = [];
     let validations = 0;
@@ -273,9 +386,14 @@ describe("SelfBench workflow", () => {
       ...(task.candidateId === "successful-sibling" ? {} : { reason: "oracle failed" }),
     });
     activities.repairValidationTask = async () => {
-      throw new Error("Activity task failed", {
-        cause: new Error("validation repair sandbox produced no output for 480000ms"),
-      });
+      throw new ActivityFailure(
+        "Activity task failed",
+        "repairValidationTask",
+        "activity-id",
+        RetryState.MAXIMUM_ATTEMPTS_REACHED,
+        "worker",
+        new Error("validation repair sandbox produced no output for 480000ms"),
+      );
     };
     let currentStatus: (() => RunStatus) | undefined;
 
@@ -386,9 +504,14 @@ describe("SelfBench workflow", () => {
       reason: "coupled test",
     });
     activities.repairTask = async () => {
-      throw new Error("Activity task failed", {
-        cause: new Error("test repair sandbox exited 1"),
-      });
+      throw new ActivityFailure(
+        "Activity task failed",
+        "repairTask",
+        "activity-id",
+        RetryState.MAXIMUM_ATTEMPTS_REACHED,
+        "worker",
+        new Error("test repair sandbox exited 1"),
+      );
     };
     let currentStatus: (() => RunStatus) | undefined;
 


### PR DESCRIPTION
## Summary
Keep Modal-backed runs diagnosable and isolated when sandboxes time out, lose transport, or exhaust Temporal retries.

- Preserve partial Modal output and attach durable failure-log artifacts.
- Keep long silent Pi operations alive with explicit process heartbeats.
- Isolate only genuinely retry-exhausted activities while propagating deterministic and cancellation failures.

## Design
### Modal execution recovery
- `src/modal-executor.ts` — fail already-cancelled requests before allocation, terminate on process or stream failure, drain both output streams, and throw `SandboxExecutionError` with the sandbox ID and partial result.
- `src/sandbox.ts` — add the typed `SandboxExecutionError` result carrier shared by sandbox callers.
- `tests/modal-executor.test.ts` — cover partial output recovery, cancellation before allocation, and stdin closure.

### Durable diagnostics and liveness
- `src/temporal/activities.ts` — persist partial discovery/authoring logs before rethrowing sandbox failures and emit periodic Pi process output so the sandbox inactivity timer does not kill healthy silent work.

### Workflow failure boundaries
- `src/temporal/workflow.ts` — isolate activity failures only after Temporal reports maximum attempts reached; continue propagating cancellations, non-retryable failures, and deterministic implementation errors.
- `tests/workflow.test.ts` — cover exhausted discovery/authoring isolation and propagation of deterministic and non-retryable failures.

## Validation
- `bun run check` — passed.
- `bun test tests review/src` — 174 passed, 0 failed.
- `bun run build` — passed (existing Vite chunk-size warning only).
- `bun run verify:package` — verified `self-bench@0.3.5`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Temporal failure isolation and Modal process lifecycle, so incorrect retry-state checks could swallow real bugs or fail whole runs. Diagnostics and heartbeats are additive but sit on the execution path.
> 
> **Overview**
> Makes Modal sandbox failures diagnosable and keeps Temporal runs from aborting on a single exhausted activity.
> 
> `ModalSandboxExecutor` now drains stdout/stderr after process, stream, inactivity, or abort failures, then throws `SandboxExecutionError` with the sandbox ID and partial result (including any readable output files). Already-aborted runs skip sandbox allocation.
> 
> Discovery and authoring persist those partial logs before rethrowing. Agent scripts wrap `pi` in `run_with_heartbeat` so silent work still emits output and does not trip the inactivity timer.
> 
> The workflow isolates a candidate or discovery shard only when Temporal reports `MAXIMUM_ATTEMPTS_REACHED`. Cancellations, non-retryable failures, and other deterministic errors still fail the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fc375cc1e548a10356b312b188f9af66c2d2de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->