### PR TITLE
Move pull request discovery into Temporal

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,12 +158,9 @@ Common failures:
 
 `self-bench run` requires an absolute or relative path to a Git checkout whose `origin` is an HTTPS or SSH GitHub URL. It pins `HEAD`; uncommitted content is excluded.
 
-The CLI collects two types of provenance:
+The CLI collects sanitized user messages from Pi, Claude Code, and Codex sessions associated with the checkout or its worktrees, then uploads that local corpus with the run request. The workflow starts by running a Temporal activity on the worker that fetches exact titles and bodies from up to 500 recent merged pull requests by non-bot authors that clear coarse tier-appropriate size thresholds. It stores the combined local and GitHub corpus as a run artifact before discovery begins.
 
-1. sanitized user messages from Pi, Claude Code, and Codex sessions associated with the checkout or its worktrees;
-2. exact titles and bodies from up to 500 recent merged pull requests by non-bot authors that clear coarse tier-appropriate size thresholds.
-
-GitHub records remain labeled `github-pull-request` and are bound to their own repository, PR number, and canonical URL. Local requests are preferred when they clearly describe the same change. Common credential forms and injected harness context are removed, but this is not a general secret scanner.
+GitHub records remain labeled `github-pull-request` and are bound to their own repository, PR number, and canonical URL. Local requests are preferred when they clearly describe the same change. A run can proceed with only local or only GitHub provenance, but fails when the combined corpus is empty. Common credential forms and injected harness context are removed, but this is not a general secret scanner.
 
 ```bash
 self-bench run \

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { buildCommit } from "./build-metadata.js";
 import { loadWorkerConfig } from "./config.js";
 import { MAX_CANDIDATES_PER_RUN } from "./contracts.js";
 import { runCommand } from "./process.js";
-import { collectGitHubPullRequestProvenance, collectRepositoryProvenance } from "./provenance.js";
+import { collectRepositoryProvenance } from "./provenance.js";
 import { isExecutionBackend, isHarborEnvironment, matchingHarborEnvironment } from "./providers.js";
 import { type PolledRunStatus, waitForRun } from "./run-wait.js";
 import { applyVercelProfile, setupVercel } from "./setup/vercel/index.js";
@@ -193,12 +193,11 @@ async function run(args: string[]): Promise<void> {
     collectRepositoryProvenance(repositoryPath, process.env.HOME ?? homedir()),
     resolveSelfBenchCommit(),
   ]);
-  const githubMessages = await collectGitHubPullRequestProvenance(repository.url);
-  const messages = [...localMessages, ...githubMessages];
-  if (messages.length === 0) {
-    throw new Error("no sanitized local-session or GitHub pull-request provenance was found");
-  }
-  const corpus = Buffer.from(`${messages.map((message) => JSON.stringify(message)).join("\n")}\n`);
+  const corpus = Buffer.from(
+    localMessages.length > 0
+      ? `${localMessages.map((message) => JSON.stringify(message)).join("\n")}\n`
+      : "",
+  );
   const provenance = await requestJson(`/v1/provenance?runId=${encodeURIComponent(runId)}`, {
     method: "POST",
     body: corpus,
@@ -222,9 +221,7 @@ async function run(args: string[]): Promise<void> {
     JSON.stringify(
       {
         ...response,
-        provenanceMessages: messages.length,
         localProvenanceMessages: localMessages.length,
-        githubPullRequestMessages: githubMessages.length,
       },
       null,
       2,

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -74,20 +74,27 @@ export async function collectRepositoryProvenance(
 
 export async function collectGitHubPullRequestProvenance(
   repositoryUrl: string,
+  token?: string,
 ): Promise<ProvenanceMessage[]> {
   const repository = githubRepository(repositoryUrl);
-  const result = await runCommand("gh", [
-    "pr",
-    "list",
-    "--repo",
-    repository,
-    "--state",
-    "merged",
-    "--limit",
-    String(GITHUB_PULL_REQUEST_LIMIT),
-    "--json",
-    "number,title,body,url,author,isDraft,additions,deletions,changedFiles",
-  ]);
+  const result = await runCommand(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      repository,
+      "--state",
+      "merged",
+      "--limit",
+      String(GITHUB_PULL_REQUEST_LIMIT),
+      "--json",
+      "number,title,body,url,author,isDraft,additions,deletions,changedFiles",
+    ],
+    {
+      env: token ? { ...process.env, GH_TOKEN: token } : process.env,
+    },
+  );
   return extractGitHubPullRequestProvenance(result.stdout, repositoryUrl);
 }
 

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -75,6 +75,7 @@ export async function collectRepositoryProvenance(
 export async function collectGitHubPullRequestProvenance(
   repositoryUrl: string,
   token?: string,
+  signal?: AbortSignal,
 ): Promise<ProvenanceMessage[]> {
   const repository = githubRepository(repositoryUrl);
   const result = await runCommand(
@@ -93,6 +94,7 @@ export async function collectGitHubPullRequestProvenance(
     ],
     {
       env: token ? { ...process.env, GH_TOKEN: token } : process.env,
+      ...(signal ? { signal } : {}),
     },
   );
   return extractGitHubPullRequestProvenance(result.stdout, repositoryUrl);

--- a/src/temporal/activities.ts
+++ b/src/temporal/activities.ts
@@ -43,7 +43,11 @@ import { refreshHarborTask } from "../harbor-task.js";
 import { sha256 } from "../hash.js";
 import { runCommand } from "../process.js";
 import { projectRoot } from "../project-paths.js";
-import { assertProvenanceMatchesPullRequest, type ProvenanceMessage } from "../provenance.js";
+import {
+  assertProvenanceMatchesPullRequest,
+  collectGitHubPullRequestProvenance,
+  type ProvenanceMessage,
+} from "../provenance.js";
 import {
   createSandboxExecutor,
   SandboxExecutionError,
@@ -111,6 +115,7 @@ export interface ExportInput {
 }
 
 export interface SelfBenchActivities {
+  collectRunProvenance(run: RunRequest): Promise<ArtifactRef>;
   discoverCandidateShard(input: DiscoveryShardInput): Promise<DiscoveryResult>;
   authorCandidate(input: AuthorCandidateInput): Promise<AuthorOutcome>;
   validateTask(input: TaskStageInput): Promise<ValidationResult>;
@@ -125,6 +130,7 @@ export function createActivities(config: SelfBenchWorkerConfig): SelfBenchActivi
   const store = createArtifactStore(config.artifact);
   const sandbox = createSandboxExecutor(config.execution);
   return {
+    collectRunProvenance: (run) => collectRunProvenance(store, run),
     discoverCandidateShard: (input) => discoverCandidateShard(store, sandbox, input),
     authorCandidate: (input) => authorCandidate(store, sandbox, input),
     validateTask: (input) => validateTask(store, config.harborEnvironment, input),
@@ -134,6 +140,25 @@ export function createActivities(config: SelfBenchWorkerConfig): SelfBenchActivi
     auditTask: (input) => auditTask(store, input),
     buildExport: (input) => buildExport(store, input),
   };
+}
+
+async function collectRunProvenance(store: ArtifactStore, run: RunRequest): Promise<ArtifactRef> {
+  Context.current().heartbeat("collecting merged GitHub pull requests");
+  const [localBytes, token] = await Promise.all([store.get(run.provenance), githubToken()]);
+  const local = parseProvenance(localBytes);
+  const github = await collectGitHubPullRequestProvenance(run.repository.url, token);
+  const messages = [...local, ...github];
+  if (messages.length === 0) {
+    throw ApplicationFailure.nonRetryable(
+      "no sanitized local-session or GitHub pull-request provenance was found",
+      "NoProvenance",
+    );
+  }
+  return await store.put(
+    `runs/${run.runId}/input/combined-provenance.jsonl`,
+    Buffer.from(`${messages.map((message) => JSON.stringify(message)).join("\n")}\n`),
+    "application/x-ndjson",
+  );
 }
 
 async function discoverCandidateShard(

--- a/src/temporal/activities.ts
+++ b/src/temporal/activities.ts
@@ -143,21 +143,25 @@ export function createActivities(config: SelfBenchWorkerConfig): SelfBenchActivi
 }
 
 async function collectRunProvenance(store: ArtifactStore, run: RunRequest): Promise<ArtifactRef> {
-  Context.current().heartbeat("collecting merged GitHub pull requests");
-  const [localBytes, token] = await Promise.all([store.get(run.provenance), githubToken()]);
-  const local = parseProvenance(localBytes);
-  const github = await collectGitHubPullRequestProvenance(run.repository.url, token);
-  const messages = [...local, ...github];
-  if (messages.length === 0) {
-    throw ApplicationFailure.nonRetryable(
-      "no sanitized local-session or GitHub pull-request provenance was found",
-      "NoProvenance",
-    );
-  }
-  return await store.put(
-    `runs/${run.runId}/input/combined-provenance.jsonl`,
-    Buffer.from(`${messages.map((message) => JSON.stringify(message)).join("\n")}\n`),
-    "application/x-ndjson",
+  return await withActivityHeartbeats(
+    "collecting merged GitHub pull requests",
+    async ({ signal }) => {
+      const [localBytes, token] = await Promise.all([store.get(run.provenance), githubToken()]);
+      const local = parseProvenance(localBytes);
+      const github = await collectGitHubPullRequestProvenance(run.repository.url, token, signal);
+      const messages = [...local, ...github];
+      if (messages.length === 0) {
+        throw ApplicationFailure.nonRetryable(
+          "no sanitized local-session or GitHub pull-request provenance was found",
+          "NoProvenance",
+        );
+      }
+      return await store.put(
+        `runs/${run.runId}/input/combined-provenance-attempt-${Context.current().info.attempt}.jsonl`,
+        Buffer.from(`${messages.map((message) => JSON.stringify(message)).join("\n")}\n`),
+        "application/x-ndjson",
+      );
+    },
   );
 }
 

--- a/src/temporal/workflow.ts
+++ b/src/temporal/workflow.ts
@@ -13,6 +13,7 @@ import type {
   Candidate,
   Difficulty,
   DiscoveryProgress,
+  DiscoveryResult,
   RunRequest,
   RunResult,
   RunStatus,
@@ -370,58 +371,92 @@ async function discoverWave(
   run: RunRequest,
   options: DiscoveryWaveOptions,
 ): Promise<Candidate[]> {
-  const targetCounts = Object.fromEntries(
+  const targetCounts = discoveryShardTargets(options.targetCounts);
+  const progress = discoveryProgress(options);
+  progress.report();
+
+  const shards = await Promise.all(
+    Array.from({ length: DISCOVERY_SHARD_COUNT }, (_unused, shardIndex) =>
+      discoverShard(activitySet, run, options, targetCounts, shardIndex, progress),
+    ),
+  );
+  return uniqueCandidates(interleave(shards.map((shard) => shard.candidates)));
+}
+
+function discoveryShardTargets(
+  targetCounts: RunRequest["candidateCounts"],
+): Record<Difficulty, number> {
+  return Object.fromEntries(
     (["easy", "medium", "hard"] as const).map((difficulty) => [
       difficulty,
-      options.targetCounts[difficulty] === 0
+      targetCounts[difficulty] === 0
         ? 0
         : Math.min(
             MAX_CANDIDATES_PER_TIER_PER_SHARD,
-            Math.ceil(options.targetCounts[difficulty] / DISCOVERY_SHARD_COUNT) +
-              DISCOVERY_SHARD_OVERFETCH,
+            Math.ceil(targetCounts[difficulty] / DISCOVERY_SHARD_COUNT) + DISCOVERY_SHARD_OVERFETCH,
           ),
     ]),
   ) as Record<Difficulty, number>;
+}
+
+function discoveryProgress(options: DiscoveryWaveOptions) {
   let completedShards = 0;
   let failedShards = 0;
-  let candidateCount = 0;
-  const reportProgress = (): void =>
+  let candidates = 0;
+  const report = (): void =>
     options.onProgress({
       wave: options.wave,
       totalShards: DISCOVERY_SHARD_COUNT,
       completedShards,
       failedShards,
-      candidates: candidateCount,
+      candidates,
     });
-  reportProgress();
-  const shards = await Promise.all(
-    Array.from({ length: DISCOVERY_SHARD_COUNT }, async (_unused, shardIndex) => {
-      try {
-        const result = await activitySet.discoverCandidateShard({
-          run,
-          wave: options.wave,
-          shardIndex,
-          shardCount: DISCOVERY_SHARD_COUNT,
-          targetCounts,
-          excludedSourcePrs: options.excludedSourcePrs,
-        } satisfies DiscoveryShardInput);
-        completedShards += 1;
-        candidateCount += result.candidates.length;
-        reportProgress();
-        return result;
-      } catch (error) {
-        if (isCancellation(error) || !isExhaustedActivityFailure(error)) {
-          throw error;
-        }
-        failedShards += 1;
-        reportProgress();
-        return { candidates: [], report: undefined };
-      }
-    }),
-  );
-  const ranked = interleave(shards.map((shard) => shard.candidates));
+
+  return {
+    report,
+    complete(candidateCount: number): void {
+      completedShards += 1;
+      candidates += candidateCount;
+      report();
+    },
+    fail(): void {
+      failedShards += 1;
+      report();
+    },
+  };
+}
+
+async function discoverShard(
+  activitySet: SelfBenchActivities,
+  run: RunRequest,
+  options: DiscoveryWaveOptions,
+  targetCounts: Readonly<Record<Difficulty, number>>,
+  shardIndex: number,
+  progress: ReturnType<typeof discoveryProgress>,
+): Promise<Pick<DiscoveryResult, "candidates">> {
+  try {
+    const result = await activitySet.discoverCandidateShard({
+      run,
+      wave: options.wave,
+      shardIndex,
+      shardCount: DISCOVERY_SHARD_COUNT,
+      targetCounts,
+      excludedSourcePrs: options.excludedSourcePrs,
+    } satisfies DiscoveryShardInput);
+    progress.complete(result.candidates.length);
+    return result;
+  } catch (error) {
+    if (isCancellation(error) || !isExhaustedActivityFailure(error)) {
+      throw error;
+    }
+    progress.fail();
+    return { candidates: [] };
+  }
+}
+
+function uniqueCandidates(candidates: readonly Candidate[]): Candidate[] {
   const seenPrs = new Set<number>();
-  return ranked.filter((candidate) => {
+  return candidates.filter((candidate) => {
     if (seenPrs.has(candidate.sourcePr)) {
       return false;
     }

--- a/src/temporal/workflow.ts
+++ b/src/temporal/workflow.ts
@@ -34,7 +34,10 @@ import type {
 export const statusQuery = defineQuery<RunStatus>("status");
 
 const taskActivities = proxyActivities<
-  Omit<SelfBenchActivities, "discoverCandidateShard" | "repairValidationTask">
+  Omit<
+    SelfBenchActivities,
+    "collectRunProvenance" | "discoverCandidateShard" | "repairValidationTask"
+  >
 >({
   startToCloseTimeout: "7 hours",
   heartbeatTimeout: "10 minutes",
@@ -56,6 +59,18 @@ const validationRepairActivity = proxyActivities<Pick<SelfBenchActivities, "repa
   },
 );
 
+const provenanceActivities = proxyActivities<Pick<SelfBenchActivities, "collectRunProvenance">>({
+  startToCloseTimeout: "5 minutes",
+  heartbeatTimeout: "3 minutes",
+  cancellationType: "WAIT_CANCELLATION_COMPLETED",
+  retry: {
+    initialInterval: "5 seconds",
+    backoffCoefficient: 2,
+    maximumInterval: "1 minute",
+    maximumAttempts: 3,
+  },
+});
+
 const discoveryActivities = proxyActivities<Pick<SelfBenchActivities, "discoverCandidateShard">>({
   startToCloseTimeout: "1 hour",
   heartbeatTimeout: "10 minutes",
@@ -69,6 +84,7 @@ const discoveryActivities = proxyActivities<Pick<SelfBenchActivities, "discoverC
 });
 
 const activities: SelfBenchActivities = {
+  collectRunProvenance: provenanceActivities.collectRunProvenance,
   discoverCandidateShard: discoveryActivities.discoverCandidateShard,
   authorCandidate: taskActivities.authorCandidate,
   validateTask: taskActivities.validateTask,
@@ -127,6 +143,8 @@ export async function executeRun(
 
   try {
     setPhase("discovering");
+    const provenance = await activitySet.collectRunProvenance(input);
+    const run = { ...input, provenance };
     const updateDiscovery = (progress: DiscoveryProgress): void => {
       status = { ...status, discovery: progress };
     };
@@ -143,7 +161,7 @@ export async function executeRun(
         setPhase("blocked");
         throw candidatePoolExhausted(selected, input.candidateCounts);
       }
-      const additions = await discoverWave(activitySet, input, {
+      const additions = await discoverWave(activitySet, run, {
         wave: discoveryWave,
         targetCounts: missing,
         excludedSourcePrs: candidates.map((candidate) => candidate.sourcePr),
@@ -180,7 +198,7 @@ export async function executeRun(
       setTasks(taskProgress);
       try {
         const authored = await activitySet.authorCandidate({
-          run: input,
+          run,
           candidate,
         } satisfies AuthorCandidateInput);
         if (authored.kind === "rejected") {
@@ -197,7 +215,7 @@ export async function executeRun(
 
         progress.status = "auditing";
         setTasks(taskProgress);
-        const audit = await activitySet.auditTask({ run: input, task } satisfies TaskStageInput);
+        const audit = await activitySet.auditTask({ run, task } satisfies TaskStageInput);
         if (!audit.accepted) {
           rejectProgress(progress, audit.reason ?? "audit rejected task");
           return;
@@ -206,7 +224,7 @@ export async function executeRun(
         progress.status = "validating";
         setTasks(taskProgress);
         let validation = await activitySet.validateTask({
-          run: input,
+          run,
           task,
         } satisfies TaskStageInput);
         if (!validation.accepted) {
@@ -215,7 +233,7 @@ export async function executeRun(
           let repaired: AuthorOutcome;
           try {
             repaired = await activitySet.repairValidationTask({
-              run: input,
+              run,
               task,
               validation,
             } satisfies ValidationRepairTaskInput);
@@ -235,7 +253,7 @@ export async function executeRun(
           progress.status = "auditing";
           setTasks(taskProgress);
           const repairAudit = await activitySet.auditTask({
-            run: input,
+            run,
             task,
           } satisfies TaskStageInput);
           if (!repairAudit.accepted) {
@@ -246,7 +264,7 @@ export async function executeRun(
           progress.status = "validating";
           setTasks(taskProgress);
           validation = await activitySet.validateTask({
-            run: input,
+            run,
             task,
           } satisfies TaskStageInput);
           if (!validation.accepted) {
@@ -257,14 +275,14 @@ export async function executeRun(
 
         progress.status = "reviewing";
         setTasks(taskProgress);
-        let review = await activitySet.reviewTask({ run: input, task } satisfies TaskStageInput);
+        let review = await activitySet.reviewTask({ run, task } satisfies TaskStageInput);
         if (!review.accepted) {
           progress.status = "repairing";
           setTasks(taskProgress);
           let repaired: AuthorOutcome;
           try {
             repaired = await activitySet.repairTask({
-              run: input,
+              run,
               task,
               review: review.report,
             } satisfies RepairTaskInput);
@@ -284,7 +302,7 @@ export async function executeRun(
           progress.status = "auditing";
           setTasks(taskProgress);
           const repairAudit = await activitySet.auditTask({
-            run: input,
+            run,
             task,
           } satisfies TaskStageInput);
           if (!repairAudit.accepted) {
@@ -295,7 +313,7 @@ export async function executeRun(
           progress.status = "validating";
           setTasks(taskProgress);
           const repairValidation = await activitySet.validateTask({
-            run: input,
+            run,
             task,
           } satisfies TaskStageInput);
           if (!repairValidation.accepted) {
@@ -308,7 +326,7 @@ export async function executeRun(
 
           progress.status = "reviewing";
           setTasks(taskProgress);
-          review = await activitySet.reviewTask({ run: input, task } satisfies TaskStageInput);
+          review = await activitySet.reviewTask({ run, task } satisfies TaskStageInput);
           if (!review.accepted) {
             rejectProgress(progress, review.reason ?? "review rejected repaired task");
             return;
@@ -336,7 +354,7 @@ export async function executeRun(
 
     setPhase("exporting");
     const exportRef = await activitySet.buildExport({
-      run: input,
+      run,
       tasks: acceptedTasks,
     } satisfies ExportInput);
     status = { ...status, phase: "complete", export: exportRef };

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -276,7 +276,7 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
       mkdir(sessionDirectory, { recursive: true }),
     ]);
     const gh = join(binaryDirectory, "gh");
-    await writeFile(gh, "#!/bin/sh\nprintf '[]\\n'\n");
+    await writeFile(gh, "#!/bin/sh\nexit 99\n");
     await chmod(gh, 0o755);
     await runCommand("git", ["init", "-q", repository]);
     await runCommand("git", ["-C", repository, "config", "user.email", "test@example.com"]);
@@ -305,6 +305,7 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
     );
 
     const exportBody = Buffer.from("verified export");
+    let uploadedProvenance = "";
     let submittedRun: Record<string, unknown> | undefined;
     const server = Bun.serve({
       hostname: "127.0.0.1",
@@ -312,6 +313,7 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
       fetch: async (request) => {
         const url = new URL(request.url);
         if (request.method === "POST" && url.pathname === "/v1/provenance") {
+          uploadedProvenance = await request.text();
           return Response.json({
             uri: "local://provenance",
             sha256: "a".repeat(64),
@@ -384,6 +386,7 @@ printf '%s|%s|%s|%s\n' "$*" "$SELFBENCH_EXECUTION_BACKEND" "$SELFBENCH_HARBOR_EN
 
       expect(exitCode, stderr).toBe(0);
       expect(await readFile(output)).toEqual(exportBody);
+      expect(uploadedProvenance).toContain("Build the feature");
       expect(submittedRun?.candidateCounts).toEqual({ easy: 1, medium: 2, hard: 3 });
       expect(stdout).toContain(`"output": "${output}"`);
       expect(stderr).toContain('"phase":"complete"');

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -18,6 +18,12 @@ const artifact: ArtifactRef = {
   contentType: "application/json",
 };
 
+const combinedProvenance: ArtifactRef = {
+  ...artifact,
+  uri: "file:///combined-provenance.jsonl",
+  contentType: "application/x-ndjson",
+};
+
 const run: RunRequest = {
   runId: "workflow-test",
   repository: { url: "https://github.com/example/repo.git", commit: "a".repeat(40) },
@@ -48,6 +54,7 @@ function candidate(id: string, sourcePr: number, difficulty: Difficulty = "hard"
 
 function acceptingActivities(discovered: readonly Candidate[]): SelfBenchActivities {
   return {
+    collectRunProvenance: async () => artifact,
     discoverCandidateShard: async ({ shardIndex }) => ({
       candidates: shardIndex === 0 ? discovered : [],
       report: artifact,
@@ -80,6 +87,20 @@ function acceptingActivities(discovered: readonly Candidate[]): SelfBenchActivit
 }
 
 describe("SelfBench workflow", () => {
+  test("uses remotely collected pull request provenance for discovery", async () => {
+    const activities = acceptingActivities([candidate("candidate", 1)]);
+    activities.collectRunProvenance = async () => combinedProvenance;
+    activities.discoverCandidateShard = async ({ run: discoveryRun, shardIndex }) => {
+      expect(discoveryRun.provenance).toEqual(combinedProvenance);
+      return {
+        candidates: shardIndex === 0 ? [candidate("candidate", 1)] : [],
+        report: artifact,
+      };
+    };
+
+    await executeRun(run, activities);
+  });
+
   test("propagates discovery cancellation", async () => {
     let currentStatus: (() => RunStatus) | undefined;
     const activities = acceptingActivities([]);


### PR DESCRIPTION
## Summary
Move merged pull-request provenance collection from the submitting CLI to the Temporal worker, and simplify discovery-wave orchestration.

- The CLI now uploads only machine-local Pi, Claude Code, and Codex requests.
- The workflow builds the combined local + GitHub provenance corpus before discovery.
- Discovery shard behavior remains unchanged but is split into focused helpers.

## Design
### Provenance ownership
- `src/cli.ts` — removes GitHub PR lookup from `self-bench run`; an empty local corpus is valid because the worker can supply GitHub provenance.
- `src/temporal/activities.ts` — adds `collectRunProvenance()`, which reads the uploaded local corpus, fetches up to 500 eligible merged PRs using worker GitHub credentials, fails only when both sources are empty, and stores a combined run artifact.
- `src/provenance.ts` — allows the worker-resolved token to be passed explicitly to the existing GitHub collection command.
- `src/temporal/workflow.ts` — runs provenance collection as a dedicated bounded/retried activity before discovery and passes the resulting artifact through every downstream stage.

### Discovery orchestration
- `src/temporal/workflow.ts` — reduces `discoverWave()` to calculating shard targets, initializing progress, running all shards, and combining candidates.
- `src/temporal/workflow.ts` — extracts target calculation into `discoveryShardTargets()`, progress state into `discoveryProgress()`, per-shard execution and retry-exhaustion handling into `discoverShard()`, and PR deduplication into `uniqueCandidates()`.

### Coverage and operations
- `tests/cli.test.ts` — proves `self-bench run` succeeds and uploads local provenance even when the CLI-side `gh` command fails.
- `tests/workflow.test.ts` — verifies discovery receives the worker-created combined provenance artifact while preserving existing shard failure and cancellation behavior.
- `docs/operations.md` — documents the local/worker split and permits local-only or GitHub-only provenance.

## Validation
- `bun run validate` — passed formatting, TypeScript checks, 179 tests, server/review builds, and package verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the provenance pipeline and when runs fail (empty local corpus is OK at submit time but still fails on the worker if GitHub also yields nothing); worker GitHub auth now gates PR corpus quality.
> 
> **Overview**
> **Merged pull-request provenance is now built on the Temporal worker** instead of in `self-bench run`. The CLI only uploads sanitized local Pi, Claude Code, and Codex session messages; it no longer calls `gh` or fails when local provenance is empty.
> 
> A new **`collectRunProvenance`** activity runs at the start of the workflow: it loads the uploaded local corpus, fetches up to 500 eligible merged PRs using **worker** GitHub credentials (with optional `GH_TOKEN` and cancellation via `collectGitHubPullRequestProvenance`), merges the two sources, fails with `NoProvenance` only when both are empty, and stores a combined NDJSON artifact. Discovery and all later stages use this artifact via an updated `run.provenance` reference.
> 
> **Discovery wave orchestration** in `workflow.ts` is refactored into `discoveryShardTargets`, `discoveryProgress`, `discoverShard`, and `uniqueCandidates` without changing shard semantics. Docs and tests reflect the split (CLI succeeds when local `gh` fails; workflow test asserts discovery sees combined provenance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff4d56d844fd42668aecbf6cc3a3323198df09c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->