### PR TITLE
Release self-bench 0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-bench",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Turn completed repository changes into durable, private Harbor evaluations",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Release `self-bench` 0.3.6, including the latest `main` changes that raise the candidate limit to 10,000 per run.

## Design
### Package release
- `package.json` — bump the published package version from `0.3.5` to `0.3.6`.
- `src/cli.ts`, `src/contracts.ts` — included from `main`; expose the 10,000-candidate run limit in the release.

## Validation
- `bun install --frozen-lockfile` — passed.
- `bun run validate` — passed: 189 tests, 0 failures.
- `bun run verify:package:docker` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no logic modifications in the diff; release risk depends on code already on main, not on edits in this PR.
> 
> **Overview**
> **Bumps the published npm package version from `0.3.5` to `0.3.6`** so `self-bench` can be released with the current `main` build (including validation and package verification already noted in the release process).
> 
> No runtime or API code changes appear in this diff—only `package.json` version metadata for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df529c120713bd7251dea545af3fe383b64b9b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->