### PR TITLE
Raise candidate run limit to 10,000

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -162,6 +162,43 @@ The CLI collects sanitized user messages from Pi, Claude Code, and Codex session
 
 GitHub records remain labeled `github-pull-request` and are bound to their own repository, PR number, and canonical URL. Local requests are preferred when they clearly describe the same change. A run can proceed with only local or only GitHub provenance, but fails when the combined corpus is empty. Common credential forms and injected harness context are removed, but this is not a general secret scanner.
 
+### Explicit local-session association
+
+Use an optional local association manifest when you know which coding session produced a merged PR and do not want remote discovery to infer that correspondence. First list the sanitized sessions found for the repository and all of its worktrees:
+
+```bash
+self-bench associate --repo /absolute/path/to/repository --list-sessions
+```
+
+The newest sessions appear first. The listing contains source type, session ID, retained user-message count, the local session file path (with the home directory abbreviated as `~`), and its filesystem modification timestamp. These fields stay in terminal output only: they are not written to the association manifest or uploaded. Request text is never printed. Treat paths and timestamps as private metadata, and redirect the listing only to a protected file if it must be saved. Select one or more complete sessions and bind them to one merged PR:
+
+```bash
+self-bench associate \
+  --repo /absolute/path/to/repository \
+  --pr 123 \
+  --session pi:01a03611-1df5-7f46-a88e-e24f4987b745 \
+  --session claude-code:9dd842c0-59d8-4838-8f29-cff97820f4e8 \
+  --output ./pr-123-sessions.json
+```
+
+`associate` calls `gh pr view` to verify that the PR is merged and belongs to the repository. It then writes the output with create-only semantics and owner-only permissions. The manifest is deterministic and text-free: it contains the repository, canonical PR identity, each selected local message identity, and a SHA-256 of the exact sanitized and whitespace-normalized content SelfBench retains. It does **not** contain request text, upload anything, mutate the repository, or start a run. Keep it private anyway because session identifiers and PR associations can be sensitive.
+
+Pass one or more manifests explicitly when starting a run:
+
+```bash
+self-bench run \
+  --repo /absolute/path/to/repository \
+  --association ./pr-123-sessions.json \
+  --easy-count 5 \
+  --medium-count 10 \
+  --hard-count 5 \
+  --output ./self-bench-tasks.tar.gz
+```
+
+The run command re-collects, whitespace-normalizes, and sanitizes local sessions, validates the manifest's repository and the complete selected-session snapshot, then annotates the exact retained messages before the existing provenance upload. Changed, added, or missing messages, cross-repository manifests, duplicate bindings, and one message associated more than once fail locally before upload. Unassociated local messages retain the existing discovery behavior only for PRs without explicit associations. On the worker, an explicit local association suppresses the GitHub title/body fallback for that PR, and materialization rejects any attempt to pair that PR with an unbound local message. The API, run request, and artifact reference contracts do not change; the existing sanitized provenance NDJSON is how the worker consumes the optional binding.
+
+Association is deliberately a user assertion, not an LLM decision. Only the local CLI can see the local session stores. An LLM would make the binding nondeterministic, expose more request text, and could invent a correspondence. Remote model discovery can still rank candidates, but materialization resolves an exact retained message and enforces the explicit PR binding.
+
 ```bash
 self-bench run \
   --repo /absolute/path/to/repository \

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -175,7 +175,7 @@ self-bench run \
   --output ./self-bench-tasks.tar.gz
 ```
 
-The three tier counts total 1–100. Each is a fixed candidate authoring budget, not an accepted-task target: rejected candidates are not replaced. Discovery expands only until it fills each requested tier budget, then accepted tasks are exported.
+The three tier counts total 1–10,000. Each is a fixed candidate authoring budget, not an accepted-task target: rejected candidates are not replaced. Discovery expands only until it fills each requested tier budget, then accepted tasks are exported.
 
 `--output` implies `--wait`. It reports phase changes, requires a successful Temporal terminal state, downloads with create-only filesystem semantics, and verifies the API-provided SHA-256.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,12 +158,9 @@ Common failures:
 
 `self-bench run` requires an absolute or relative path to a Git checkout whose `origin` is an HTTPS or SSH GitHub URL. It pins `HEAD`; uncommitted content is excluded.
 
-The CLI collects two types of provenance:
+The CLI collects sanitized user messages from Pi, Claude Code, and Codex sessions associated with the checkout or its worktrees, then uploads that local corpus with the run request. The workflow starts by running a Temporal activity on the worker that fetches exact titles and bodies from up to 500 recent merged pull requests by non-bot authors that clear coarse tier-appropriate size thresholds. It stores the combined local and GitHub corpus as a run artifact before discovery begins.
 
-1. sanitized user messages from Pi, Claude Code, and Codex sessions associated with the checkout or its worktrees;
-2. exact titles and bodies from up to 500 recent merged pull requests by non-bot authors that clear coarse tier-appropriate size thresholds.
-
-GitHub records remain labeled `github-pull-request` and are bound to their own repository, PR number, and canonical URL. Local requests are preferred when they clearly describe the same change. Common credential forms and injected harness context are removed, but this is not a general secret scanner.
+GitHub records remain labeled `github-pull-request` and are bound to their own repository, PR number, and canonical URL. Local requests are preferred when they clearly describe the same change. A run can proceed with only local or only GitHub provenance, but fails when the combined corpus is empty. Common credential forms and injected harness context are removed, but this is not a general secret scanner.
 
 ```bash
 self-bench run \

--- a/docs/task-construction.md
+++ b/docs/task-construction.md
@@ -17,7 +17,9 @@ SelfBench creates easy, medium, and hard Harbor evaluations from completed pull 
 
 Each task is grounded in one retained human request. SelfBench prefers exact user messages from local Pi, Claude Code, or Codex sessions associated with the repository or its worktrees. For third-party repositories, an exact GitHub pull-request title and optional body from a non-bot author is also valid.
 
-GitHub records are stored with a distinct `github-pull-request` source type, canonical URL, and PR number. Discovery cannot pair the request from one PR with another PR. A model-authored benchmark instruction may restate the retained request but may not add behavior inferred only from the implementation or tests.
+GitHub records are stored with a distinct `github-pull-request` source type, canonical URL, and PR number. Discovery cannot pair the request from one PR with another PR. A local message may also carry an explicit PR binding supplied through `self-bench associate`; materialization must then reject every unbound local message for that PR, as well as omitting the GitHub title/body fallback. Association manifests contain only message identities and hashes of SelfBench's sanitized, whitespace-normalized content, while the existing provenance artifact retains that exact normalized text for the task. No model creates associations or request text.
+
+A model-authored benchmark instruction may restate the retained request but may not add behavior inferred only from the implementation or tests.
 
 ## Difficulty gates
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,6 +9,7 @@ import { createArtifactStore } from "./artifacts.js";
 import type { SelfBenchConfig } from "./config.js";
 import {
   artifactRefSchema,
+  MAX_CANDIDATES_PER_RUN,
   type RunPhase,
   type RunRequest,
   type RunStatus,
@@ -24,9 +25,9 @@ const submissionSchema = z.object({
   repository: repositoryRefSchema,
   provenance: artifactRefSchema,
   candidateCounts: z.object({
-    easy: z.number().int().min(0).max(100),
-    medium: z.number().int().min(0).max(100),
-    hard: z.number().int().min(0).max(100),
+    easy: z.number().int().min(0).max(MAX_CANDIDATES_PER_RUN),
+    medium: z.number().int().min(0).max(MAX_CANDIDATES_PER_RUN),
+    hard: z.number().int().min(0).max(MAX_CANDIDATES_PER_RUN),
   }),
   authoringModel: z.string().min(1).default("gpt-5.6-sol"),
   selfbenchCommit: z.string().regex(/^[0-9a-f]{40}$/i),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import { buildCommit } from "./build-metadata.js";
 import { loadWorkerConfig } from "./config.js";
+import { MAX_CANDIDATES_PER_RUN } from "./contracts.js";
 import { runCommand } from "./process.js";
 import { collectGitHubPullRequestProvenance, collectRepositoryProvenance } from "./provenance.js";
 import { isExecutionBackend, isHarborEnvironment, matchingHarborEnvironment } from "./providers.js";
@@ -183,8 +184,8 @@ async function run(args: string[]): Promise<void> {
     hard: nonnegativeInteger(parsed.values["hard-count"] ?? "0", "--hard-count"),
   };
   const totalCandidates = candidateCounts.easy + candidateCounts.medium + candidateCounts.hard;
-  if (totalCandidates < 1 || totalCandidates > 100) {
-    fail("the total candidate count must be between 1 and 100");
+  if (totalCandidates < 1 || totalCandidates > MAX_CANDIDATES_PER_RUN) {
+    fail(`the total candidate count must be between 1 and ${MAX_CANDIDATES_PER_RUN}`);
   }
   const runId = parsed.values["run-id"] ?? defaultRunId();
   const [repository, localMessages, selfbenchCommit] = await Promise.all([

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,17 @@ import { buildCommit } from "./build-metadata.js";
 import { loadWorkerConfig } from "./config.js";
 import { MAX_CANDIDATES_PER_RUN } from "./contracts.js";
 import { runCommand } from "./process.js";
-import { collectRepositoryProvenance } from "./provenance.js";
+import {
+  collectRepositoryProvenance,
+  collectRepositoryProvenanceWithMetadata,
+} from "./provenance.js";
+import {
+  applyProvenanceAssociationManifests,
+  associationSessionSummaries,
+  createProvenanceAssociationManifest,
+  resolveMergedPullRequest,
+  writeProvenanceAssociationManifest,
+} from "./provenance-associations.js";
 import { isExecutionBackend, isHarborEnvironment, matchingHarborEnvironment } from "./providers.js";
 import { type PolledRunStatus, waitForRun } from "./run-wait.js";
 import { applyVercelProfile, setupVercel } from "./setup/vercel/index.js";
@@ -29,6 +39,9 @@ switch (command) {
     break;
   case "run":
     await run(rest);
+    break;
+  case "associate":
+    await associate(rest);
     break;
   case "down":
     await down();
@@ -162,6 +175,57 @@ async function down(): Promise<void> {
   await runCommand("docker", ["compose", "--file", resolve(projectRoot, "compose.yaml"), "down"]);
 }
 
+async function associate(args: string[]): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      repo: { type: "string", short: "r" },
+      pr: { type: "string" },
+      session: { type: "string", multiple: true },
+      output: { type: "string", short: "o" },
+      "list-sessions": { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+  const repositoryPath = resolve(parsed.values.repo ?? fail("--repo is required"));
+  const [repository, collected] = await Promise.all([
+    resolveRepository(repositoryPath),
+    collectRepositoryProvenanceWithMetadata(repositoryPath, process.env.HOME ?? homedir()),
+  ]);
+  const localMessages = collected.messages;
+  const sessions = associationSessionSummaries(localMessages, collected.sessions);
+  if (parsed.values["list-sessions"]) {
+    console.log(JSON.stringify({ repository: repository.url, sessions }, null, 2));
+    return;
+  }
+
+  const sourcePr = positiveInteger(parsed.values.pr ?? fail("--pr is required"), "--pr");
+  const output = resolve(parsed.values.output ?? fail("--output is required"));
+  const selectors = parsed.values.session ?? [];
+  const pullRequest = await resolveMergedPullRequest(repository.url, sourcePr);
+  const manifest = createProvenanceAssociationManifest({
+    repositoryUrl: repository.url,
+    pullRequest,
+    messages: localMessages,
+    sessionSelectors: selectors,
+  });
+  await writeProvenanceAssociationManifest(output, manifest);
+  console.log(
+    JSON.stringify(
+      {
+        output,
+        repository: manifest.repository,
+        sourcePr: manifest.sourcePr,
+        sourceUrl: manifest.sourceUrl,
+        sessions: selectors.length,
+        messages: manifest.messages.length,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
 async function run(args: string[]): Promise<void> {
   const parsed = parseArgs({
     args,
@@ -174,6 +238,7 @@ async function run(args: string[]): Promise<void> {
       model: { type: "string", default: "gpt-5.6-sol" },
       wait: { type: "boolean", default: false },
       output: { type: "string", short: "o" },
+      association: { type: "string", multiple: true },
     },
     strict: true,
   });
@@ -188,11 +253,16 @@ async function run(args: string[]): Promise<void> {
     fail(`the total candidate count must be between 1 and ${MAX_CANDIDATES_PER_RUN}`);
   }
   const runId = parsed.values["run-id"] ?? defaultRunId();
-  const [repository, localMessages, selfbenchCommit] = await Promise.all([
+  const [repository, collectedMessages, selfbenchCommit] = await Promise.all([
     resolveRepository(repositoryPath),
     collectRepositoryProvenance(repositoryPath, process.env.HOME ?? homedir()),
     resolveSelfBenchCommit(),
   ]);
+  const localMessages = await applyProvenanceAssociationManifests(
+    collectedMessages,
+    repository.url,
+    parsed.values.association ?? [],
+  );
   const corpus = Buffer.from(
     localMessages.length > 0
       ? `${localMessages.map((message) => JSON.stringify(message)).join("\n")}\n`
@@ -222,6 +292,7 @@ async function run(args: string[]): Promise<void> {
       {
         ...response,
         localProvenanceMessages: localMessages.length,
+        associationManifests: parsed.values.association?.length ?? 0,
       },
       null,
       2,
@@ -374,6 +445,14 @@ function asPolledRunStatus(value: Record<string, unknown>): PolledRunStatus {
   return { ...value, phase: value.phase };
 }
 
+function positiveInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
 function nonnegativeInteger(value: string, label: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 0) {
@@ -398,8 +477,12 @@ Usage:
   self-bench up [--backend docker|modal|vercel] [--harbor-environment docker|modal]
                 [--modal-config PATH] [--vercel-profile NAME]
   self-bench down
+  self-bench associate --repo PATH --list-sessions
+  self-bench associate --repo PATH --pr NUMBER --session TYPE:SESSION_ID [...]
+                       --output ASSOCIATION.json
   self-bench run --repo PATH [--easy-count N] [--medium-count N] [--hard-count N]
-                  [--model MODEL] [--run-id ID] [--wait] [--output OUTPUT.tar.gz]
+                  [--model MODEL] [--association ASSOCIATION.json ...]
+                  [--run-id ID] [--wait] [--output OUTPUT.tar.gz]
   self-bench status RUN_ID
   self-bench cancel RUN_ID
   self-bench download RUN_ID OUTPUT.tar.gz
@@ -409,6 +492,10 @@ The up command starts the local stack. Docker and Modal default Harbor to the ma
 requires --harbor-environment because Harbor does not support Vercel. Modal generation or Harbor uses
 ~/.modal.toml unless --modal-config overrides it. Run self-bench setup vercel once to create or select a
 project, publish the pinned runtime image, verify access, and save an owner-only local profile.
+
+The associate command runs locally. --list-sessions prints selectors, counts, local paths, and modification
+times, but never request text. Association writes a create-only, text-free manifest; it never uploads or
+starts a run. Pass the manifest to run with --association (repeatable). No LLM participates in association.
 
 The tier counts are candidate authoring budgets, not accepted-task targets. Rejected candidates are not
 replaced, and the export contains only accepted tasks. The run command performs only repository metadata

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { buildCommit } from "./build-metadata.js";
 import { loadWorkerConfig } from "./config.js";
 import { MAX_CANDIDATES_PER_RUN } from "./contracts.js";
 import { runCommand } from "./process.js";
-import { collectGitHubPullRequestProvenance, collectRepositoryProvenance } from "./provenance.js";
+import { collectRepositoryProvenance } from "./provenance.js";
 import { isExecutionBackend, isHarborEnvironment, matchingHarborEnvironment } from "./providers.js";
 import { type PolledRunStatus, waitForRun } from "./run-wait.js";
 import { applyVercelProfile, setupVercel } from "./setup/vercel/index.js";
@@ -193,12 +193,11 @@ async function run(args: string[]): Promise<void> {
     collectRepositoryProvenance(repositoryPath, process.env.HOME ?? homedir()),
     resolveSelfBenchCommit(),
   ]);
-  const githubMessages = await collectGitHubPullRequestProvenance(repository.url);
-  const messages = [...localMessages, ...githubMessages];
-  if (messages.length === 0) {
-    throw new Error("no sanitized local-session or GitHub pull-request provenance was found");
-  }
-  const corpus = Buffer.from(`${messages.map((message) => JSON.stringify(message)).join("\n")}\n`);
+  const corpus = Buffer.from(
+    localMessages.length > 0
+      ? `${localMessages.map((message) => JSON.stringify(message)).join("\n")}\n`
+      : "",
+  );
   const provenance = await requestJson(`/v1/provenance?runId=${encodeURIComponent(runId)}`, {
     method: "POST",
     body: corpus,
@@ -222,9 +221,7 @@ async function run(args: string[]): Promise<void> {
     JSON.stringify(
       {
         ...response,
-        provenanceMessages: messages.length,
         localProvenanceMessages: localMessages.length,
-        githubPullRequestMessages: githubMessages.length,
       },
       null,
       2,

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -22,17 +22,19 @@ export type ArtifactRef = z.infer<typeof artifactRefSchema>;
 export const difficultySchema = z.enum(["easy", "medium", "hard"]);
 export type Difficulty = z.infer<typeof difficultySchema>;
 
+export const MAX_CANDIDATES_PER_RUN = 10_000;
+
 const candidateCountsSchema = z
   .object({
-    easy: z.number().int().min(0).max(100),
-    medium: z.number().int().min(0).max(100),
-    hard: z.number().int().min(0).max(100),
+    easy: z.number().int().min(0).max(MAX_CANDIDATES_PER_RUN),
+    medium: z.number().int().min(0).max(MAX_CANDIDATES_PER_RUN),
+    hard: z.number().int().min(0).max(MAX_CANDIDATES_PER_RUN),
   })
   .refine(({ easy, medium, hard }) => easy + medium + hard >= 1, {
     message: "at least one candidate must be requested",
   })
-  .refine(({ easy, medium, hard }) => easy + medium + hard <= 100, {
-    message: "at most 100 candidates may be requested",
+  .refine(({ easy, medium, hard }) => easy + medium + hard <= MAX_CANDIDATES_PER_RUN, {
+    message: `at most ${MAX_CANDIDATES_PER_RUN} candidates may be requested`,
   });
 
 const runVersionSchema = z

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -22,7 +22,6 @@ export default function discoveryExtension(pi: ExtensionAPI): void {
               sourceUrl: Type.String({ minLength: 1 }),
               baseCommit: Type.String({ pattern: "^[0-9a-fA-F]{40}$" }),
               completedCommit: Type.String({ pattern: "^[0-9a-fA-F]{40}$" }),
-              request: Type.String({ minLength: 1 }),
               provenance: Type.Object({
                 sourceType: Type.Union([
                   Type.Literal("pi"),

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
@@ -51,10 +51,20 @@ export default function discoveryExtension(pi: ExtensionAPI): void {
       if (!candidates) {
         throw new Error("submit_discovery received no candidates");
       }
-      writeFileSync(output, `${JSON.stringify({ candidates }, null, 2)}\n`, { flag: "wx" });
+      const exclusionsPath = process.env.SELFBENCH_DISCOVERY_EXCLUSIONS;
+      if (!exclusionsPath) {
+        throw new Error("SELFBENCH_DISCOVERY_EXCLUSIONS is not configured");
+      }
+      const excluded = new Set<number>(JSON.parse(readFileSync(exclusionsPath, "utf8")));
+      const accepted = candidates.filter(
+        ({ sourcePr }) => sourcePr !== undefined && !excluded.has(sourcePr),
+      );
+      writeFileSync(output, `${JSON.stringify({ candidates: accepted }, null, 2)}\n`, {
+        flag: "wx",
+      });
       return {
-        content: [{ type: "text", text: `Submitted ${candidates.length} candidates.` }],
-        details: { candidates },
+        content: [{ type: "text", text: `Submitted ${accepted.length} new candidates.` }],
+        details: { candidates: accepted },
       };
     },
   });

--- a/src/provenance-associations.ts
+++ b/src/provenance-associations.ts
@@ -1,0 +1,311 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { z } from "zod";
+import { assertPullRequestBelongsToRepository, githubRepository } from "./github.js";
+import { sha256 } from "./hash.js";
+import { runCommand } from "./process.js";
+import type {
+  LocalSessionMetadata,
+  ProvenanceMessage,
+  SessionProvenanceFormat,
+} from "./provenance.js";
+
+const localSourceTypeSchema = z.enum(["pi", "claude-code", "codex"]);
+type LocalSourceType = z.infer<typeof localSourceTypeSchema>;
+
+const associationMessageSchema = z
+  .object({
+    sourceType: localSourceTypeSchema,
+    sessionId: z.string().min(1),
+    messageIndex: z.number().int().nonnegative(),
+    contentSha256: z.string().regex(/^[0-9a-f]{64}$/),
+  })
+  .strict();
+
+export const provenanceAssociationManifestSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    repository: z.string().regex(/^[^/]+\/[^/]+$/),
+    sourcePr: z.number().int().positive(),
+    sourceUrl: z.string().url(),
+    messages: z.array(associationMessageSchema).min(1),
+  })
+  .strict();
+
+export type ProvenanceAssociationManifest = z.infer<typeof provenanceAssociationManifestSchema>;
+
+export interface AssociationSessionSummary {
+  readonly selector: string;
+  readonly sourceType: LocalSourceType;
+  readonly sessionId: string;
+  readonly messageCount: number;
+  readonly modifiedAt?: string;
+  readonly paths?: readonly string[];
+}
+
+export interface MergedPullRequest {
+  readonly sourcePr: number;
+  readonly sourceUrl: string;
+}
+
+export function associationSessionSummaries(
+  messages: readonly ProvenanceMessage[],
+  metadata: readonly LocalSessionMetadata[] = [],
+): AssociationSessionSummary[] {
+  const metadataBySelector = new Map<string, { modifiedAt: string; paths: Set<string> }>();
+  for (const session of metadata) {
+    if (!isLocalSourceType(session.sourceType)) {
+      continue;
+    }
+    const selector = sessionSelector(session.sourceType, session.sessionId);
+    const existing = metadataBySelector.get(selector);
+    metadataBySelector.set(selector, {
+      modifiedAt:
+        !existing || session.modifiedAt > existing.modifiedAt
+          ? session.modifiedAt
+          : existing.modifiedAt,
+      paths: new Set([...(existing?.paths ?? []), session.path]),
+    });
+  }
+
+  const counts = new Map<string, AssociationSessionSummary>();
+  for (const message of messages) {
+    if (!isLocalSourceType(message.sourceType)) {
+      continue;
+    }
+    const selector = sessionSelector(message.sourceType, message.sessionId);
+    const existing = counts.get(selector);
+    const sessionMetadata = metadataBySelector.get(selector);
+    counts.set(selector, {
+      selector,
+      sourceType: message.sourceType,
+      sessionId: message.sessionId,
+      messageCount: (existing?.messageCount ?? 0) + 1,
+      ...(sessionMetadata
+        ? {
+            modifiedAt: sessionMetadata.modifiedAt,
+            paths: [...sessionMetadata.paths].sort(),
+          }
+        : {}),
+    });
+  }
+  return [...counts.values()].sort(
+    (left, right) =>
+      (right.modifiedAt ?? "").localeCompare(left.modifiedAt ?? "") ||
+      left.selector.localeCompare(right.selector),
+  );
+}
+
+export function createProvenanceAssociationManifest(input: {
+  readonly repositoryUrl: string;
+  readonly pullRequest: MergedPullRequest;
+  readonly messages: readonly ProvenanceMessage[];
+  readonly sessionSelectors: readonly string[];
+}): ProvenanceAssociationManifest {
+  const repository = githubRepository(input.repositoryUrl);
+  assertPullRequestBelongsToRepository(
+    input.repositoryUrl,
+    input.pullRequest.sourceUrl,
+    input.pullRequest.sourcePr,
+  );
+  if (input.sessionSelectors.length === 0) {
+    throw new Error("at least one --session is required to create an association manifest");
+  }
+
+  const selected = new Set(input.sessionSelectors.map(parseSessionSelector));
+  if (selected.size !== input.sessionSelectors.length) {
+    throw new Error("each --session selector must be unique");
+  }
+  const available = new Set(
+    associationSessionSummaries(input.messages).map(({ selector }) => selector),
+  );
+  for (const selector of selected) {
+    if (!available.has(selector)) {
+      throw new Error(`local session ${selector} was not found for this repository`);
+    }
+  }
+
+  const messageKeys = new Set<string>();
+  const messages = input.messages
+    .filter(
+      (message): message is ProvenanceMessage & { sourceType: LocalSourceType } =>
+        isLocalSourceType(message.sourceType) &&
+        selected.has(sessionSelector(message.sourceType, message.sessionId)),
+    )
+    .map((message) => {
+      const key = messageKey(message.sourceType, message.sessionId, message.messageIndex);
+      if (messageKeys.has(key)) {
+        throw new Error(`local provenance contains duplicate message identity ${key}`);
+      }
+      messageKeys.add(key);
+      return {
+        sourceType: message.sourceType,
+        sessionId: message.sessionId,
+        messageIndex: message.messageIndex,
+        contentSha256: sha256(message.content),
+      };
+    })
+    .sort(compareAssociationMessages);
+
+  return provenanceAssociationManifestSchema.parse({
+    schemaVersion: 1,
+    repository,
+    sourcePr: input.pullRequest.sourcePr,
+    sourceUrl: input.pullRequest.sourceUrl,
+    messages,
+  });
+}
+
+export async function writeProvenanceAssociationManifest(
+  path: string,
+  manifest: ProvenanceAssociationManifest,
+): Promise<void> {
+  await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+}
+
+export async function applyProvenanceAssociationManifests(
+  messages: readonly ProvenanceMessage[],
+  repositoryUrl: string,
+  paths: readonly string[],
+): Promise<ProvenanceMessage[]> {
+  if (paths.length === 0) {
+    return [...messages];
+  }
+  const repository = githubRepository(repositoryUrl);
+  const manifests = await Promise.all(
+    paths.map(async (path) => {
+      const value = JSON.parse(await readFile(path, "utf8"));
+      return { path, manifest: provenanceAssociationManifestSchema.parse(value) };
+    }),
+  );
+  const messageByKey = new Map<string, ProvenanceMessage>();
+  for (const message of messages) {
+    const key = messageKey(message.sourceType, message.sessionId, message.messageIndex);
+    if (messageByKey.has(key)) {
+      throw new Error(`local provenance contains duplicate message identity ${key}`);
+    }
+    messageByKey.set(key, message);
+  }
+
+  const associations = new Map<string, MergedPullRequest>();
+  for (const { path, manifest } of manifests) {
+    if (manifest.repository.toLowerCase() !== repository) {
+      throw new Error(
+        `association manifest ${path} belongs to ${manifest.repository}, not ${repository}`,
+      );
+    }
+    assertPullRequestBelongsToRepository(repositoryUrl, manifest.sourceUrl, manifest.sourcePr);
+    for (const selector of new Set(
+      manifest.messages.map((message) => sessionSelector(message.sourceType, message.sessionId)),
+    )) {
+      const expected = manifest.messages
+        .filter((message) => sessionSelector(message.sourceType, message.sessionId) === selector)
+        .sort(compareAssociationMessages);
+      const current = messages
+        .filter(
+          (message): message is ProvenanceMessage & { sourceType: LocalSourceType } =>
+            isLocalSourceType(message.sourceType) &&
+            sessionSelector(message.sourceType, message.sessionId) === selector,
+        )
+        .map((message) => ({
+          sourceType: message.sourceType,
+          sessionId: message.sessionId,
+          messageIndex: message.messageIndex,
+          contentSha256: sha256(message.content),
+        }))
+        .sort(compareAssociationMessages);
+      if (JSON.stringify(current) !== JSON.stringify(expected)) {
+        throw new Error(`association manifest ${path} does not match local session ${selector}`);
+      }
+    }
+    for (const reference of manifest.messages) {
+      const key = messageKey(reference.sourceType, reference.sessionId, reference.messageIndex);
+      const message = messageByKey.get(key);
+      if (!message || sha256(message.content) !== reference.contentSha256) {
+        throw new Error(`association manifest ${path} does not match local message ${key}`);
+      }
+      if (associations.has(key)) {
+        throw new Error(`local message ${key} is associated more than once`);
+      }
+      associations.set(key, {
+        sourcePr: manifest.sourcePr,
+        sourceUrl: manifest.sourceUrl,
+      });
+    }
+  }
+
+  return messages.map((message) => {
+    const association = associations.get(
+      messageKey(message.sourceType, message.sessionId, message.messageIndex),
+    );
+    return association ? { ...message, ...association } : message;
+  });
+}
+
+export async function resolveMergedPullRequest(
+  repositoryUrl: string,
+  sourcePr: number,
+): Promise<MergedPullRequest> {
+  const repository = githubRepository(repositoryUrl);
+  const result = await runCommand("gh", [
+    "pr",
+    "view",
+    String(sourcePr),
+    "--repo",
+    repository,
+    "--json",
+    "number,url,state,mergedAt",
+  ]);
+  const parsed = z
+    .object({
+      number: z.number().int().positive(),
+      url: z.string().url(),
+      state: z.string(),
+      mergedAt: z.string().nullable(),
+    })
+    .parse(JSON.parse(result.stdout));
+  if (parsed.number !== sourcePr) {
+    throw new Error(`GitHub returned pull request ${parsed.number}; expected ${sourcePr}`);
+  }
+  assertPullRequestBelongsToRepository(repositoryUrl, parsed.url, sourcePr);
+  if (parsed.state !== "MERGED" || !parsed.mergedAt) {
+    throw new Error(`pull request ${repository}#${sourcePr} is not merged`);
+  }
+  return { sourcePr, sourceUrl: parsed.url };
+}
+
+function parseSessionSelector(value: string): string {
+  const separator = value.indexOf(":");
+  if (separator < 1 || separator === value.length - 1) {
+    throw new Error(`invalid session selector ${JSON.stringify(value)}; expected TYPE:SESSION_ID`);
+  }
+  const sourceType = value.slice(0, separator);
+  localSourceTypeSchema.parse(sourceType);
+  return sessionSelector(sourceType as LocalSourceType, value.slice(separator + 1));
+}
+
+function sessionSelector(sourceType: LocalSourceType, sessionId: string): string {
+  return `${sourceType}:${sessionId}`;
+}
+
+function messageKey(
+  sourceType: SessionProvenanceFormat | "github-pull-request",
+  sessionId: string,
+  messageIndex: number,
+): string {
+  return `${sourceType}:${sessionId}:${messageIndex}`;
+}
+
+function compareAssociationMessages(
+  left: z.infer<typeof associationMessageSchema>,
+  right: z.infer<typeof associationMessageSchema>,
+): number {
+  return (
+    left.sourceType.localeCompare(right.sourceType) ||
+    left.sessionId.localeCompare(right.sessionId) ||
+    left.messageIndex - right.messageIndex
+  );
+}
+
+function isLocalSourceType(value: string): value is LocalSourceType {
+  return value === "pi" || value === "claude-code" || value === "codex";
+}

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -1,23 +1,50 @@
-import { readdir, readFile } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { basename, join, relative } from "node:path";
+import { z } from "zod";
 import { assertPullRequestBelongsToRepository, githubRepository } from "./github.js";
 import { runCommand } from "./process.js";
 
 export type SessionProvenanceFormat = "codex" | "claude-code" | "pi" | "generic";
 
-interface ProvenanceMessageBase {
+const provenanceMessageBaseSchema = z.object({
+  sessionId: z.string().min(1),
+  messageIndex: z.number().int().nonnegative(),
+  content: z.string().min(1),
+});
+
+const localProvenanceMessageSchema = provenanceMessageBaseSchema
+  .extend({
+    sourceType: z.enum(["codex", "claude-code", "pi", "generic"]),
+    sourcePr: z.number().int().positive().optional(),
+    sourceUrl: z.string().url().optional(),
+  })
+  .refine(
+    (message) => (message.sourcePr === undefined) === (message.sourceUrl === undefined),
+    "sourcePr and sourceUrl must be supplied together",
+  );
+
+export const provenanceMessageSchema = z.union([
+  localProvenanceMessageSchema,
+  provenanceMessageBaseSchema.extend({
+    sourceType: z.literal("github-pull-request"),
+    sourcePr: z.number().int().positive(),
+    sourceUrl: z.string().url(),
+  }),
+]);
+
+export type ProvenanceMessage = z.infer<typeof provenanceMessageSchema>;
+
+export interface LocalSessionMetadata {
+  readonly sourceType: SessionProvenanceFormat;
   readonly sessionId: string;
-  readonly messageIndex: number;
-  readonly content: string;
+  readonly path: string;
+  readonly modifiedAt: string;
 }
 
-export type ProvenanceMessage =
-  | (ProvenanceMessageBase & { readonly sourceType: SessionProvenanceFormat })
-  | (ProvenanceMessageBase & {
-      readonly sourceType: "github-pull-request";
-      readonly sourcePr: number;
-      readonly sourceUrl: string;
-    });
+export interface RepositoryProvenanceCollection {
+  readonly messages: readonly ProvenanceMessage[];
+  readonly sessions: readonly LocalSessionMetadata[];
+}
 
 interface JsonRecord {
   readonly [key: string]: unknown;
@@ -51,9 +78,19 @@ export async function collectRepositoryProvenance(
   repositoryPath: string,
   homeDirectory: string,
 ): Promise<ProvenanceMessage[]> {
+  return [
+    ...(await collectRepositoryProvenanceWithMetadata(repositoryPath, homeDirectory)).messages,
+  ];
+}
+
+export async function collectRepositoryProvenanceWithMetadata(
+  repositoryPath: string,
+  homeDirectory: string,
+): Promise<RepositoryProvenanceCollection> {
   const worktrees = await repositoryWorktrees(repositoryPath);
   const encodedWorktrees = worktrees.flatMap((path) => [path, encodeSessionPath(path)]);
   const messages: ProvenanceMessage[] = [];
+  const sessions: LocalSessionMetadata[] = [];
 
   for (const [format, relativeRoot] of SOURCE_ROOTS) {
     const root = join(homeDirectory, relativeRoot);
@@ -65,11 +102,27 @@ export async function collectRepositoryProvenance(
       ) {
         continue;
       }
-      messages.push(...extractProvenanceMessages(raw, format, basename(path)));
+      const extracted = extractProvenanceMessages(raw, format, basename(path));
+      if (extracted.length === 0) {
+        continue;
+      }
+      messages.push(...extracted);
+      const file = await stat(path).catch(() => undefined);
+      if (file) {
+        const sessionIds = new Set(extracted.map((message) => message.sessionId));
+        for (const sessionId of sessionIds) {
+          sessions.push({
+            sourceType: format,
+            sessionId,
+            path: displaySessionPath(path, homeDirectory),
+            modifiedAt: file.mtime.toISOString(),
+          });
+        }
+      }
     }
   }
 
-  return deduplicateMessages(messages);
+  return { messages: deduplicateMessages(messages), sessions };
 }
 
 export async function collectGitHubPullRequestProvenance(
@@ -139,17 +192,53 @@ export function extractGitHubPullRequestProvenance(
   return messages;
 }
 
+export function combineRunProvenance(
+  repositoryUrl: string,
+  local: readonly ProvenanceMessage[],
+  github: readonly ProvenanceMessage[],
+): ProvenanceMessage[] {
+  const explicitlyAssociatedPrs = new Set<number>();
+  for (const message of local) {
+    if (message.sourcePr === undefined || message.sourceUrl === undefined) {
+      continue;
+    }
+    assertPullRequestBelongsToRepository(repositoryUrl, message.sourceUrl, message.sourcePr);
+    explicitlyAssociatedPrs.add(message.sourcePr);
+  }
+  return [
+    ...local,
+    ...github.filter(
+      (message) =>
+        message.sourceType !== "github-pull-request" ||
+        !explicitlyAssociatedPrs.has(message.sourcePr),
+    ),
+  ];
+}
+
 export function assertProvenanceMatchesPullRequest(
   message: ProvenanceMessage,
   sourcePr: number,
   sourceUrl: string,
+  provenance: readonly ProvenanceMessage[] = [message],
 ): void {
   if (
-    message.sourceType === "github-pull-request" &&
+    (message.sourcePr !== undefined || message.sourceUrl !== undefined) &&
     (message.sourcePr !== sourcePr || message.sourceUrl !== sourceUrl)
   ) {
     throw new Error(
       `pull request ${sourceUrl}#${sourcePr} does not match provenance ${message.sourceUrl}#${message.sourcePr}`,
+    );
+  }
+  const hasExplicitLocalAssociation = provenance.some(
+    (item) => item.sourceType !== "github-pull-request" && item.sourcePr === sourcePr,
+  );
+  if (
+    hasExplicitLocalAssociation &&
+    message.sourceType !== "github-pull-request" &&
+    (message.sourcePr !== sourcePr || message.sourceUrl !== sourceUrl)
+  ) {
+    throw new Error(
+      `pull request ${sourceUrl}#${sourcePr} has explicit local provenance; unbound local provenance cannot be selected`,
     );
   }
 }
@@ -427,11 +516,17 @@ async function listJsonFiles(root: string): Promise<string[]> {
   const entries = await readdir(root, { recursive: true, withFileTypes: true }).catch(() => []);
   return entries
     .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
-    .map((entry) => join(entry.parentPath, entry.name));
+    .map((entry) => join(entry.parentPath, entry.name))
+    .sort();
 }
 
 function encodeSessionPath(path: string): string {
   return path.replaceAll("/", "-");
+}
+
+function displaySessionPath(path: string, homeDirectory: string): string {
+  const fromHome = relative(homeDirectory, path);
+  return fromHome && !fromHome.startsWith("..") ? `~/${fromHome}` : path;
 }
 
 function deduplicateMessages(messages: readonly ProvenanceMessage[]): ProvenanceMessage[] {

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -74,20 +74,29 @@ export async function collectRepositoryProvenance(
 
 export async function collectGitHubPullRequestProvenance(
   repositoryUrl: string,
+  token?: string,
+  signal?: AbortSignal,
 ): Promise<ProvenanceMessage[]> {
   const repository = githubRepository(repositoryUrl);
-  const result = await runCommand("gh", [
-    "pr",
-    "list",
-    "--repo",
-    repository,
-    "--state",
-    "merged",
-    "--limit",
-    String(GITHUB_PULL_REQUEST_LIMIT),
-    "--json",
-    "number,title,body,url,author,isDraft,additions,deletions,changedFiles",
-  ]);
+  const result = await runCommand(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      repository,
+      "--state",
+      "merged",
+      "--limit",
+      String(GITHUB_PULL_REQUEST_LIMIT),
+      "--json",
+      "number,title,body,url,author,isDraft,additions,deletions,changedFiles",
+    ],
+    {
+      env: token ? { ...process.env, GH_TOKEN: token } : process.env,
+      ...(signal ? { signal } : {}),
+    },
+  );
   return extractGitHubPullRequestProvenance(result.stdout, repositoryUrl);
 }
 

--- a/src/temporal/activities.ts
+++ b/src/temporal/activities.ts
@@ -198,6 +198,10 @@ async function discoverCandidateShard(
               inactivityTimeoutMs: AGENT_INACTIVITY_TIMEOUT_MS,
               files: [
                 { path: "/work/discovery.ts", contents: extension },
+                {
+                  path: "/work/excluded-source-prs.json",
+                  contents: JSON.stringify(input.excludedSourcePrs),
+                },
                 { path: "/work/provenance.jsonl", contents: shardBytes },
                 { path: "/work/prompt.txt", contents: discoveryShardPrompt(input, shard.length) },
               ],
@@ -211,6 +215,7 @@ async function discoverCandidateShard(
                 SOURCE_REPO_URL: run.repository.url,
                 SOURCE_COMMIT: run.repository.commit,
                 AUTHOR_MODEL: run.authoring.model,
+                SELFBENCH_DISCOVERY_EXCLUSIONS: "/work/excluded-source-prs.json",
                 SELFBENCH_DISCOVERY_OUTPUT: "/work/discovery.json",
               },
               command: ["bash", "-lc", modalAgentScript("discovery.ts", "submit_discovery")],
@@ -937,13 +942,7 @@ async function buildExport(store: ArtifactStore, input: ExportInput): Promise<Ar
 }
 
 function discoveryShardPrompt(input: DiscoveryShardInput, provenanceCount: number): string {
-  const exclusions =
-    input.excludedSourcePrs.length > 0
-      ? `Do not return any of these already-considered pull requests: ${input.excludedSourcePrs.join(", ")}.`
-      : "No pull requests have been considered yet.";
-  return `Discover and rank SelfBench candidates from this assigned provenance shard. Return at most easy=${input.targetCounts.easy}, medium=${input.targetCounts.medium}, hard=${input.targetCounts.hard}.
-
-${exclusions}
+  return `Discover and rank SelfBench candidates from this assigned provenance shard. Return at most easy=${input.targetCounts.easy}, medium=${input.targetCounts.medium}, hard=${input.targetCounts.hard}. The submit_discovery tool silently removes pull requests already considered in earlier discovery waves.
 
 Assign each candidate exactly one difficulty using the separable implementation core, excluding tests, generated code, formatting churn, and unrelated cleanup:
 - easy: at least 20 changed implementation lines across at least 1 implementation file, with at least 1 viable fail-to-pass test;

--- a/src/temporal/activities.ts
+++ b/src/temporal/activities.ts
@@ -43,7 +43,11 @@ import { refreshHarborTask } from "../harbor-task.js";
 import { sha256 } from "../hash.js";
 import { runCommand } from "../process.js";
 import { projectRoot } from "../project-paths.js";
-import { assertProvenanceMatchesPullRequest, type ProvenanceMessage } from "../provenance.js";
+import {
+  assertProvenanceMatchesPullRequest,
+  collectGitHubPullRequestProvenance,
+  type ProvenanceMessage,
+} from "../provenance.js";
 import {
   createSandboxExecutor,
   SandboxExecutionError,
@@ -111,6 +115,7 @@ export interface ExportInput {
 }
 
 export interface SelfBenchActivities {
+  collectRunProvenance(run: RunRequest): Promise<ArtifactRef>;
   discoverCandidateShard(input: DiscoveryShardInput): Promise<DiscoveryResult>;
   authorCandidate(input: AuthorCandidateInput): Promise<AuthorOutcome>;
   validateTask(input: TaskStageInput): Promise<ValidationResult>;
@@ -125,6 +130,7 @@ export function createActivities(config: SelfBenchWorkerConfig): SelfBenchActivi
   const store = createArtifactStore(config.artifact);
   const sandbox = createSandboxExecutor(config.execution);
   return {
+    collectRunProvenance: (run) => collectRunProvenance(store, run),
     discoverCandidateShard: (input) => discoverCandidateShard(store, sandbox, input),
     authorCandidate: (input) => authorCandidate(store, sandbox, input),
     validateTask: (input) => validateTask(store, config.harborEnvironment, input),
@@ -134,6 +140,29 @@ export function createActivities(config: SelfBenchWorkerConfig): SelfBenchActivi
     auditTask: (input) => auditTask(store, input),
     buildExport: (input) => buildExport(store, input),
   };
+}
+
+async function collectRunProvenance(store: ArtifactStore, run: RunRequest): Promise<ArtifactRef> {
+  return await withActivityHeartbeats(
+    "collecting merged GitHub pull requests",
+    async ({ signal }) => {
+      const [localBytes, token] = await Promise.all([store.get(run.provenance), githubToken()]);
+      const local = parseProvenance(localBytes);
+      const github = await collectGitHubPullRequestProvenance(run.repository.url, token, signal);
+      const messages = [...local, ...github];
+      if (messages.length === 0) {
+        throw ApplicationFailure.nonRetryable(
+          "no sanitized local-session or GitHub pull-request provenance was found",
+          "NoProvenance",
+        );
+      }
+      return await store.put(
+        `runs/${run.runId}/input/combined-provenance-attempt-${Context.current().info.attempt}.jsonl`,
+        Buffer.from(`${messages.map((message) => JSON.stringify(message)).join("\n")}\n`),
+        "application/x-ndjson",
+      );
+    },
+  );
 }
 
 async function discoverCandidateShard(

--- a/src/temporal/activities.ts
+++ b/src/temporal/activities.ts
@@ -46,7 +46,9 @@ import { projectRoot } from "../project-paths.js";
 import {
   assertProvenanceMatchesPullRequest,
   collectGitHubPullRequestProvenance,
+  combineRunProvenance,
   type ProvenanceMessage,
+  provenanceMessageSchema,
 } from "../provenance.js";
 import {
   createSandboxExecutor,
@@ -72,7 +74,6 @@ const discoveryPlanSchema = z.object({
       sourceUrl: z.string().url(),
       baseCommit: z.string().regex(/^[0-9a-f]{40}$/i),
       completedCommit: z.string().regex(/^[0-9a-f]{40}$/i),
-      request: z.string().min(1),
       provenance: z.object({
         sourceType: z.enum(["pi", "claude-code", "codex", "generic", "github-pull-request"]),
         sessionId: z.string().min(1),
@@ -149,7 +150,7 @@ async function collectRunProvenance(store: ArtifactStore, run: RunRequest): Prom
       const [localBytes, token] = await Promise.all([store.get(run.provenance), githubToken()]);
       const local = parseProvenance(localBytes);
       const github = await collectGitHubPullRequestProvenance(run.repository.url, token, signal);
-      const messages = [...local, ...github];
+      const messages = combineRunProvenance(run.repository.url, local, github);
       if (messages.length === 0) {
         throw ApplicationFailure.nonRetryable(
           "no sanitized local-session or GitHub pull-request provenance was found",
@@ -269,6 +270,7 @@ async function discoverCandidateShard(
     store,
     run,
     shard,
+    provenance,
     planBytes,
     logs,
     input.targetCounts,
@@ -282,6 +284,7 @@ async function materializeDiscovery(
   store: ArtifactStore,
   run: RunRequest,
   provenance: readonly ProvenanceMessage[],
+  allProvenance: readonly ProvenanceMessage[],
   planBytes: Uint8Array,
   logs: ArtifactRef,
   maxCandidates: Readonly<Record<Difficulty, number>>,
@@ -293,16 +296,7 @@ async function materializeDiscovery(
 
   const candidates: Candidate[] = [];
   for (const raw of plan.candidates) {
-    const message = provenance.find(
-      (item) =>
-        item.sourceType === raw.provenance.sourceType &&
-        item.sessionId === raw.provenance.sessionId &&
-        item.messageIndex === raw.provenance.messageIndex,
-    );
-    if (!message) {
-      throw new Error(`candidate ${raw.candidateId} references unknown provenance`);
-    }
-    assertProvenanceMatchesPullRequest(message, raw.sourcePr, raw.sourceUrl);
+    const message = selectCandidateProvenance(provenance, allProvenance, raw);
     const staged = Buffer.from(
       `${JSON.stringify({ source: message, messages: [{ role: "user", content: message.content }] })}\n`,
     );
@@ -327,6 +321,38 @@ async function materializeDiscovery(
     "application/json",
   );
   return { candidates, report };
+}
+
+export function selectCandidateProvenance(
+  available: readonly ProvenanceMessage[],
+  allProvenance: readonly ProvenanceMessage[],
+  candidate: {
+    readonly candidateId: string;
+    readonly sourcePr: number;
+    readonly sourceUrl: string;
+    readonly provenance: {
+      readonly sourceType: ProvenanceMessage["sourceType"];
+      readonly sessionId: string;
+      readonly messageIndex: number;
+    };
+  },
+): ProvenanceMessage {
+  const message = available.find(
+    (item) =>
+      item.sourceType === candidate.provenance.sourceType &&
+      item.sessionId === candidate.provenance.sessionId &&
+      item.messageIndex === candidate.provenance.messageIndex,
+  );
+  if (!message) {
+    throw new Error(`candidate ${candidate.candidateId} references unknown provenance`);
+  }
+  assertProvenanceMatchesPullRequest(
+    message,
+    candidate.sourcePr,
+    candidate.sourceUrl,
+    allProvenance,
+  );
+  return message;
 }
 
 function parseDiscoveryPlan(
@@ -981,7 +1007,7 @@ Choose the highest tier whose thresholds the candidate honestly meets. Every tie
 
 Every candidate must be a pull request from SOURCE_REPO_URL. Repository names or pull requests mentioned inside provenance messages are context only; never follow them into another repository. sourceUrl must be the canonical GitHub pull-request URL for SOURCE_REPO_URL and sourcePr must match its number.
 
-The sanitized corpus at /work/provenance.jsonl contains ${provenanceCount} human requests. Local Pi, Claude Code, and Codex requests are preferred when they clearly correspond to the same change. Records with sourceType github-pull-request contain the non-bot PR author's exact title and optional body and are valid fallback provenance. A github-pull-request record may be used only for its own sourcePr and sourceUrl. Select provenance only by an exact sourceType, sessionId, and messageIndex present in the corpus. Never invent or reconstruct request text from implementation or tests. Inspect merged PR metadata and diffs with gh and git. Resolve the exact base and completed 40-character commits. Do not modify the repository.
+The sanitized corpus at /work/provenance.jsonl contains ${provenanceCount} human requests. Local Pi, Claude Code, and Codex requests are preferred when they clearly correspond to the same change. A local record with sourcePr and sourceUrl has an explicit user-supplied association and may be used only for that PR. Records with sourceType github-pull-request contain the non-bot PR author's exact title and optional body and are valid fallback provenance; they too may be used only for their own sourcePr and sourceUrl. Select provenance only by an exact sourceType, sessionId, and messageIndex present in the corpus. Never invent or reconstruct request text from implementation or tests. Inspect merged PR metadata and diffs with gh and git. Resolve the exact base and completed 40-character commits. Do not modify the repository.
 
 Return fewer candidates when the shard does not contain enough valid requests; an empty candidate list is valid. Call submit_discovery exactly once. Do not return prose after the tool call.`;
 }
@@ -1291,7 +1317,7 @@ function parseProvenance(value: Uint8Array): ProvenanceMessage[] {
     .toString("utf8")
     .split("\n")
     .filter((line) => line.trim())
-    .map((line) => JSON.parse(line) as ProvenanceMessage);
+    .map((line) => provenanceMessageSchema.parse(JSON.parse(line)));
 }
 
 function readAsset(relativePath: string): Promise<Buffer> {

--- a/src/temporal/activities.ts
+++ b/src/temporal/activities.ts
@@ -942,7 +942,7 @@ async function buildExport(store: ArtifactStore, input: ExportInput): Promise<Ar
 }
 
 function discoveryShardPrompt(input: DiscoveryShardInput, provenanceCount: number): string {
-  return `Discover and rank SelfBench candidates from this assigned provenance shard. Return at most easy=${input.targetCounts.easy}, medium=${input.targetCounts.medium}, hard=${input.targetCounts.hard}. The submit_discovery tool silently removes pull requests already considered in earlier discovery waves.
+  return `Discover and rank SelfBench candidates from this assigned provenance shard. Return at most easy=${input.targetCounts.easy}, medium=${input.targetCounts.medium}, hard=${input.targetCounts.hard}. Before selecting a pull request, query its number against /work/excluded-source-prs.json with jq; do not print or read the full exclusion list into context. The submit_discovery tool also removes any already-considered pull requests as a final safeguard.
 
 Assign each candidate exactly one difficulty using the separable implementation core, excluding tests, generated code, formatting churn, and unrelated cleanup:
 - easy: at least 20 changed implementation lines across at least 1 implementation file, with at least 1 viable fail-to-pass test;

--- a/src/temporal/workflow.ts
+++ b/src/temporal/workflow.ts
@@ -18,6 +18,7 @@ import type {
   RunStatus,
   TaskProgress,
 } from "../contracts.js";
+import { MAX_CANDIDATES_PER_RUN } from "../contracts.js";
 import type {
   AuthorCandidateInput,
   DiscoveryShardInput,
@@ -79,7 +80,7 @@ const activities: SelfBenchActivities = {
 const DISCOVERY_SHARD_COUNT = 8;
 const DISCOVERY_SHARD_OVERFETCH = 3;
 const MAX_CANDIDATES_PER_TIER_PER_SHARD = 8;
-const MAX_DISCOVERED_CANDIDATES = 300;
+const MAX_DISCOVERED_CANDIDATES = MAX_CANDIDATES_PER_RUN * 3;
 
 export async function selfBenchRunWorkflow(input: RunRequest): Promise<RunResult> {
   return await executeRun(input, activities, (status) => setHandler(statusQuery, () => status()));

--- a/src/temporal/workflow.ts
+++ b/src/temporal/workflow.ts
@@ -19,6 +19,7 @@ import type {
   TaskProgress,
 } from "../contracts.js";
 import { MAX_CANDIDATES_PER_RUN } from "../contracts.js";
+import { parallelMap } from "../parallel.js";
 import type {
   AuthorCandidateInput,
   DiscoveryShardInput,
@@ -81,6 +82,7 @@ const DISCOVERY_SHARD_COUNT = 8;
 const DISCOVERY_SHARD_OVERFETCH = 3;
 const MAX_CANDIDATES_PER_TIER_PER_SHARD = 8;
 const MAX_DISCOVERED_CANDIDATES = MAX_CANDIDATES_PER_RUN * 3;
+const MAX_CONCURRENT_CANDIDATES = 100;
 
 export async function selfBenchRunWorkflow(input: RunRequest): Promise<RunResult> {
   return await executeRun(input, activities, (status) => setHandler(statusQuery, () => status()));
@@ -329,7 +331,7 @@ export async function executeRun(
     };
 
     setPhase("authoring");
-    await Promise.all(selectedCandidates.map(processCandidate));
+    await parallelMap(selectedCandidates, MAX_CONCURRENT_CANDIDATES, processCandidate);
 
     setPhase("exporting");
     const exportRef = await activitySet.buildExport({

--- a/src/temporal/workflow.ts
+++ b/src/temporal/workflow.ts
@@ -13,6 +13,7 @@ import type {
   Candidate,
   Difficulty,
   DiscoveryProgress,
+  DiscoveryResult,
   RunRequest,
   RunResult,
   RunStatus,
@@ -33,7 +34,10 @@ import type {
 export const statusQuery = defineQuery<RunStatus>("status");
 
 const taskActivities = proxyActivities<
-  Omit<SelfBenchActivities, "discoverCandidateShard" | "repairValidationTask">
+  Omit<
+    SelfBenchActivities,
+    "collectRunProvenance" | "discoverCandidateShard" | "repairValidationTask"
+  >
 >({
   startToCloseTimeout: "7 hours",
   heartbeatTimeout: "10 minutes",
@@ -55,6 +59,18 @@ const validationRepairActivity = proxyActivities<Pick<SelfBenchActivities, "repa
   },
 );
 
+const provenanceActivities = proxyActivities<Pick<SelfBenchActivities, "collectRunProvenance">>({
+  startToCloseTimeout: "5 minutes",
+  heartbeatTimeout: "3 minutes",
+  cancellationType: "WAIT_CANCELLATION_COMPLETED",
+  retry: {
+    initialInterval: "5 seconds",
+    backoffCoefficient: 2,
+    maximumInterval: "1 minute",
+    maximumAttempts: 3,
+  },
+});
+
 const discoveryActivities = proxyActivities<Pick<SelfBenchActivities, "discoverCandidateShard">>({
   startToCloseTimeout: "1 hour",
   heartbeatTimeout: "10 minutes",
@@ -68,6 +84,7 @@ const discoveryActivities = proxyActivities<Pick<SelfBenchActivities, "discoverC
 });
 
 const activities: SelfBenchActivities = {
+  collectRunProvenance: provenanceActivities.collectRunProvenance,
   discoverCandidateShard: discoveryActivities.discoverCandidateShard,
   authorCandidate: taskActivities.authorCandidate,
   validateTask: taskActivities.validateTask,
@@ -126,6 +143,8 @@ export async function executeRun(
 
   try {
     setPhase("discovering");
+    const provenance = await activitySet.collectRunProvenance(input);
+    const run = { ...input, provenance };
     const updateDiscovery = (progress: DiscoveryProgress): void => {
       status = { ...status, discovery: progress };
     };
@@ -142,7 +161,7 @@ export async function executeRun(
         setPhase("blocked");
         throw candidatePoolExhausted(selected, input.candidateCounts);
       }
-      const additions = await discoverWave(activitySet, input, {
+      const additions = await discoverWave(activitySet, run, {
         wave: discoveryWave,
         targetCounts: missing,
         excludedSourcePrs: candidates.map((candidate) => candidate.sourcePr),
@@ -179,7 +198,7 @@ export async function executeRun(
       setTasks(taskProgress);
       try {
         const authored = await activitySet.authorCandidate({
-          run: input,
+          run,
           candidate,
         } satisfies AuthorCandidateInput);
         if (authored.kind === "rejected") {
@@ -196,7 +215,7 @@ export async function executeRun(
 
         progress.status = "auditing";
         setTasks(taskProgress);
-        const audit = await activitySet.auditTask({ run: input, task } satisfies TaskStageInput);
+        const audit = await activitySet.auditTask({ run, task } satisfies TaskStageInput);
         if (!audit.accepted) {
           rejectProgress(progress, audit.reason ?? "audit rejected task");
           return;
@@ -205,7 +224,7 @@ export async function executeRun(
         progress.status = "validating";
         setTasks(taskProgress);
         let validation = await activitySet.validateTask({
-          run: input,
+          run,
           task,
         } satisfies TaskStageInput);
         if (!validation.accepted) {
@@ -214,7 +233,7 @@ export async function executeRun(
           let repaired: AuthorOutcome;
           try {
             repaired = await activitySet.repairValidationTask({
-              run: input,
+              run,
               task,
               validation,
             } satisfies ValidationRepairTaskInput);
@@ -234,7 +253,7 @@ export async function executeRun(
           progress.status = "auditing";
           setTasks(taskProgress);
           const repairAudit = await activitySet.auditTask({
-            run: input,
+            run,
             task,
           } satisfies TaskStageInput);
           if (!repairAudit.accepted) {
@@ -245,7 +264,7 @@ export async function executeRun(
           progress.status = "validating";
           setTasks(taskProgress);
           validation = await activitySet.validateTask({
-            run: input,
+            run,
             task,
           } satisfies TaskStageInput);
           if (!validation.accepted) {
@@ -256,14 +275,14 @@ export async function executeRun(
 
         progress.status = "reviewing";
         setTasks(taskProgress);
-        let review = await activitySet.reviewTask({ run: input, task } satisfies TaskStageInput);
+        let review = await activitySet.reviewTask({ run, task } satisfies TaskStageInput);
         if (!review.accepted) {
           progress.status = "repairing";
           setTasks(taskProgress);
           let repaired: AuthorOutcome;
           try {
             repaired = await activitySet.repairTask({
-              run: input,
+              run,
               task,
               review: review.report,
             } satisfies RepairTaskInput);
@@ -283,7 +302,7 @@ export async function executeRun(
           progress.status = "auditing";
           setTasks(taskProgress);
           const repairAudit = await activitySet.auditTask({
-            run: input,
+            run,
             task,
           } satisfies TaskStageInput);
           if (!repairAudit.accepted) {
@@ -294,7 +313,7 @@ export async function executeRun(
           progress.status = "validating";
           setTasks(taskProgress);
           const repairValidation = await activitySet.validateTask({
-            run: input,
+            run,
             task,
           } satisfies TaskStageInput);
           if (!repairValidation.accepted) {
@@ -307,7 +326,7 @@ export async function executeRun(
 
           progress.status = "reviewing";
           setTasks(taskProgress);
-          review = await activitySet.reviewTask({ run: input, task } satisfies TaskStageInput);
+          review = await activitySet.reviewTask({ run, task } satisfies TaskStageInput);
           if (!review.accepted) {
             rejectProgress(progress, review.reason ?? "review rejected repaired task");
             return;
@@ -335,7 +354,7 @@ export async function executeRun(
 
     setPhase("exporting");
     const exportRef = await activitySet.buildExport({
-      run: input,
+      run,
       tasks: acceptedTasks,
     } satisfies ExportInput);
     status = { ...status, phase: "complete", export: exportRef };
@@ -370,58 +389,92 @@ async function discoverWave(
   run: RunRequest,
   options: DiscoveryWaveOptions,
 ): Promise<Candidate[]> {
-  const targetCounts = Object.fromEntries(
+  const targetCounts = discoveryShardTargets(options.targetCounts);
+  const progress = discoveryProgress(options);
+  progress.report();
+
+  const shards = await Promise.all(
+    Array.from({ length: DISCOVERY_SHARD_COUNT }, (_unused, shardIndex) =>
+      discoverShard(activitySet, run, options, targetCounts, shardIndex, progress),
+    ),
+  );
+  return uniqueCandidates(interleave(shards.map((shard) => shard.candidates)));
+}
+
+function discoveryShardTargets(
+  targetCounts: RunRequest["candidateCounts"],
+): Record<Difficulty, number> {
+  return Object.fromEntries(
     (["easy", "medium", "hard"] as const).map((difficulty) => [
       difficulty,
-      options.targetCounts[difficulty] === 0
+      targetCounts[difficulty] === 0
         ? 0
         : Math.min(
             MAX_CANDIDATES_PER_TIER_PER_SHARD,
-            Math.ceil(options.targetCounts[difficulty] / DISCOVERY_SHARD_COUNT) +
-              DISCOVERY_SHARD_OVERFETCH,
+            Math.ceil(targetCounts[difficulty] / DISCOVERY_SHARD_COUNT) + DISCOVERY_SHARD_OVERFETCH,
           ),
     ]),
   ) as Record<Difficulty, number>;
+}
+
+function discoveryProgress(options: DiscoveryWaveOptions) {
   let completedShards = 0;
   let failedShards = 0;
-  let candidateCount = 0;
-  const reportProgress = (): void =>
+  let candidates = 0;
+  const report = (): void =>
     options.onProgress({
       wave: options.wave,
       totalShards: DISCOVERY_SHARD_COUNT,
       completedShards,
       failedShards,
-      candidates: candidateCount,
+      candidates,
     });
-  reportProgress();
-  const shards = await Promise.all(
-    Array.from({ length: DISCOVERY_SHARD_COUNT }, async (_unused, shardIndex) => {
-      try {
-        const result = await activitySet.discoverCandidateShard({
-          run,
-          wave: options.wave,
-          shardIndex,
-          shardCount: DISCOVERY_SHARD_COUNT,
-          targetCounts,
-          excludedSourcePrs: options.excludedSourcePrs,
-        } satisfies DiscoveryShardInput);
-        completedShards += 1;
-        candidateCount += result.candidates.length;
-        reportProgress();
-        return result;
-      } catch (error) {
-        if (isCancellation(error) || !isExhaustedActivityFailure(error)) {
-          throw error;
-        }
-        failedShards += 1;
-        reportProgress();
-        return { candidates: [], report: undefined };
-      }
-    }),
-  );
-  const ranked = interleave(shards.map((shard) => shard.candidates));
+
+  return {
+    report,
+    complete(candidateCount: number): void {
+      completedShards += 1;
+      candidates += candidateCount;
+      report();
+    },
+    fail(): void {
+      failedShards += 1;
+      report();
+    },
+  };
+}
+
+async function discoverShard(
+  activitySet: SelfBenchActivities,
+  run: RunRequest,
+  options: DiscoveryWaveOptions,
+  targetCounts: Readonly<Record<Difficulty, number>>,
+  shardIndex: number,
+  progress: ReturnType<typeof discoveryProgress>,
+): Promise<Pick<DiscoveryResult, "candidates">> {
+  try {
+    const result = await activitySet.discoverCandidateShard({
+      run,
+      wave: options.wave,
+      shardIndex,
+      shardCount: DISCOVERY_SHARD_COUNT,
+      targetCounts,
+      excludedSourcePrs: options.excludedSourcePrs,
+    } satisfies DiscoveryShardInput);
+    progress.complete(result.candidates.length);
+    return result;
+  } catch (error) {
+    if (isCancellation(error) || !isExhaustedActivityFailure(error)) {
+      throw error;
+    }
+    progress.fail();
+    return { candidates: [] };
+  }
+}
+
+function uniqueCandidates(candidates: readonly Candidate[]): Candidate[] {
   const seenPrs = new Set<number>();
-  return ranked.filter((candidate) => {
+  return candidates.filter((candidate) => {
     if (seenPrs.has(candidate.sourcePr)) {
       return false;
     }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -18,6 +18,21 @@ const submission = {
 };
 
 describe("API run metadata", () => {
+  test("accepts up to ten thousand candidates", () => {
+    const built = buildRunRequest(loadConfig(), {
+      ...submission,
+      candidateCounts: { easy: 3_334, medium: 3_333, hard: 3_333 },
+    });
+
+    expect(built.candidateCounts).toEqual({ easy: 3_334, medium: 3_333, hard: 3_333 });
+    expect(() =>
+      buildRunRequest(loadConfig(), {
+        ...submission,
+        candidateCounts: { easy: 3_334, medium: 3_334, hard: 3_333 },
+      }),
+    ).toThrow();
+  });
+
   test("persists the effective Vercel timeout cap with provider and Harbor metadata", () => {
     const config = loadConfig({
       SELFBENCH_EXECUTION_BACKEND: "vercel",

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { sha256 } from "../src/hash.js";
@@ -262,6 +262,146 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
     expect(dockerWithModalHarbor.some((line) => line.includes("Dockerfile.sandbox"))).toBe(true);
   });
 
+  test("associate verifies a merged PR and writes a private text-free manifest", async () => {
+    const root = await mkdtemp(join(tmpdir(), "selfbench-cli-associate-"));
+    roots.push(root);
+    const repository = join(root, "repo");
+    const home = join(root, "home");
+    const binaryDirectory = join(root, "bin");
+    const sessionDirectory = join(home, ".pi/agent/sessions/repository");
+    const output = join(root, "association.json");
+    await Promise.all([
+      mkdir(repository),
+      mkdir(binaryDirectory),
+      mkdir(sessionDirectory, { recursive: true }),
+    ]);
+    await runCommand("git", ["init", "-q", repository]);
+    await runCommand("git", ["-C", repository, "config", "user.email", "test@example.com"]);
+    await runCommand("git", ["-C", repository, "config", "user.name", "Test"]);
+    await writeFile(join(repository, "README.md"), "test repository\n");
+    await runCommand("git", ["-C", repository, "add", "."]);
+    await runCommand("git", ["-C", repository, "commit", "-qm", "base"]);
+    await runCommand("git", [
+      "-C",
+      repository,
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/example/project.git",
+    ]);
+    const repositoryWorktree = await realpath(repository);
+    const request = `Build the private feature in ${repositoryWorktree}`;
+    await writeFile(
+      join(sessionDirectory, "session.jsonl"),
+      [
+        JSON.stringify({
+          type: "session",
+          id: "session-1",
+          cwd: repositoryWorktree,
+          timestamp: "2026-08-24T00:00:00Z",
+        }),
+        JSON.stringify({
+          type: "message",
+          parentId: "parent",
+          message: { role: "user", content: request },
+        }),
+      ].join("\n"),
+    );
+    const gh = join(binaryDirectory, "gh");
+    await writeFile(
+      gh,
+      `#!/bin/sh
+printf '%s\\n' '{"number":42,"url":"https://github.com/example/project/pull/42","state":"MERGED","mergedAt":"2026-08-23T00:00:00Z"}'
+`,
+    );
+    await chmod(gh, 0o755);
+
+    const listChild = Bun.spawn(
+      [process.execPath, "src/cli.ts", "associate", "--repo", repository, "--list-sessions"],
+      {
+        cwd: join(import.meta.dir, ".."),
+        env: {
+          ...process.env,
+          HOME: home,
+          PATH: `${binaryDirectory}:${process.env.PATH ?? ""}`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [listExitCode, listStdout, listStderr] = await Promise.all([
+      listChild.exited,
+      new Response(listChild.stdout).text(),
+      new Response(listChild.stderr).text(),
+    ]);
+    expect(listExitCode, listStderr).toBe(0);
+    expect(JSON.parse(listStdout)).toEqual({
+      repository: "https://github.com/example/project.git",
+      sessions: [
+        {
+          selector: "pi:session-1",
+          sourceType: "pi",
+          sessionId: "session-1",
+          messageCount: 1,
+          modifiedAt: expect.any(String),
+          paths: ["~/.pi/agent/sessions/repository/session.jsonl"],
+        },
+      ],
+    });
+    expect(listStdout).not.toContain(request);
+
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        "src/cli.ts",
+        "associate",
+        "--repo",
+        repository,
+        "--pr",
+        "42",
+        "--session",
+        "pi:session-1",
+        "--output",
+        output,
+      ],
+      {
+        cwd: join(import.meta.dir, ".."),
+        env: {
+          ...process.env,
+          HOME: home,
+          PATH: `${binaryDirectory}:${process.env.PATH ?? ""}`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+
+    expect(exitCode, stderr).toBe(0);
+    const manifest = JSON.parse(await readFile(output, "utf8"));
+    expect(manifest).toEqual({
+      schemaVersion: 1,
+      repository: "example/project",
+      sourcePr: 42,
+      sourceUrl: "https://github.com/example/project/pull/42",
+      messages: [
+        {
+          sourceType: "pi",
+          sessionId: "session-1",
+          messageIndex: 0,
+          contentSha256: sha256(request),
+        },
+      ],
+    });
+    expect(JSON.stringify(manifest)).not.toContain("Build the private feature");
+    expect(stdout).not.toContain("Build the private feature");
+    expect((await stat(output)).mode & 0o777).toBe(0o600);
+  });
+
   test("run --output waits for completion and downloads a verified export", async () => {
     const root = await mkdtemp(join(tmpdir(), "selfbench-cli-"));
     roots.push(root);
@@ -270,6 +410,7 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
     const binaryDirectory = join(root, "bin");
     const sessionDirectory = join(home, ".codex/sessions");
     const output = join(root, "result.tar.gz");
+    const association = join(root, "association.json");
     await Promise.all([
       mkdir(repository),
       mkdir(binaryDirectory),
@@ -293,15 +434,33 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
       "https://github.com/example/project.git",
     ]);
     const repositoryWorktree = await realpath(repository);
+    const request = `Build the feature in ${repositoryWorktree}`;
     await writeFile(
       join(sessionDirectory, "session.jsonl"),
       [
         JSON.stringify({ type: "session_meta", payload: { id: "session-1" } }),
         JSON.stringify({
           type: "event_msg",
-          payload: { type: "user_message", message: `Build the feature in ${repositoryWorktree}` },
+          payload: { type: "user_message", message: request },
         }),
       ].join("\n"),
+    );
+    await writeFile(
+      association,
+      JSON.stringify({
+        schemaVersion: 1,
+        repository: "example/project",
+        sourcePr: 42,
+        sourceUrl: "https://github.com/example/project/pull/42",
+        messages: [
+          {
+            sourceType: "codex",
+            sessionId: "session-1",
+            messageIndex: 0,
+            contentSha256: sha256(request),
+          },
+        ],
+      }),
     );
 
     const exportBody = Buffer.from("verified export");
@@ -362,6 +521,8 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
           "2",
           "--hard-count",
           "3",
+          "--association",
+          association,
           "--output",
           output,
         ],
@@ -387,6 +548,11 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
       expect(exitCode, stderr).toBe(0);
       expect(await readFile(output)).toEqual(exportBody);
       expect(uploadedProvenance).toContain("Build the feature");
+      expect(JSON.parse(uploadedProvenance)).toMatchObject({
+        content: request,
+        sourcePr: 42,
+        sourceUrl: "https://github.com/example/project/pull/42",
+      });
       expect(submittedRun?.candidateCounts).toEqual({ easy: 1, medium: 2, hard: 3 });
       expect(stdout).toContain(`"output": "${output}"`);
       expect(stderr).toContain('"phase":"complete"');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -276,7 +276,7 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
       mkdir(sessionDirectory, { recursive: true }),
     ]);
     const gh = join(binaryDirectory, "gh");
-    await writeFile(gh, "#!/bin/sh\nprintf '[]\\n'\n");
+    await writeFile(gh, "#!/bin/sh\nexit 99\n");
     await chmod(gh, 0o755);
     await runCommand("git", ["init", "-q", repository]);
     await runCommand("git", ["-C", repository, "config", "user.email", "test@example.com"]);
@@ -305,6 +305,7 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
     );
 
     const exportBody = Buffer.from("verified export");
+    let uploadedProvenance = "";
     let submittedRun: Record<string, unknown> | undefined;
     const server = Bun.serve({
       hostname: "127.0.0.1",
@@ -312,6 +313,7 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
       fetch: async (request) => {
         const url = new URL(request.url);
         if (request.method === "POST" && url.pathname === "/v1/provenance") {
+          uploadedProvenance = await request.text();
           return Response.json({
             uri: "local://provenance",
             sha256: "a".repeat(64),
@@ -384,6 +386,7 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
 
       expect(exitCode, stderr).toBe(0);
       expect(await readFile(output)).toEqual(exportBody);
+      expect(uploadedProvenance).toContain("Build the feature");
       expect(submittedRun?.candidateCounts).toEqual({ easy: 1, medium: 2, hard: 3 });
       expect(stdout).toContain(`"output": "${output}"`);
       expect(stderr).toContain('"phase":"complete"');

--- a/tests/contracts.test.ts
+++ b/tests/contracts.test.ts
@@ -47,7 +47,7 @@ describe("contracts", () => {
     }
   });
 
-  test("requires between one and one hundred candidates across tiers", () => {
+  test("requires between one and ten thousand candidates across tiers", () => {
     expect(
       runRequestSchema.safeParse({
         ...request,
@@ -57,13 +57,13 @@ describe("contracts", () => {
     expect(
       runRequestSchema.safeParse({
         ...request,
-        candidateCounts: { easy: 34, medium: 33, hard: 33 },
+        candidateCounts: { easy: 3_334, medium: 3_333, hard: 3_333 },
       }).success,
     ).toBe(true);
     expect(
       runRequestSchema.safeParse({
         ...request,
-        candidateCounts: { easy: 34, medium: 34, hard: 33 },
+        candidateCounts: { easy: 3_334, medium: 3_334, hard: 3_333 },
       }).success,
     ).toBe(false);
   });

--- a/tests/provenance-associations.test.ts
+++ b/tests/provenance-associations.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sha256 } from "../src/hash.js";
+import { extractProvenanceMessages, type ProvenanceMessage } from "../src/provenance.js";
+import {
+  applyProvenanceAssociationManifests,
+  associationSessionSummaries,
+  createProvenanceAssociationManifest,
+} from "../src/provenance-associations.js";
+
+const repositoryUrl = "https://github.com/example/project.git";
+const sourceUrl = "https://github.com/example/project/pull/42";
+const messages: ProvenanceMessage[] = [
+  {
+    sourceType: "pi",
+    sessionId: "session-b",
+    messageIndex: 0,
+    content: "Authorization: Bearer [REDACTED] add routing",
+  },
+  {
+    sourceType: "pi",
+    sessionId: "session-a",
+    messageIndex: 1,
+    content: "Preserve the fallback",
+  },
+  {
+    sourceType: "pi",
+    sessionId: "session-a",
+    messageIndex: 0,
+    content: "Build the public routing API",
+  },
+  {
+    sourceType: "generic",
+    sessionId: "generic-session",
+    messageIndex: 0,
+    content: "Do not offer this session",
+  },
+];
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("provenance association manifests", () => {
+  test("lists local sessions with identifying file metadata but without message content", () => {
+    expect(
+      associationSessionSummaries(messages, [
+        {
+          sourceType: "pi",
+          sessionId: "session-a",
+          path: "~/.pi/agent/sessions/a.jsonl",
+          modifiedAt: "2026-08-24T01:00:00.000Z",
+        },
+        {
+          sourceType: "pi",
+          sessionId: "session-a",
+          path: "~/.pi/agent/sessions/archived-a.jsonl",
+          modifiedAt: "2026-08-24T02:00:00.000Z",
+        },
+        {
+          sourceType: "pi",
+          sessionId: "session-b",
+          path: "~/.pi/agent/sessions/b.jsonl",
+          modifiedAt: "2026-08-23T01:00:00.000Z",
+        },
+      ]),
+    ).toEqual([
+      {
+        selector: "pi:session-a",
+        sourceType: "pi",
+        sessionId: "session-a",
+        messageCount: 2,
+        modifiedAt: "2026-08-24T02:00:00.000Z",
+        paths: ["~/.pi/agent/sessions/a.jsonl", "~/.pi/agent/sessions/archived-a.jsonl"],
+      },
+      {
+        selector: "pi:session-b",
+        sourceType: "pi",
+        sessionId: "session-b",
+        messageCount: 1,
+        modifiedAt: "2026-08-23T01:00:00.000Z",
+        paths: ["~/.pi/agent/sessions/b.jsonl"],
+      },
+    ]);
+  });
+
+  test("hashes the exact sanitized and whitespace-normalized retained message", () => {
+    const raw = [
+      { type: "session", id: "normalized-session" },
+      {
+        type: "message",
+        parentId: "parent",
+        message: {
+          role: "user",
+          content: "  Authorization: Bearer private-token build routing.\n\n",
+        },
+      },
+    ]
+      .map((record) => JSON.stringify(record))
+      .join("\n");
+    const retained = extractProvenanceMessages(raw, "pi");
+    const manifest = createProvenanceAssociationManifest({
+      repositoryUrl,
+      pullRequest: { sourcePr: 42, sourceUrl },
+      messages: retained,
+      sessionSelectors: ["pi:normalized-session"],
+    });
+
+    expect(retained[0]?.content).toBe("Authorization: Bearer [REDACTED] build routing.");
+    expect(manifest.messages[0]?.contentSha256).toBe(
+      sha256("Authorization: Bearer [REDACTED] build routing."),
+    );
+  });
+
+  test("creates a deterministic text-free manifest for exact sanitized messages", () => {
+    const manifest = createProvenanceAssociationManifest({
+      repositoryUrl,
+      pullRequest: { sourcePr: 42, sourceUrl },
+      messages,
+      sessionSelectors: ["pi:session-a"],
+    });
+
+    expect(manifest).toEqual({
+      schemaVersion: 1,
+      repository: "example/project",
+      sourcePr: 42,
+      sourceUrl,
+      messages: [
+        {
+          sourceType: "pi",
+          sessionId: "session-a",
+          messageIndex: 0,
+          contentSha256: "5a14476a9c1591b902fac983e908ac96a660f456096ae6bf4802816ac1ffcbf9",
+        },
+        {
+          sourceType: "pi",
+          sessionId: "session-a",
+          messageIndex: 1,
+          contentSha256: "a7ed6f18e665f3de35513c1b9e5aefc5b1bdcaa1f8e1951e5d970ff79d299343",
+        },
+      ],
+    });
+    expect(JSON.stringify(manifest)).not.toContain("Build the public routing API");
+    expect(JSON.stringify(manifest)).not.toContain("REDACTED");
+  });
+
+  test("applies a valid binding without changing exact message content", async () => {
+    const root = await mkdtemp(join(tmpdir(), "selfbench-association-"));
+    roots.push(root);
+    const path = join(root, "association.json");
+    const manifest = createProvenanceAssociationManifest({
+      repositoryUrl,
+      pullRequest: { sourcePr: 42, sourceUrl },
+      messages,
+      sessionSelectors: ["pi:session-a"],
+    });
+    await writeFile(path, JSON.stringify(manifest));
+
+    const associated = await applyProvenanceAssociationManifests(messages, repositoryUrl, [path]);
+
+    expect(associated.map(({ content }) => content)).toEqual(
+      messages.map(({ content }) => content),
+    );
+    expect(associated[1]).toMatchObject({ sourcePr: 42, sourceUrl });
+    expect(associated[2]).toMatchObject({ sourcePr: 42, sourceUrl });
+    expect(associated[0]).toEqual(messages[0]);
+  });
+
+  test("rejects repository drift, content drift, and conflicting associations", async () => {
+    const root = await mkdtemp(join(tmpdir(), "selfbench-association-invalid-"));
+    roots.push(root);
+    const manifest = createProvenanceAssociationManifest({
+      repositoryUrl,
+      pullRequest: { sourcePr: 42, sourceUrl },
+      messages,
+      sessionSelectors: ["pi:session-a"],
+    });
+    const wrongRepository = join(root, "wrong-repository.json");
+    const changedContent = join(root, "changed-content.json");
+    const inventedText = join(root, "invented-text.json");
+    const duplicate = join(root, "duplicate.json");
+    await Promise.all([
+      writeFile(wrongRepository, JSON.stringify({ ...manifest, repository: "other/project" })),
+      writeFile(
+        changedContent,
+        JSON.stringify({
+          ...manifest,
+          messages: manifest.messages.map((message, index) =>
+            index === 0 ? { ...message, contentSha256: "a".repeat(64) } : message,
+          ),
+        }),
+      ),
+      writeFile(
+        inventedText,
+        JSON.stringify({
+          ...manifest,
+          messages: [{ ...manifest.messages[0], content: "Invented request text" }],
+        }),
+      ),
+      writeFile(duplicate, JSON.stringify(manifest)),
+    ]);
+
+    await expect(
+      applyProvenanceAssociationManifests(messages, repositoryUrl, [wrongRepository]),
+    ).rejects.toThrow("belongs to other/project");
+    await expect(
+      applyProvenanceAssociationManifests(messages, repositoryUrl, [changedContent]),
+    ).rejects.toThrow("does not match local session");
+    await expect(
+      applyProvenanceAssociationManifests(messages, repositoryUrl, [inventedText]),
+    ).rejects.toThrow();
+    await expect(
+      applyProvenanceAssociationManifests(
+        [
+          ...messages,
+          {
+            sourceType: "pi",
+            sessionId: "session-a",
+            messageIndex: 2,
+            content: "A later follow-up",
+          },
+        ],
+        repositoryUrl,
+        [duplicate],
+      ),
+    ).rejects.toThrow("does not match local session");
+    await expect(
+      applyProvenanceAssociationManifests(messages, repositoryUrl, [duplicate, duplicate]),
+    ).rejects.toThrow("associated more than once");
+  });
+});

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
   assertProvenanceMatchesPullRequest,
+  combineRunProvenance,
   extractGitHubPullRequestProvenance,
   extractProvenanceMessages,
+  type ProvenanceMessage,
   redactSecrets,
 } from "../src/provenance.js";
+import { selectCandidateProvenance } from "../src/temporal/activities.js";
 
 describe("provenance sanitization", () => {
   test("extracts human Codex messages and ignores injected context", () => {
@@ -26,6 +29,31 @@ describe("provenance sanitization", () => {
         sessionId: "session-1",
         messageIndex: 0,
         content: "Build the feature",
+      },
+    ]);
+  });
+
+  test("normalizes local user-message whitespace before secret redaction", () => {
+    const raw = [
+      { type: "session", id: "session-1" },
+      {
+        type: "message",
+        parentId: "parent",
+        message: {
+          role: "user",
+          content: "  Authorization: Bearer private-token keep this spacing.\n\n",
+        },
+      },
+    ]
+      .map((record) => JSON.stringify(record))
+      .join("\n");
+
+    expect(extractProvenanceMessages(raw, "pi")).toEqual([
+      {
+        sourceType: "pi",
+        sessionId: "session-1",
+        messageIndex: 0,
+        content: "Authorization: Bearer [REDACTED] keep this spacing.",
       },
     ]);
   });
@@ -107,6 +135,90 @@ describe("provenance sanitization", () => {
         sourceUrl: "https://github.com/example/project/pull/41",
       },
     ]);
+  });
+
+  test("prefers explicit local associations over GitHub fallback for the same PR", () => {
+    const local = {
+      sourceType: "codex" as const,
+      sessionId: "session-1",
+      messageIndex: 0,
+      content: "Build the feature",
+      sourcePr: 42,
+      sourceUrl: "https://github.com/example/project/pull/42",
+    };
+    const github = {
+      sourceType: "github-pull-request" as const,
+      sessionId: "github:example/project#42",
+      messageIndex: 0,
+      content: "Fallback title",
+      sourcePr: 42,
+      sourceUrl: "https://github.com/example/project/pull/42",
+    };
+
+    expect(combineRunProvenance("https://github.com/example/project", [local], [github])).toEqual([
+      local,
+    ]);
+  });
+
+  test("binds explicitly associated local provenance to its exact pull request", () => {
+    const message = {
+      sourceType: "pi" as const,
+      sessionId: "session-1",
+      messageIndex: 0,
+      content: "Build the feature",
+      sourcePr: 42,
+      sourceUrl: "https://github.com/example/project/pull/42",
+    };
+
+    expect(() =>
+      assertProvenanceMatchesPullRequest(message, 41, "https://github.com/example/project/pull/41"),
+    ).toThrow("does not match provenance");
+    expect(() =>
+      assertProvenanceMatchesPullRequest(message, 42, "https://github.com/example/project/pull/42"),
+    ).not.toThrow();
+  });
+
+  test("backend rejects unbound local provenance when a PR has an explicit association", () => {
+    const unbound: ProvenanceMessage = {
+      sourceType: "pi",
+      sessionId: "unbound-session",
+      messageIndex: 0,
+      content: "A different request",
+    };
+    const bound: ProvenanceMessage = {
+      sourceType: "codex",
+      sessionId: "bound-session",
+      messageIndex: 0,
+      content: "Build the feature",
+      sourcePr: 42,
+      sourceUrl: "https://github.com/example/project/pull/42",
+    };
+    const candidate = {
+      candidateId: "candidate-42",
+      sourcePr: 42,
+      sourceUrl: "https://github.com/example/project/pull/42",
+      provenance: {
+        sourceType: unbound.sourceType,
+        sessionId: unbound.sessionId,
+        messageIndex: unbound.messageIndex,
+      },
+    };
+
+    const discoveryShard = [unbound];
+    const completeCorpus = [unbound, bound];
+    expect(() => selectCandidateProvenance(discoveryShard, completeCorpus, candidate)).toThrow(
+      "has explicit local provenance; unbound local provenance cannot be selected",
+    );
+    expect(
+      selectCandidateProvenance([bound], [unbound, bound], {
+        ...candidate,
+        provenance: {
+          sourceType: bound.sourceType,
+          sessionId: bound.sessionId,
+          messageIndex: bound.messageIndex,
+        },
+      }),
+    ).toBe(bound);
   });
 
   test("binds GitHub provenance to its exact pull request", () => {

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -187,6 +187,38 @@ describe("SelfBench workflow", () => {
     expect(currentStatus?.().rejected).toBe(1);
   });
 
+  test("bounds candidate activity fanout for large runs", async () => {
+    const candidates = Array.from({ length: 101 }, (_unused, index) =>
+      candidate(`candidate-${index}`, index + 1),
+    );
+    const activities = acceptingActivities(candidates);
+    let active = 0;
+    let peak = 0;
+    activities.authorCandidate = async ({ candidate: value }) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      active -= 1;
+      return {
+        kind: "authored",
+        task: {
+          candidateId: value.candidateId,
+          taskId: `${value.candidateId}-task`,
+          definition: artifact,
+          bundle: artifact,
+        },
+      };
+    };
+
+    const result = await executeRun(
+      { ...run, candidateCounts: { easy: 0, medium: 0, hard: candidates.length } },
+      activities,
+    );
+
+    expect(peak).toBe(100);
+    expect(result.acceptedTaskIds).toHaveLength(candidates.length);
+  });
+
   test("expands discovery only until every tier authoring budget is filled", async () => {
     const targetCounts: Array<Record<Difficulty, number>> = [];
     const activities = acceptingActivities([]);

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -18,6 +18,12 @@ const artifact: ArtifactRef = {
   contentType: "application/json",
 };
 
+const combinedProvenance: ArtifactRef = {
+  ...artifact,
+  uri: "file:///combined-provenance.jsonl",
+  contentType: "application/x-ndjson",
+};
+
 const run: RunRequest = {
   runId: "workflow-test",
   repository: { url: "https://github.com/example/repo.git", commit: "a".repeat(40) },
@@ -48,6 +54,7 @@ function candidate(id: string, sourcePr: number, difficulty: Difficulty = "hard"
 
 function acceptingActivities(discovered: readonly Candidate[]): SelfBenchActivities {
   return {
+    collectRunProvenance: async () => artifact,
     discoverCandidateShard: async ({ shardIndex }) => ({
       candidates: shardIndex === 0 ? discovered : [],
       report: artifact,
@@ -80,6 +87,20 @@ function acceptingActivities(discovered: readonly Candidate[]): SelfBenchActivit
 }
 
 describe("SelfBench workflow", () => {
+  test("uses remotely collected pull request provenance for discovery", async () => {
+    const activities = acceptingActivities([candidate("candidate", 1)]);
+    activities.collectRunProvenance = async () => combinedProvenance;
+    activities.discoverCandidateShard = async ({ run: discoveryRun, shardIndex }) => {
+      expect(discoveryRun.provenance).toEqual(combinedProvenance);
+      return {
+        candidates: shardIndex === 0 ? [candidate("candidate", 1)] : [],
+        report: artifact,
+      };
+    };
+
+    await executeRun(run, activities);
+  });
+
   test("propagates discovery cancellation", async () => {
     let currentStatus: (() => RunStatus) | undefined;
     const activities = acceptingActivities([]);


### PR DESCRIPTION
## Summary
Raise the per-run candidate budget from 100 to 10,000 while preserving the requirement that every run request at least one candidate.

- Applies the same ceiling at the CLI, API, and durable run-contract boundaries.
- Bounds large-run candidate fanout and keeps discovery exclusions out of model prompts.

## Design
### Request validation
- `src/contracts.ts` — defines `MAX_CANDIDATES_PER_RUN` as the shared 10,000-candidate ceiling and applies it to per-tier and aggregate run validation.
- `src/cli.ts` — uses the shared ceiling for immediate user-facing validation.
- `src/api.ts` — accepts the larger tier counts before constructing the durable `RunRequest`, avoiding a mismatch between CLI and server behavior.

### Workflow capacity
- `src/temporal/workflow.ts` — scales the discovery pool with the run budget and limits candidate processing to 100 concurrent pipelines rather than scheduling all selected candidates at once.
- `src/temporal/activities.ts` and `src/extensions/discovery.ts` — pass prior PR exclusions as a sandbox file and enforce them in the submission tool, avoiding unbounded exclusion lists in model prompts.

### Coverage and documentation
- `tests/workflow.test.ts` — verifies that large candidate sets never exceed the bounded workflow fanout.
- `tests/contracts.test.ts` and `tests/api.test.ts` — cover the exact 10,000 boundary and reject 10,001 candidates.
- `docs/operations.md` — documents the new aggregate tier-count range.

## Validation
- `bun run validate` — passed: formatting, TypeScript checks, 178 tests, server/review builds, and package verification.
- CI retry passed after the initial run hit an unrelated timing flake in `tests/process.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the provenance pipeline, discovery contracts, and task materialization rules that ground every benchmark candidate; mistakes could mis-bind requests to PRs or break large runs, though association is validated locally and APIs are unchanged.
> 
> **Overview**
> Raises the per-run **candidate authoring budget from 100 to 10,000** via shared `MAX_CANDIDATES_PER_RUN` validation in contracts, the API, and CLI, and scales workflow capacity with a larger discovery pool plus **100 concurrent** candidate pipelines instead of unbounded `Promise.all`.
> 
> Adds **`self-bench associate`** to list local Pi/Claude/Codex sessions and write **text-free, hash-bound manifests** that tie selected sessions to a merged PR; **`self-bench run --association`** re-validates those manifests locally and annotates uploaded local provenance with `sourcePr`/`sourceUrl` before the worker runs.
> 
> **Moves merged GitHub PR provenance collection to the worker**: the CLI uploads only local sanitized NDJSON, then a new `collectRunProvenance` activity merges it with up to 500 GitHub PRs (`combineRunProvenance` drops GitHub fallback when a PR has explicit local bindings). Discovery no longer carries inline `request` text—candidates reference provenance identities only—and **PR exclusions** are passed as a sandbox file and enforced in `submit_discovery` so large exclusion lists stay out of model prompts. Materialization rejects unbound local messages for explicitly associated PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a91d97fcbf3a48a07f0935d0c84a4f972ffd48b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->