### PR TITLE
Organize Vercel setup modules

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,9 +15,8 @@ import { runCommand } from "./process.js";
 import { collectGitHubPullRequestProvenance, collectRepositoryProvenance } from "./provenance.js";
 import { isExecutionBackend, isHarborEnvironment, matchingHarborEnvironment } from "./providers.js";
 import { type PolledRunStatus, waitForRun } from "./run-wait.js";
+import { applyVercelProfile, setupVercel } from "./setup/vercel/index.js";
 import { SetupCanceledError } from "./terminal-prompts.js";
-import { applyVercelProfile } from "./vercel-profile.js";
-import { setupVercel } from "./vercel-setup.js";
 
 const [command, ...rest] = process.argv.slice(2);
 switch (command) {

--- a/src/setup/vercel/cli.ts
+++ b/src/setup/vercel/cli.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import { z } from "zod";
-import { type CommandOutputHandler, type CommandResult, runCommand } from "./process.js";
+import { type CommandOutputHandler, type CommandResult, runCommand } from "../../process.js";
 
 const MINIMUM_CLI_VERSION = [59, 1, 3] as const;
 const PAGE_SIZE = "100";

--- a/src/setup/vercel/index.ts
+++ b/src/setup/vercel/index.ts
@@ -1,0 +1,3 @@
+export { applyVercelProfile } from "./profile.js";
+export type { VercelSetupCli, VercelSetupServices } from "./setup.js";
+export { setupVercel } from "./setup.js";

--- a/src/setup/vercel/probe.ts
+++ b/src/setup/vercel/probe.ts
@@ -1,7 +1,10 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { APIError, Sandbox } from "@vercel/sandbox";
-import type { VercelCredentials } from "./config.js";
-import { HOBBY_VERCEL_TIMEOUT_CAP_MS, STANDARD_VERCEL_TIMEOUT_CAP_MS } from "./sandbox/timeout.js";
+import type { VercelCredentials } from "../../config.js";
+import {
+  HOBBY_VERCEL_TIMEOUT_CAP_MS,
+  STANDARD_VERCEL_TIMEOUT_CAP_MS,
+} from "../../sandbox/timeout.js";
 
 const PROBE_COMMAND_TIMEOUT_MS = 15_000;
 const CLEANUP_TIMEOUT_MS = 60_000;

--- a/src/setup/vercel/profile.ts
+++ b/src/setup/vercel/profile.ts
@@ -4,7 +4,10 @@ import { chmod, lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/pr
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { z } from "zod";
-import { parseSandboxTimeoutCapText, STANDARD_VERCEL_TIMEOUT_CAP_MS } from "./sandbox/timeout.js";
+import {
+  parseSandboxTimeoutCapText,
+  STANDARD_VERCEL_TIMEOUT_CAP_MS,
+} from "../../sandbox/timeout.js";
 
 const CONFIG_FILE = "config.json";
 const CREDENTIALS_FILE = "credentials.json";

--- a/src/setup/vercel/runtime-image.ts
+++ b/src/setup/vercel/runtime-image.ts
@@ -1,10 +1,10 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { sha256 } from "./hash.js";
-import type { CommandOutputHandler } from "./process.js";
-import type { SetupPrompter } from "./terminal-prompts.js";
-import type { SetupReporter } from "./terminal-reporter.js";
-import type { VcrTag } from "./vercel-cli.js";
+import { sha256 } from "../../hash.js";
+import type { CommandOutputHandler } from "../../process.js";
+import type { SetupPrompter } from "../../terminal-prompts.js";
+import type { SetupReporter } from "../../terminal-reporter.js";
+import type { VcrTag } from "./cli.js";
 
 export const DEFAULT_VCR_REPOSITORY = "selfbench-runtime";
 

--- a/src/setup/vercel/setup.ts
+++ b/src/setup/vercel/setup.ts
@@ -1,15 +1,16 @@
 import { dirname, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
-import type { VercelCredentials } from "./config.js";
+import type { VercelCredentials } from "../../config.js";
 import {
   isInteractiveTerminal,
   SetupCanceledError,
   type SetupPrompter,
   TerminalPrompter,
-} from "./terminal-prompts.js";
-import { type SetupReporter, TerminalSetupReporter } from "./terminal-reporter.js";
-import { VercelCli, type VercelProject, type VercelTeam } from "./vercel-cli.js";
+} from "../../terminal-prompts.js";
+import { type SetupReporter, TerminalSetupReporter } from "../../terminal-reporter.js";
+import { VercelCli, type VercelProject, type VercelTeam } from "./cli.js";
+import { probeVercelCapability, type VercelCapability } from "./probe.js";
 import {
   loadVercelProfileData,
   saveVercelProfile,
@@ -17,14 +18,13 @@ import {
   type VercelProfile,
   type VercelProfileData,
   validateVercelProfileName,
-} from "./vercel-profile.js";
+} from "./profile.js";
 import {
   DEFAULT_VCR_REPOSITORY,
   ensureVercelRuntimeImage,
   type VercelRuntimeImageCli,
   vercelRuntimeFingerprint,
-} from "./vercel-runtime-image.js";
-import { probeVercelCapability, type VercelCapability } from "./vercel-setup-probe.js";
+} from "./runtime-image.js";
 
 const DEFAULT_PROFILE_NAME = "default";
 const DEFAULT_PROJECT_NAME = "selfbench-sandbox";
@@ -402,7 +402,7 @@ function imageDigest(image: string): string {
 }
 
 function defaultProjectRoot(): string {
-  return resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 }
 
 function errorMessage(error: unknown): string {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { sha256 } from "../src/hash.js";
 import { runCommand } from "../src/process.js";
-import { saveVercelProfile } from "../src/vercel-profile.js";
+import { saveVercelProfile } from "../src/setup/vercel/profile.js";
 
 const roots: string[] = [];
 

--- a/tests/vercel-cli.test.ts
+++ b/tests/vercel-cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { CommandOutputHandler, CommandResult } from "../src/process.js";
-import { VercelCli, type VercelCommandRunner } from "../src/vercel-cli.js";
+import { VercelCli, type VercelCommandRunner } from "../src/setup/vercel/cli.js";
 
 class FakeRunner implements VercelCommandRunner {
   readonly captured: string[][] = [];

--- a/tests/vercel-profile.test.ts
+++ b/tests/vercel-profile.test.ts
@@ -9,7 +9,7 @@ import {
   profileFilePaths,
   saveVercelProfile,
   type VercelProfile,
-} from "../src/vercel-profile.js";
+} from "../src/setup/vercel/profile.js";
 
 const roots: string[] = [];
 const image = `selfbench-runtime@sha256:${"a".repeat(64)}`;

--- a/tests/vercel-setup-probe.test.ts
+++ b/tests/vercel-setup-probe.test.ts
@@ -3,7 +3,7 @@ import {
   HOBBY_VERCEL_TIMEOUT_CAP_MS,
   STANDARD_VERCEL_TIMEOUT_CAP_MS,
 } from "../src/sandbox/timeout.js";
-import { probeVercelCapability, type VercelSandboxProbeApi } from "../src/vercel-setup-probe.js";
+import { probeVercelCapability, type VercelSandboxProbeApi } from "../src/setup/vercel/probe.js";
 
 const credentials = {
   token: "vcp_super_secret",

--- a/tests/vercel-setup.test.ts
+++ b/tests/vercel-setup.test.ts
@@ -7,12 +7,16 @@ import {
   HOBBY_VERCEL_TIMEOUT_CAP_MS,
   STANDARD_VERCEL_TIMEOUT_CAP_MS,
 } from "../src/sandbox/timeout.js";
+import type { VcrTag, VercelProject, VercelTeam } from "../src/setup/vercel/cli.js";
+import { loadVercelProfileData, saveVercelProfile } from "../src/setup/vercel/profile.js";
+import { vercelRuntimeFingerprint } from "../src/setup/vercel/runtime-image.js";
+import {
+  setupVercel,
+  type VercelSetupCli,
+  type VercelSetupServices,
+} from "../src/setup/vercel/setup.js";
 import type { PromptChoice, SetupPrompter } from "../src/terminal-prompts.js";
 import type { SetupReporter, SetupTaskLabels } from "../src/terminal-reporter.js";
-import type { VcrTag, VercelProject, VercelTeam } from "../src/vercel-cli.js";
-import { loadVercelProfileData, saveVercelProfile } from "../src/vercel-profile.js";
-import { vercelRuntimeFingerprint } from "../src/vercel-runtime-image.js";
-import { setupVercel, type VercelSetupCli, type VercelSetupServices } from "../src/vercel-setup.js";
 
 const roots: string[] = [];
 const repositoryRoot = join(import.meta.dir, "..");


### PR DESCRIPTION
## Summary
Group Vercel setup and provisioning code under one dedicated module so it is visibly separate from the runtime sandbox provider.

- Removes the scattered top-level `src/vercel-*.ts` layout.
- Preserves existing behavior and public CLI wiring.

## Design
### Vercel setup modules
- `src/setup/vercel/` — contains the CLI wrapper, profile storage, capability probe, runtime-image provisioning, and setup orchestrator with non-redundant filenames.
- `src/setup/vercel/index.ts` — exposes the setup surface consumed by the main CLI.
- `src/setup/vercel/setup.ts` — updates module-relative imports and preserves project-root resolution after moving the file deeper in the source tree.

### Integration and tests
- `src/cli.ts` — imports Vercel setup functionality through the new module entry point.
- `tests/vercel-*.test.ts` and `tests/cli.test.ts` — follow the reorganized source paths without changing test behavior.

## Validation
- `bun run check` — passed.
- `bun test` — 176 tests passed, 0 failed.
- `bun run build:server` — passed.
- `git diff --check` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical file moves and import path updates with no intended logic changes; project-root resolution was adjusted to match the new module depth.
> 
> **Overview**
> Moves Vercel **setup and provisioning** code out of scattered top-level `src/vercel-*.ts` files into **`src/setup/vercel/`**, with shorter local names (`cli`, `profile`, `probe`, `runtime-image`, `setup`) and a barrel **`index.ts`** that exports `setupVercel` and `applyVercelProfile`.
> 
> The main CLI now imports from `./setup/vercel/index.js` instead of separate profile/setup modules. Moved files retarget shared imports to `../../` (e.g. `config`, `process`, `sandbox/timeout`). **`defaultProjectRoot()`** in setup goes up one more directory (`../../..`) so runtime image builds still resolve the repo root after the deeper path.
> 
> Tests update import paths only; behavior and CLI wiring are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cd4eb4c3718e05ef3242deb702726c8188eebcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->