### PR TITLE
Polish credentials and add Codex device sign-in

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "4.7.0",
         "drizzle-kit": "^0.31.10",
+        "happy-dom": "20.14.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-router": "7.18.3",
@@ -653,6 +654,10 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
@@ -747,6 +752,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -832,6 +839,8 @@
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -924,6 +933,8 @@
     "grok-mermaid": ["grok-mermaid@0.2.2", "", {}, "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA=="],
 
     "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
+
+    "happy-dom": ["happy-dom@20.14.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-y/Kvh5vDe7SDa57PYU3eBtPFznlbDnXBcm0S14JU+JddqRr8ZGly2YopPuvrg9UKfBVmTYkQNAA9btBkwT4Kzw=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1302,6 +1313,8 @@
     "webpack": ["webpack@5.109.2", "", { "dependencies": { "@types/estree": "^1.0.8", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.16.0", "browserslist": "^4.28.1", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.24.4", "es-module-lexer": "^2.1.0", "eslint-scope": "5.1.1", "events": "^3.2.0", "graceful-fs": "^4.2.11", "mime-db": "^1.54.0", "minimizer-webpack-plugin": "^5.6.1", "neo-async": "^2.6.2", "schema-utils": "^4.3.3", "tapable": "^2.3.0", "watchpack": "^2.5.2", "webpack-sources": "^3.5.1" }, "peerDependencies": { "webpack-cli": "*" }, "optionalPeers": ["webpack-cli"], "bin": { "webpack": "bin/webpack.js" } }, "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw=="],
 
     "webpack-sources": ["webpack-sources@3.5.1", "", {}, "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@clack/prompts": "1.7.0",
         "@google-cloud/storage": "^7.22.0",
+        "@openai/codex": "0.153.4",
         "@radix-ui/react-dropdown-menu": "2.1.24",
         "@radix-ui/react-slot": "1.3.3",
         "@sinclair/typebox": "0.34.41",
@@ -353,6 +354,20 @@
     "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ=="],
 
     "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
+
+    "@openai/codex": ["@openai/codex@0.153.4", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.4-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.4-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.4-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.153.4-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.4-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.153.4-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-wbHDmit7S/YvBGVX1DQmk13xtWblZ2cApeJ/pB7xDZ10Cna+DZc5ij7f0F4OxdsXN4FW1oLT48OpogUI1+8Y2w=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.153.4-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B1qhN3fa1ay0R0wGziXqgwSkB5icpYChNKHhtBHff/0UtSTC7z+l8aTtvMlGjH3E8HEvY3+njIJelM9CAAoVWg=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.153.4-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-vnSbbPzfoDZmmyzsxswsDDXQ06IVFBzkQU7/hroB3ji93Ok2utcsq8Psfk2tjF5r9mEx8RWFJhzuTGHG26/NDA=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.153.4-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-QKdjYLYV4hXIuUQDP3P6F4NXuWFoKo9WUoV4nAREIx55kiUyi8UsYdsVobkeXir5n/maEQgYMCKLHVma4rNPiw=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.153.4-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-x1EcwBlY3AObM1VTUHNM2AzAJQsyreGdagpF+qFiYi/Oa30VBktvvG0C6tLtCzqW6hjZNWkGZQWmeVk7MuJKWg=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.153.4-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-/FBh42976ltF1kxDoPQBg1Q6+hwChRU5/sm5dfeC8kFVQMvOCGoGeY5d8rRZGVJE8XojlXo74VQb0sHowcfgBw=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.153.4-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "4.7.0",
     "drizzle-kit": "^0.31.10",
+    "happy-dom": "20.14.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-router": "7.18.3",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@clack/prompts": "1.7.0",
     "@google-cloud/storage": "^7.22.0",
+    "@openai/codex": "0.153.4",
     "@sinclair/typebox": "0.34.41",
     "@temporalio/activity": "^1.23.0",
     "@temporalio/client": "^1.23.0",

--- a/review/src/main.tsx
+++ b/review/src/main.tsx
@@ -25,7 +25,20 @@ function Boot() {
       cancelled = true;
     };
   }, []);
-  if (site === null) return null;
+  if (site === null)
+    return (
+      <div role="status" aria-label="Loading Application" className="space-y-7 p-8">
+        <span className="sr-only">Loading application…</span>
+        <div
+          aria-hidden="true"
+          className="h-7 w-44 animate-pulse bg-(--border) motion-reduce:animate-none"
+        />
+        <div
+          aria-hidden="true"
+          className="h-48 animate-pulse border border-(--border) bg-(--card) motion-reduce:animate-none"
+        />
+      </div>
+    );
   return site ? <WebApp /> : <App />;
 }
 

--- a/review/src/web/ConnectRepoSheet.tsx
+++ b/review/src/web/ConnectRepoSheet.tsx
@@ -8,6 +8,7 @@ import {
   type Repo,
   type RepoDetail,
 } from "./api";
+import { ListSkeleton } from "./LoadingSkeleton";
 import type { SiteOrg } from "./session";
 
 export interface ConnectRepoSheetProps {
@@ -189,7 +190,7 @@ export function ConnectRepoSheet({
           aria-label="Repositories"
         >
           {mode === "mine" && repos.status === "loading" && (
-            <p className="py-4 text-muted">Loading repositories…</p>
+            <ListSkeleton label="Loading Repositories" />
           )}
           {mode === "mine" && repos.status === "error" && (
             <p className="py-4 text-muted mt-4 font-mono text-base leading-relaxed text-danger">
@@ -202,7 +203,7 @@ export function ConnectRepoSheet({
             </p>
           )}
           {mode === "public" && detail?.status === "loading" && (
-            <p className="py-4 text-muted">Looking up {typedName}…</p>
+            <ListSkeleton label="Looking Up Repository" rows={1} />
           )}
           {mode === "public" && detail?.status === "error" && (
             <p className="py-4 text-muted mt-4 font-mono text-base leading-relaxed text-danger">

--- a/review/src/web/LoadingSkeleton.tsx
+++ b/review/src/web/LoadingSkeleton.tsx
@@ -1,0 +1,58 @@
+export function Skeleton({ className = "" }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`block animate-pulse bg-surface-3 motion-reduce:animate-none ${className}`}
+    />
+  );
+}
+
+export function ListSkeleton({ label, rows = 3 }: { label: string; rows?: number }) {
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className="divide-y divide-line border border-line bg-surface"
+    >
+      <span className="sr-only">{label}</span>
+      {["first", "second", "third", "fourth"].slice(0, rows).map((key) => (
+        <div key={key} className="flex items-center gap-4 px-5 py-5" aria-hidden="true">
+          <Skeleton className="size-10 shrink-0" />
+          <div className="min-w-0 flex-1 space-y-3">
+            <Skeleton className="h-3.5 w-36 max-w-full" />
+            <Skeleton className="h-3 w-56 max-w-full" />
+          </div>
+          <Skeleton className="hidden h-5 w-20 sm:block" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function SiteSkeleton() {
+  return (
+    <div className="min-h-screen lg:pl-60" role="status" aria-label="Loading Workspace">
+      <span className="sr-only">Loading workspace…</span>
+      <aside
+        aria-hidden="true"
+        className="fixed inset-y-0 left-0 hidden w-60 space-y-6 border-r border-line bg-surface p-6 lg:block"
+      >
+        <Skeleton className="h-8 w-36" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-4 w-32" />
+      </aside>
+      <div
+        aria-hidden="true"
+        className="flex h-14 items-center justify-end border-b border-line px-8"
+      >
+        <Skeleton className="size-7" />
+      </div>
+      <div className="space-y-7 px-4 py-8 sm:px-8" aria-hidden="true">
+        <Skeleton className="h-6 w-52" />
+        <Skeleton className="h-4 w-80 max-w-full" />
+        <ListSkeleton label="Loading Content" />
+      </div>
+    </div>
+  );
+}

--- a/review/src/web/SidebarOrgPicker.tsx
+++ b/review/src/web/SidebarOrgPicker.tsx
@@ -10,10 +10,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./primitives/dropdown-menu";
-import { SidebarMenuButton } from "./primitives/sidebar";
 import type { SiteOrg } from "./session";
 
-/** The org picker pinned to the bottom of the sidebar. */
+/** Switch accounts without taking space from the sidebar navigation. */
 export function SidebarOrgPicker({
   org,
   orgs,
@@ -25,32 +24,46 @@ export function SidebarOrgPicker({
 }) {
   const root = React.useRef<HTMLDivElement>(null);
   const [container, setContainer] = React.useState<HTMLElement | null>(null);
-  React.useEffect(() => setContainer(root.current?.closest("dialog") ?? null), []);
+  React.useEffect(() => {
+    setContainer(
+      root.current?.closest("dialog") ?? root.current?.closest<HTMLElement>(".sb") ?? null,
+    );
+  }, []);
   const personal = orgs.filter((item) => item.kind === "user");
   const organizations = orgs.filter((item) => item.kind === "org");
   return (
     <div ref={root}>
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
-          <SidebarMenuButton
-            size="lg"
+          <button
+            type="button"
             aria-label="Organization"
-            className="border border-line hover:border-line-strong"
+            className="group flex min-h-14 w-full cursor-pointer items-center gap-3 border border-transparent px-2.5 py-2 text-left transition-colors hover:border-mint/60 hover:bg-surface-2 focus-visible:outline-2 focus-visible:outline-mint data-[state=open]:border-mint data-[state=open]:bg-surface-2"
           >
-            <Avatar login={org.login} url={org.avatarUrl} size={26} />
-            <span className="min-w-0 flex-1 truncate text-ink">{org.login}</span>
-            <ChevronsUpDown className="text-dim" />
-          </SidebarMenuButton>
+            <span className="shrink-0 overflow-hidden border border-line">
+              <Avatar login={org.login} url={org.avatarUrl} size={28} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate font-sans text-[15px] font-semibold leading-5 text-ink">
+                {org.login}
+              </span>
+              <span className="block font-sans text-xs leading-5 text-dim">
+                {org.kind === "user" ? "Personal Account" : "Organization"}
+              </span>
+            </span>
+            <ChevronsUpDown
+              aria-hidden="true"
+              className="size-3.5 shrink-0 text-dim transition-colors group-hover:text-mint-bright"
+            />
+          </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
           container={container}
           side="top"
           align="start"
-          className="w-64"
+          className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0 max-w-[calc(100vw-24px)] p-1.5"
           aria-label="Switch Organization"
         >
-          <DropdownMenuLabel>Switch Organization</DropdownMenuLabel>
-          <DropdownMenuSeparator />
           <DropdownMenuRadioGroup
             value={org.login}
             onValueChange={(login) => {
@@ -58,20 +71,20 @@ export function SidebarOrgPicker({
               if (selected) onSelect(selected);
             }}
           >
-            <DropdownMenuLabel className="font-mono text-xs font-medium tracking-[0.14em] text-mint uppercase">
-              Personal
-            </DropdownMenuLabel>
             {personal.map((item) => (
               <OrgItem key={item.login} org={item} />
             ))}
             {organizations.length > 0 && (
-              <DropdownMenuLabel className="font-mono text-xs font-medium tracking-[0.14em] text-mint uppercase">
-                Organizations
-              </DropdownMenuLabel>
+              <>
+                {personal.length > 0 && <DropdownMenuSeparator />}
+                <DropdownMenuLabel className="px-2 pt-2 pb-1 font-sans text-xs text-dim">
+                  Organizations
+                </DropdownMenuLabel>
+                {organizations.map((item) => (
+                  <OrgItem key={item.login} org={item} />
+                ))}
+              </>
             )}
-            {organizations.map((item) => (
-              <OrgItem key={item.login} org={item} />
-            ))}
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -81,12 +94,19 @@ export function SidebarOrgPicker({
 
 function OrgItem({ org }: { org: SiteOrg }) {
   return (
-    <DropdownMenuRadioItem value={org.login}>
-      <Avatar login={org.login} url={org.avatarUrl} size={20} />
-      <span className="min-w-0 flex-1 truncate">{org.login}</span>
-      {org.kind === "org" && org.role === "admin" && (
-        <span className="font-mono text-sm tracking-widest text-dim uppercase">admin</span>
-      )}
+    <DropdownMenuRadioItem
+      value={org.login}
+      className="min-h-9 gap-2.5 py-1.5 data-[state=checked]:bg-mint/5"
+    >
+      <span className="shrink-0 overflow-hidden border border-line">
+        <Avatar login={org.login} url={org.avatarUrl} size={24} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-sans text-sm leading-5">{org.login}</span>
+        {org.kind === "user" && (
+          <span className="block font-sans text-xs leading-5 text-dim">Personal Account</span>
+        )}
+      </span>
     </DropdownMenuRadioItem>
   );
 }

--- a/review/src/web/SiteSidebar.test.tsx
+++ b/review/src/web/SiteSidebar.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { SiteSidebar } from "./SiteSidebar";
+import type { SiteOrg } from "./session";
+
+function renderSidebar(path: string, kind: SiteOrg["kind"] = "org") {
+  const org: SiteOrg = { login: "example-account", kind, role: "admin" };
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={[path]}>
+      <SiteSidebar
+        user={{ login: "example-user" }}
+        org={org}
+        orgs={[org]}
+        onSelect={() => {}}
+        onSignOut={async () => {}}
+      />
+    </MemoryRouter>,
+  );
+}
+
+test("sidebar navigation uses larger sans labels and roomy rows", () => {
+  const html = renderSidebar("/");
+  const links = html.match(/<a[^>]*data-slot="sidebar-menu-button"[^>]*>/g) ?? [];
+  expect(links).toHaveLength(2);
+  for (const link of links) {
+    expect(link).toContain("font-sans");
+    expect(link).toContain("text-[15px]");
+    expect(link).toContain("h-11");
+    expect(link).not.toContain("font-mono");
+  }
+  expect(html).toContain('aria-label="Organization Navigation"');
+  expect(html).toContain('aria-label="Organization Settings"');
+});
+
+test("sidebar preserves active navigation across repository and settings routes", () => {
+  for (const [path, href] of [
+    ["/", "/"],
+    ["/repos/example-account/example-repo", "/"],
+    ["/settings/credentials", "/settings/credentials"],
+  ]) {
+    const html = renderSidebar(path);
+    const active = html.match(/<a[^>]*data-active="true"[^>]*>/g) ?? [];
+    expect(active).toHaveLength(1);
+    expect(active[0]).toContain(`href="${href}"`);
+  }
+});
+
+test("account picker keeps its menu affordance and readable personal account label", () => {
+  const html = renderSidebar("/", "user");
+  expect(html).toContain('aria-haspopup="menu"');
+  expect(html).toContain('aria-label="Organization"');
+  expect(html).toContain("cursor-pointer");
+  expect(html).toContain("example-account");
+  expect(html).toContain("Personal Account");
+  expect(html).toContain("font-sans text-xs leading-5 text-dim");
+  expect(html).toContain(
+    'class="block truncate font-sans text-[15px] font-semibold leading-5 text-ink"',
+  );
+});

--- a/review/src/web/UserMenu.tsx
+++ b/review/src/web/UserMenu.tsx
@@ -8,7 +8,6 @@ export function UserMenu({ user, onSignOut }: { user: SiteUser; onSignOut: () =>
   return (
     <Dropdown
       label="Account"
-      above
       className="user-menu"
       trigger={
         <>

--- a/review/src/web/WebApp.tsx
+++ b/review/src/web/WebApp.tsx
@@ -5,6 +5,7 @@ import { ComparisonPage } from "./evaluation/ComparisonPage";
 import { CredentialsPage } from "./evaluation/CredentialsPage";
 import { EvaluationPage } from "./evaluation/EvaluationPage";
 import { RunPage } from "./evaluation/RunPage";
+import { SiteSkeleton } from "./LoadingSkeleton";
 import { AddPrPage } from "./pages/AddPrPage";
 import { LoginPage } from "./pages/LoginPage";
 import { RepoPage } from "./pages/RepoPage";
@@ -49,7 +50,9 @@ export function WebApp() {
   return (
     <SessionContext.Provider value={value}>
       <div className="sb min-h-full bg-bg font-sans text-base leading-normal text-ink antialiased [&_a]:no-underline [&_button:not(:disabled)]:cursor-pointer [&_:focus-visible]:outline-2 [&_:focus-visible]:outline-mint-bright [&_:focus-visible]:outline-offset-2 motion-reduce:[&_*]:transition-none">
-        {session.status === "loading" ? null : (
+        {session.status === "loading" ? (
+          <SiteSkeleton />
+        ) : (
           <BrowserRouter>
             <Routes>
               <Route path="/login" element={<LoginPage />} />

--- a/review/src/web/evaluation/CodexSignIn.test.tsx
+++ b/review/src/web/evaluation/CodexSignIn.test.tsx
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, expect, mock, spyOn, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { CredentialEditor } from "./CredentialEditor";
+
+const base = "/api/orgs/test/credentials/codex-login";
+const saved = { id: "credential", name: "Codex", kind: "openai", auth: "codex-login" };
+const session = (id: string, status = "waiting") => ({
+  id,
+  status,
+  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  instructions: { userCode: "TEST-CODE", verificationUrl: "https://auth.openai.com/codex/device" },
+});
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+let browser: Window;
+let root: Root;
+let container: HTMLDivElement;
+let restoreGlobals: () => void;
+let requests: string[];
+let respond: (path: string, method: string) => Response | Promise<Response>;
+let restoreFetch: () => void;
+const onSaved = mock(async () => {});
+const onCancel = mock(() => {});
+
+beforeEach(async () => {
+  browser = new Window({ url: "https://selfbench.test" });
+  const globals = {
+    window: browser,
+    document: browser.document,
+    HTMLElement: browser.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+  const previous = Object.keys(globals).map(
+    (key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)] as const,
+  );
+  for (const [key, value] of Object.entries(globals))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  restoreGlobals = () => {
+    for (const [key, descriptor] of previous) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+  };
+  requests = [];
+  respond = () => Response.json({});
+  const fetch = spyOn(globalThis, "fetch").mockImplementation((async (input, init) => {
+    const path = String(input);
+    const method = init?.method ?? "GET";
+    requests.push(`${method} ${path}`);
+    return respond(path, method);
+  }) as typeof globalThis.fetch);
+  restoreFetch = () => fetch.mockRestore();
+  onSaved.mockClear();
+  onCancel.mockClear();
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <CredentialEditor
+        org="test"
+        auth="codex-login"
+        onSave={async () => {}}
+        onSaved={onSaved}
+        onCancel={onCancel}
+      />,
+    );
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  restoreFetch();
+  restoreGlobals();
+  await browser.happyDOM.close();
+});
+
+function button(label: string) {
+  const result = [...container.querySelectorAll("button")].find(
+    (item) => (item.getAttribute("aria-label") ?? item.textContent?.trim()) === label,
+  );
+  if (!result) throw new Error(`Missing button: ${label}`);
+  return result;
+}
+async function click(label: string) {
+  await act(async () => button(label).click());
+}
+async function waitFor(predicate: () => boolean) {
+  const deadline = Date.now() + 3_000;
+  while (!predicate() && Date.now() < deadline)
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 25)));
+  expect(predicate()).toBe(true);
+}
+
+test("restarting after a polling error does not revive the cancelled attempt", async () => {
+  const restart = deferred<Response>();
+  let starts = 0;
+  respond = (path) => {
+    if (path === base) {
+      starts += 1;
+      return starts === 1 ? Response.json(session("old")) : restart.promise;
+    }
+    if (path === `${base}/old`)
+      return Response.json({ error: "Could not check sign-in" }, { status: 410 });
+    if (path === `${base}/new`) return Response.json(session("new", "ready"));
+    if (path.endsWith("/complete")) return Response.json(saved);
+    return Response.json({});
+  };
+  await click("Sign in with ChatGPT");
+  await waitFor(() => !!container.querySelector('[role="alert"]'));
+  await click("Start Again");
+  // The server waits for the old Codex process to close before returning the new session.
+  await act(async () => new Promise((resolve) => setTimeout(resolve, 650)));
+  expect(requests.filter((request) => request === `GET ${base}/old`)).toHaveLength(1);
+  await act(async () => restart.resolve(Response.json(session("new"))));
+  await waitFor(() => onSaved.mock.calls.length === 1);
+  expect(container.textContent).toContain("Codex Connected");
+  expect(container.querySelector('[role="alert"]')).toBeNull();
+});
+
+test("dismissal waits for the approved credential to save and refresh the list", async () => {
+  const saving = deferred<Response>();
+  respond = (path) => {
+    if (path === base) return Response.json(session("approved"));
+    if (path.endsWith("/complete")) return saving.promise;
+    return Response.json(session("approved", "ready"));
+  };
+  await click("Sign in with ChatGPT");
+  await waitFor(() => requests.includes(`POST ${base}/approved/complete`));
+  expect(button("Close").disabled).toBe(true);
+  expect(button("Cancel Sign-In").disabled).toBe(true);
+  await click("Close");
+  await click("Cancel Sign-In");
+  const cancel = new browser.Event("cancel", { cancelable: true });
+  await act(async () => browser.document.querySelector("dialog")?.dispatchEvent(cancel));
+  expect(cancel.defaultPrevented).toBe(true);
+  expect(onCancel).not.toHaveBeenCalled();
+  expect(requests.some((request) => request.endsWith("/cancel"))).toBe(false);
+  await act(async () => saving.resolve(Response.json(saved)));
+  await waitFor(() => onSaved.mock.calls.length === 1);
+  expect(button("Close").disabled).toBe(false);
+  expect(container.textContent).toContain("Codex Connected");
+});
+
+test("a failed save unlocks dismissal and can retry the approved session", async () => {
+  let saves = 0;
+  respond = (path) => {
+    if (path === base) return Response.json(session("approved"));
+    if (path.endsWith("/complete")) {
+      saves += 1;
+      return saves === 1
+        ? Response.json({ error: "Storage unavailable. Retry saving." }, { status: 503 })
+        : Response.json(saved);
+    }
+    return Response.json(session("approved", "ready"));
+  };
+  await click("Sign in with ChatGPT");
+  await waitFor(() => !!container.querySelector('[role="alert"]'));
+  expect(button("Close").disabled).toBe(false);
+  expect(button("Cancel Sign-In").disabled).toBe(false);
+  expect(onSaved).not.toHaveBeenCalled();
+  await click("Retry");
+  await waitFor(() => onSaved.mock.calls.length === 1);
+  expect(saves).toBe(2);
+});

--- a/review/src/web/evaluation/CodexSignIn.tsx
+++ b/review/src/web/evaluation/CodexSignIn.tsx
@@ -9,11 +9,13 @@ export function CodexSignIn({
   org,
   name,
   onActiveChange,
+  onSavingChange,
   onDone,
 }: {
   org: string;
   name: string;
   onActiveChange(active: boolean): void;
+  onSavingChange(saving: boolean): void;
   onDone(): Promise<void>;
 }) {
   const url = `/api/orgs/${encodeURIComponent(org)}/credentials/codex-login`;
@@ -23,6 +25,7 @@ export function CodexSignIn({
   const [copied, setCopied] = React.useState(false);
   const [copyHint, setCopyHint] = React.useState("");
   const attempt = React.useRef<string>(undefined);
+  const generation = React.useRef(0);
   const alive = React.useRef(true);
   const completed = React.useRef(onDone);
   completed.current = onDone;
@@ -31,6 +34,7 @@ export function CodexSignIn({
     alive.current = true;
     return () => {
       alive.current = false;
+      generation.current += 1;
       if (attempt.current)
         void evaluationRequest(`${url}/${attempt.current}/cancel`, {}).catch(() => undefined);
     };
@@ -39,19 +43,23 @@ export function CodexSignIn({
   React.useEffect(() => {
     if (!sessionId || error) return;
     let disposed = false;
+    const current = generation.current;
+    const stale = () => disposed || current !== generation.current;
     let timer: ReturnType<typeof setTimeout>;
     const poll = async () => {
       try {
         const next = await evaluationRequest<CodexLoginStatus>(`${url}/${sessionId}`);
-        if (disposed) return;
+        if (stale()) return;
         if (next.status === "ready") {
           setSession({ ...next, status: "saving" });
+          onSavingChange(true);
           const credential = await evaluationRequest<NonNullable<CodexLoginStatus["credential"]>>(
             `${url}/${sessionId}/complete`,
             {},
           );
-          if (!disposed) {
+          if (!stale()) {
             setSession({ ...next, status: "saved", credential });
+            onSavingChange(false);
             onActiveChange(false);
             void completed.current();
           }
@@ -65,8 +73,10 @@ export function CodexSignIn({
         }
         timer = setTimeout(poll, 1500);
       } catch (cause) {
-        if (!disposed)
+        if (!stale()) {
+          onSavingChange(false);
           setError(cause instanceof Error ? cause.message : "Could not check sign-in. Try again.");
+        }
       }
     };
     timer = setTimeout(poll, 500);
@@ -74,8 +84,10 @@ export function CodexSignIn({
       disposed = true;
       clearTimeout(timer);
     };
-  }, [sessionId, error, url, onActiveChange]);
+  }, [sessionId, error, url, onActiveChange, onSavingChange]);
   const start = async () => {
+    generation.current += 1;
+    setSession(undefined);
     setStarting(true);
     setError("");
     setCopied(false);

--- a/review/src/web/evaluation/CodexSignIn.tsx
+++ b/review/src/web/evaluation/CodexSignIn.tsx
@@ -1,0 +1,251 @@
+import { ArrowUpRight, Check, Copy, Terminal } from "lucide-react";
+import React from "react";
+import type { CodexLoginStatus } from "../../../../src/evaluation/codex-login";
+import { Skeleton } from "../LoadingSkeleton";
+import { Button, buttonStyles } from "../ui";
+import { evaluationRequest } from "./api";
+
+export function CodexSignIn({
+  org,
+  name,
+  onActiveChange,
+  onDone,
+}: {
+  org: string;
+  name: string;
+  onActiveChange(active: boolean): void;
+  onDone(): Promise<void>;
+}) {
+  const url = `/api/orgs/${encodeURIComponent(org)}/credentials/codex-login`;
+  const [session, setSession] = React.useState<CodexLoginStatus>();
+  const [starting, setStarting] = React.useState(false);
+  const [error, setError] = React.useState("");
+  const [copied, setCopied] = React.useState(false);
+  const [copyHint, setCopyHint] = React.useState("");
+  const attempt = React.useRef<string>(undefined);
+  const alive = React.useRef(true);
+  const completed = React.useRef(onDone);
+  completed.current = onDone;
+  const code = React.useRef<HTMLInputElement>(null);
+  React.useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+      if (attempt.current)
+        void evaluationRequest(`${url}/${attempt.current}/cancel`, {}).catch(() => undefined);
+    };
+  }, [url]);
+  const sessionId = session?.id;
+  React.useEffect(() => {
+    if (!sessionId || error) return;
+    let disposed = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const poll = async () => {
+      try {
+        const next = await evaluationRequest<CodexLoginStatus>(`${url}/${sessionId}`);
+        if (disposed) return;
+        if (next.status === "ready") {
+          setSession({ ...next, status: "saving" });
+          const credential = await evaluationRequest<NonNullable<CodexLoginStatus["credential"]>>(
+            `${url}/${sessionId}/complete`,
+            {},
+          );
+          if (!disposed) {
+            setSession({ ...next, status: "saved", credential });
+            onActiveChange(false);
+            void completed.current();
+          }
+          return;
+        }
+        setSession(next);
+        if (next.status === "failed" || next.status === "saved") {
+          onActiveChange(false);
+          if (next.status === "saved") void completed.current();
+          return;
+        }
+        timer = setTimeout(poll, 1500);
+      } catch (cause) {
+        if (!disposed)
+          setError(cause instanceof Error ? cause.message : "Could not check sign-in. Try again.");
+      }
+    };
+    timer = setTimeout(poll, 500);
+    return () => {
+      disposed = true;
+      clearTimeout(timer);
+    };
+  }, [sessionId, error, url, onActiveChange]);
+  const start = async () => {
+    setStarting(true);
+    setError("");
+    setCopied(false);
+    setCopyHint("");
+    onActiveChange(true);
+    try {
+      const next = await evaluationRequest<CodexLoginStatus>(url, { name: name.trim() });
+      if (!alive.current) {
+        void evaluationRequest(`${url}/${next.id}/cancel`, {}).catch(() => undefined);
+        return;
+      }
+      attempt.current = next.id;
+      setSession(next);
+    } catch (cause) {
+      if (alive.current) {
+        setError(cause instanceof Error ? cause.message : "Could not start sign-in");
+        onActiveChange(false);
+      }
+    } finally {
+      if (alive.current) setStarting(false);
+    }
+  };
+  if (session?.status === "saved")
+    return (
+      <div className="border border-mint/25 bg-mint/5 p-5" role="status">
+        <Check className="mb-3 text-mint" size={22} aria-hidden="true" />
+        <h3 className="font-semibold">Codex Connected</h3>
+        <p className="mt-2 text-sm leading-6 text-muted">
+          {session.credential?.name} is saved and ready for Codex runs in {org}.
+        </p>
+        <Button type="button" className="mt-5" variant="primary" onClick={() => void onDone()}>
+          Done
+        </Button>
+      </div>
+    );
+  return (
+    <div className="space-y-4">
+      {!session && !starting ? (
+        <div className="border border-line bg-bg p-5">
+          <Terminal size={24} className="mb-3 text-mint" aria-hidden="true" />
+          <h3 className="text-sm font-semibold">Connect Your ChatGPT Account</h3>
+          <p className="mt-2 text-sm leading-6 text-muted">
+            You’ll receive a one-time code to enter on OpenAI. After you approve, your sign-in is
+            saved for Codex runs across {org}.
+          </p>
+          <Button
+            type="button"
+            className="mt-5 w-full"
+            variant="primary"
+            disabled={!name.trim()}
+            onClick={() => void start()}
+          >
+            Sign in with ChatGPT
+            <ArrowUpRight size={15} aria-hidden="true" />
+          </Button>
+        </div>
+      ) : starting || session?.status === "starting" ? (
+        <div
+          role="status"
+          aria-label="Preparing Sign-In"
+          className="space-y-4 border border-line bg-bg p-5"
+        >
+          <Skeleton className="h-4 w-44" />
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-9 w-full" />
+          <span className="sr-only">Preparing your sign-in code…</span>
+        </div>
+      ) : session?.status === "failed" ? (
+        <div role="alert" className="border border-danger/30 p-5">
+          <p className="text-sm leading-6 text-danger">{session.error}</p>
+          <Button type="button" className="mt-4" onClick={() => void start()}>
+            Start Again
+          </Button>
+        </div>
+      ) : (
+        <div className="border border-line bg-bg p-5">
+          <ol className="space-y-5 text-sm">
+            <li>
+              <p className="mb-3 font-medium">
+                <span className="mr-2 font-mono text-dim">01</span>Copy Your One-Time Code
+              </p>
+              <div className="flex border border-line-strong bg-surface">
+                <input
+                  ref={code}
+                  aria-label="One-Time Code"
+                  readOnly
+                  value={session?.instructions?.userCode ?? ""}
+                  onFocus={(event) => event.target.select()}
+                  className="min-w-0 flex-1 bg-transparent p-3 text-center font-mono text-xl tracking-[0.15em] text-mint outline-none"
+                />
+                <button
+                  type="button"
+                  aria-label={copied ? "Code Copied" : "Copy Code"}
+                  title={copied ? "Code Copied" : "Copy Code"}
+                  className="border-l border-line px-4 text-muted hover:text-mint"
+                  onClick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(session?.instructions?.userCode ?? "");
+                      setCopied(true);
+                    } catch {
+                      code.current?.focus();
+                      code.current?.select();
+                      setCopyHint("Copy the selected code, then open OpenAI to continue.");
+                    }
+                  }}
+                >
+                  {copied ? (
+                    <Check size={16} aria-hidden="true" />
+                  ) : (
+                    <Copy size={16} aria-hidden="true" />
+                  )}
+                </button>
+              </div>
+              {copyHint && (
+                <p role="status" className="mt-2 text-xs text-muted">
+                  {copyHint}
+                </p>
+              )}
+            </li>
+            <li>
+              <p className="mb-3 font-medium">
+                <span className="mr-2 font-mono text-dim">02</span>Approve on OpenAI
+              </p>
+              <a
+                className={`${buttonStyles.primary} w-full`}
+                href={session?.instructions?.verificationUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Open OpenAI
+                <ArrowUpRight size={15} aria-hidden="true" />
+              </a>
+              <p className="mt-2 text-xs leading-5 text-muted">
+                Sign in, enter the code, and approve access. Then return here.
+              </p>
+            </li>
+          </ol>
+          <p
+            className="mt-5 flex items-center gap-2 border-t border-line pt-4 text-xs text-muted"
+            role="status"
+          >
+            <span
+              className="size-1.5 animate-pulse bg-mint motion-reduce:animate-none"
+              aria-hidden="true"
+            />
+            {session?.status === "saving"
+              ? "Saving your credential…"
+              : "Waiting for approval on OpenAI…"}
+          </p>
+        </div>
+      )}
+      {error && (
+        <div role="alert" className="text-sm leading-6 text-danger">
+          <p>{error}</p>
+          {session && (
+            <div className="mt-2 flex gap-2">
+              <Button type="button" onClick={() => setError("")}>
+                Retry
+              </Button>
+              <Button type="button" variant="ghost" onClick={() => void start()}>
+                Start Again
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+      <p className="text-xs leading-5 text-muted">
+        Device code login must be enabled in your ChatGPT security settings. Your ChatGPT
+        subscription limits apply.
+      </p>
+    </div>
+  );
+}

--- a/review/src/web/evaluation/CredentialEditor.tsx
+++ b/review/src/web/evaluation/CredentialEditor.tsx
@@ -187,6 +187,7 @@ export function CredentialEditor({
               org={org}
               name={draft.name}
               onActiveChange={setSigningIn}
+              onSavingChange={setBusy}
               onDone={onSaved}
             />
           ) : (

--- a/review/src/web/evaluation/CredentialEditor.tsx
+++ b/review/src/web/evaluation/CredentialEditor.tsx
@@ -1,56 +1,93 @@
+import { LockKeyhole, X } from "lucide-react";
 import React from "react";
 import type { CredentialInfo } from "../../../../src/evaluation/account";
 import type { CredentialDraft } from "../../../../src/evaluation/credentials";
 import { Button, Input, Select } from "../ui";
+import { useModalDialog } from "../useModalDialog";
+import { CodexSignIn } from "./CodexSignIn";
+import { CredentialSecret } from "./CredentialSecret";
+import { providers, sandboxes } from "./credential-presentation";
 
-const providerOptions = [
-  { id: "openai", label: "OpenAI" },
-  { id: "anthropic", label: "Anthropic" },
-  { id: "openrouter", label: "OpenRouter" },
-  { id: "custom", label: "Custom" },
-];
-const sandboxOptions = [
-  { id: "e2b", label: "E2B" },
-  { id: "modal", label: "Modal" },
-  { id: "daytona", label: "Daytona" },
-];
-
+const field = "grid gap-2 text-sm font-medium text-ink";
 export function CredentialEditor({
   previous,
+  kind = "openai",
+  auth = "api-key",
+  org,
   onSave,
+  onSaved,
   onCancel,
 }: {
   previous?: CredentialInfo;
+  kind?: CredentialDraft["kind"];
+  auth?: CredentialDraft["auth"];
+  org: string;
   onSave(value: CredentialDraft): Promise<void>;
+  onSaved(): Promise<void>;
   onCancel(): void;
 }) {
   const [draft, setDraft] = React.useState<CredentialDraft>({
-    name: previous ? `${previous.name} replacement` : "",
-    kind: previous?.kind ?? "openai",
-    auth: previous?.auth ?? "api-key",
+    name: previous
+      ? `${previous.name} replacement`.slice(0, 80)
+      : auth === "codex-login"
+        ? "Codex"
+        : "",
+    kind: previous?.kind ?? kind,
+    auth: previous?.auth ?? auth,
     value: "",
     endpoint: previous?.endpoint,
   });
   const [busy, setBusy] = React.useState(false);
+  const [signingIn, setSigningIn] = React.useState(false);
+  const [importing, setImporting] = React.useState(false);
   const [error, setError] = React.useState("");
+  const name = React.useRef<HTMLInputElement>(null);
+  const dialog = useModalDialog(name);
+  const isLogin = draft.auth === "codex-login" && !importing;
+  const keyLabel =
+    draft.kind === "modal"
+      ? "Modal Token Secret"
+      : sandboxes.some((entry) => entry.id === draft.kind)
+        ? "Sandbox API Key"
+        : "Model API Key";
   return (
-    <section className="my-6 max-w-2xl border border-line bg-surface p-5 [&_h2]:mb-4 [&_small]:text-sm">
-      <h2>{previous ? "Replace Credential" : "Add Credential"}</h2>
-      {previous && (
-        <p className="mt-2 text-base text-muted">
-          Creates a new credential. Existing runs keep their original reference; delete the old
-          credential when no longer needed.
-        </p>
-      )}
+    <dialog
+      ref={dialog}
+      aria-labelledby="credential-title"
+      aria-describedby="credential-description"
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) onCancel();
+      }}
+      className="fixed inset-0 m-auto max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-lg overflow-y-auto border border-line-strong bg-surface p-0 text-ink shadow-2xl backdrop:bg-black/65"
+    >
+      <header className="flex items-start justify-between gap-4 border-b border-line px-6 py-5">
+        <div>
+          <h2 id="credential-title" className="text-lg font-semibold">
+            {previous ? "Replace Credential" : "Add Credential"}
+          </h2>
+          <p id="credential-description" className="mt-1 text-sm text-muted">
+            Available to repositories in <span className="font-medium text-ink">{org}</span>.
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          className="-mr-2 px-2"
+          aria-label="Close"
+          disabled={busy}
+          onClick={onCancel}
+        >
+          <X size={18} aria-hidden="true" />
+        </Button>
+      </header>
       <form
         onSubmit={async (event) => {
           event.preventDefault();
-          if (busy) return;
+          if (busy || isLogin) return;
           setBusy(true);
           setError("");
           try {
             await onSave(draft);
-            setDraft({ ...draft, value: "", tokenId: "" });
           } catch (cause) {
             setError(cause instanceof Error ? cause.message : "Could not save credential");
           } finally {
@@ -58,177 +95,182 @@ export function CredentialEditor({
           }
         }}
       >
-        <fieldset className="min-w-0 border-0 p-0" disabled={busy}>
-          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-6">
-            <label
-              htmlFor="credentialeditor-field-0"
-              className="grid gap-2 font-mono text-sm text-muted"
-            >
-              Name
-              <Input
-                id="credentialeditor-field-0"
-                required
-                maxLength={80}
-                value={draft.name}
-                onChange={(event) => setDraft({ ...draft, name: event.target.value })}
-              />
-            </label>
-            <label
-              htmlFor="credentialeditor-field-1"
-              className="grid gap-2 font-mono text-sm text-muted"
-            >
+        <div className="space-y-5 px-6 py-6">
+          {previous && (
+            <p className="border-l-2 border-line-strong pl-3 text-xs leading-5 text-muted">
+              This creates a new credential. Existing runs keep the original; delete it when it’s no
+              longer needed.
+            </p>
+          )}
+          <fieldset disabled={busy || signingIn} className="space-y-5">
+            <label className={field} htmlFor="credential-provider">
               Provider or Sandbox
               <Select
-                id="credentialeditor-field-1"
-                aria-label="Provider or Sandbox"
+                id="credential-provider"
                 value={draft.kind}
-                onChange={(event) =>
+                onChange={(event) => {
                   setDraft({
                     name: draft.name,
                     kind: event.target.value as CredentialDraft["kind"],
                     auth: "api-key",
                     value: "",
-                  })
-                }
+                  });
+                  setImporting(false);
+                  setError("");
+                }}
               >
                 <optgroup label="Model Providers">
-                  {providerOptions.map((provider) => (
-                    <option key={provider.id} value={provider.id}>
-                      {provider.label}
+                  {providers.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.label}
                     </option>
                   ))}
                 </optgroup>
                 <optgroup label="Sandboxes">
-                  {sandboxOptions.map((sandbox) => (
-                    <option key={sandbox.id} value={sandbox.id}>
-                      {sandbox.label}
+                  {sandboxes.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.label}
                     </option>
                   ))}
                 </optgroup>
               </Select>
             </label>
             {draft.kind === "openai" && (
-              <label
-                htmlFor="credentialeditor-field-2"
-                className="col-span-full grid gap-2 font-mono text-sm text-muted"
-              >
-                Authentication
-                <Select
-                  id="credentialeditor-field-2"
-                  value={draft.auth}
-                  onChange={(event) =>
-                    setDraft({
-                      ...draft,
-                      auth: event.target.value as CredentialDraft["auth"],
-                      value: "",
-                    })
-                  }
-                >
-                  <option value="api-key">OpenAI API Key (Usage Billed)</option>
-                  <option value="codex-login">Codex / ChatGPT Sign-In (Codex Only)</option>
-                </Select>
-              </label>
+              <fieldset>
+                <legend className="mb-2 text-sm font-medium">Authentication</legend>
+                <div className="grid grid-cols-2 border border-line-strong p-1">
+                  {[
+                    { id: "api-key", label: "API Key" },
+                    { id: "codex-login", label: "ChatGPT Sign-In" },
+                  ].map((option) => (
+                    <button
+                      key={option.id}
+                      type="button"
+                      aria-pressed={draft.auth === option.id}
+                      className={`px-2 py-2 text-sm transition-colors ${draft.auth === option.id ? "bg-surface-3 font-medium text-mint" : "text-muted hover:text-ink"}`}
+                      onClick={() => {
+                        setDraft({
+                          ...draft,
+                          auth: option.id as CredentialDraft["auth"],
+                          value: "",
+                        });
+                        setImporting(false);
+                        setError("");
+                      }}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
             )}
-            {draft.kind === "custom" && (
-              <label
-                htmlFor="credentialeditor-field-3"
-                className="col-span-full grid gap-2 font-mono text-sm text-muted"
-              >
-                Endpoint
-                <Input
-                  id="credentialeditor-field-3"
-                  required
-                  type="url"
-                  placeholder="https://approved-host.example/v1"
-                  value={draft.endpoint ?? ""}
-                  onChange={(event) => setDraft({ ...draft, endpoint: event.target.value })}
-                />
-                <small>HTTPS OpenAI-compatible endpoint on an operator-approved host.</small>
-              </label>
-            )}
-            {draft.kind === "modal" && (
-              <label
-                htmlFor="credentialeditor-field-4"
-                className="col-span-full grid gap-2 font-mono text-sm text-muted"
-              >
-                Modal Token ID
-                <Input
-                  id="credentialeditor-field-4"
-                  required
-                  type="password"
-                  autoComplete="new-password"
-                  value={draft.tokenId ?? ""}
-                  onChange={(event) => setDraft({ ...draft, tokenId: event.target.value })}
-                />
-              </label>
-            )}
-            {draft.auth === "codex-login" ? (
-              <label
-                htmlFor="credentialeditor-field-5"
-                className="col-span-full grid gap-2 font-mono text-sm text-muted"
-              >
-                Codex auth.json
-                <Input
-                  id="credentialeditor-field-5"
-                  required
-                  type="file"
-                  accept="application/json,.json"
-                  onChange={async (event) => {
-                    const file = event.target.files?.[0];
-                    if (!file) return;
-                    if (file.size > 24000) {
-                      setError("Auth file exceeds 24 KB");
-                      return;
-                    }
-                    setDraft({ ...draft, value: await file.text() });
-                  }}
-                />
-                <small>
-                  Explicitly saves your sign-in encrypted for use in the selected sandbox.
-                  Subscription limits still apply. No API-key fallback.
-                </small>
-              </label>
-            ) : (
-              <label
-                htmlFor="credentialeditor-field-6"
-                className="col-span-full grid gap-2 font-mono text-sm text-muted"
-              >
-                {["e2b", "daytona"].includes(draft.kind)
-                  ? "Sandbox API Key"
-                  : draft.kind === "modal"
-                    ? "Modal Token Secret"
-                    : "Model API Key"}
-                <Input
-                  id="credentialeditor-field-6"
-                  required
-                  type="password"
-                  autoComplete="new-password"
-                  maxLength={4096}
-                  value={draft.value}
-                  onChange={(event) => setDraft({ ...draft, value: event.target.value })}
-                />
-              </label>
-            )}
-          </div>
+            <label className={field} htmlFor="credential-name">
+              Credential Name
+              <Input
+                ref={name}
+                id="credential-name"
+                required
+                maxLength={80}
+                placeholder={
+                  draft.auth === "codex-login" ? "e.g. Team Codex" : "e.g. Evaluation API key"
+                }
+                value={draft.name}
+                onChange={(event) => setDraft({ ...draft, name: event.target.value })}
+              />
+              <span className="text-xs font-normal text-muted">
+                A name your team will recognize when choosing credentials.
+              </span>
+            </label>
+          </fieldset>
+          {isLogin ? (
+            <CodexSignIn
+              org={org}
+              name={draft.name}
+              onActiveChange={setSigningIn}
+              onDone={onSaved}
+            />
+          ) : (
+            <fieldset className="space-y-5" disabled={busy}>
+              {draft.kind === "custom" && (
+                <label className={field} htmlFor="credential-endpoint">
+                  Endpoint
+                  <Input
+                    id="credential-endpoint"
+                    type="url"
+                    required
+                    placeholder="https://approved-host.example/v1"
+                    value={draft.endpoint ?? ""}
+                    onChange={(event) => setDraft({ ...draft, endpoint: event.target.value })}
+                  />
+                  <span className="text-xs font-normal leading-5 text-muted">
+                    An OpenAI-compatible HTTPS endpoint on an approved host.
+                  </span>
+                </label>
+              )}
+              {draft.kind === "modal" && (
+                <label className={field} htmlFor="credential-token-id">
+                  Modal Token ID
+                  <Input
+                    id="credential-token-id"
+                    required
+                    autoComplete="off"
+                    maxLength={4096}
+                    value={draft.tokenId ?? ""}
+                    onChange={(event) => setDraft({ ...draft, tokenId: event.target.value })}
+                  />
+                </label>
+              )}
+              <CredentialSecret
+                draft={draft}
+                setDraft={setDraft}
+                importing={importing}
+                org={org}
+                setError={setError}
+                keyLabel={keyLabel}
+                key={`${draft.kind}-${draft.auth}`}
+              />
+            </fieldset>
+          )}
+          {draft.auth === "codex-login" && !signingIn && (
+            <button
+              type="button"
+              className="text-xs text-muted underline underline-offset-4 hover:text-mint"
+              onClick={() => {
+                setImporting((value) => !value);
+                setDraft({ ...draft, value: "" });
+                setError("");
+              }}
+            >
+              {importing ? "Use Browser Sign-In" : "Import an Existing auth.json"}
+            </button>
+          )}
           {error && (
-            <p className="my-4 font-mono text-base text-danger" role="alert">
+            <p role="alert" className="text-sm leading-6 text-danger">
               {error}
             </p>
           )}
-          <p className="mt-2 text-base text-muted">
-            Saved secrets are never shown again. Saving does not run a model or validate account
-            access.
+        </div>
+        <footer className="flex flex-wrap items-center justify-between gap-4 border-t border-line bg-bg/50 px-6 py-4">
+          <p className="flex items-center gap-2 text-xs text-muted">
+            <LockKeyhole size={13} aria-hidden="true" />
+            Encrypted Storage
           </p>
-          <div className="flex flex-wrap items-center justify-between gap-4 py-3.5">
-            <Button type="button" variant="ghost" onClick={onCancel}>
-              Cancel
+          <div className="flex gap-2">
+            <Button type="button" variant="ghost" disabled={busy} onClick={onCancel}>
+              {signingIn ? "Cancel Sign-In" : "Cancel"}
             </Button>
-            <Button type="submit" variant="primary" disabled={!draft.value}>
-              {busy ? "Saving…" : "Save Credential"}
-            </Button>
+            {!isLogin && (
+              <Button
+                type="submit"
+                variant="primary"
+                disabled={busy || !draft.value || !draft.name.trim()}
+              >
+                {busy ? "Saving…" : "Save Credential"}
+              </Button>
+            )}
           </div>
-        </fieldset>
+        </footer>
       </form>
-    </section>
+    </dialog>
   );
 }

--- a/review/src/web/evaluation/CredentialGroup.tsx
+++ b/review/src/web/evaluation/CredentialGroup.tsx
@@ -1,0 +1,129 @@
+import { Box, KeyRound, Plus, RefreshCw, Terminal, Trash2 } from "lucide-react";
+import type { CredentialInfo } from "../../../../src/evaluation/account";
+import { ListSkeleton } from "../LoadingSkeleton";
+import { Button } from "../ui";
+import { credentialAccess, credentialProvider } from "./credential-presentation";
+
+export function CredentialGroup({
+  title,
+  description,
+  credentials,
+  loading,
+  canManage,
+  sandbox = false,
+  onAdd,
+  onReplace,
+  onDelete,
+}: {
+  title: string;
+  description: string;
+  credentials: CredentialInfo[];
+  loading: boolean;
+  canManage: boolean;
+  sandbox?: boolean;
+  onAdd(): void;
+  onReplace(credential: CredentialInfo): void;
+  onDelete(credential: CredentialInfo): void;
+}) {
+  const Icon = sandbox ? Box : KeyRound;
+  return (
+    <section aria-label={title}>
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <div>
+          <h2 className="flex items-center gap-2.5 font-semibold">
+            {title}
+            <span className="font-mono text-xs font-normal text-dim">
+              {loading ? "" : credentials.length}
+            </span>
+          </h2>
+          <p className="mt-1 text-sm text-muted">{description}</p>
+        </div>
+        {canManage && (
+          <Button variant="ghost" onClick={onAdd}>
+            <Plus size={14} aria-hidden="true" />
+            {sandbox ? "Add Sandbox" : "Add Provider"}
+          </Button>
+        )}
+      </div>
+      {loading ? (
+        <ListSkeleton label={`Loading ${title}`} rows={sandbox ? 2 : 3} />
+      ) : credentials.length ? (
+        <ul className="divide-y divide-line border border-line bg-surface">
+          {credentials.map((credential) => {
+            const Mark = credential.auth === "codex-login" ? Terminal : Icon;
+            return (
+              <li
+                key={credential.id}
+                className="group flex flex-wrap items-center gap-4 px-4 py-4 sm:px-5"
+              >
+                <span className="grid size-10 shrink-0 place-items-center border border-line bg-bg text-muted">
+                  <Mark size={18} strokeWidth={1.5} aria-hidden="true" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold text-ink" title={credential.name}>
+                    {credential.name}
+                  </p>
+                  <p className="mt-1 truncate text-xs text-muted" title={credential.endpoint}>
+                    {credentialProvider(credential)}
+                    <span className="px-2 text-dim" aria-hidden="true">
+                      /
+                    </span>
+                    {credentialAccess(credential)}
+                    {credential.endpoint && (
+                      <span className="ml-2 font-mono">{credential.endpoint}</span>
+                    )}
+                  </p>
+                </div>
+                <span className="hidden items-center gap-1.5 font-mono text-xs text-muted sm:inline-flex">
+                  <span className="size-1.5 bg-mint/60" aria-hidden="true" />
+                  Saved
+                </span>
+                {canManage && (
+                  <div className="flex items-center gap-1 border-l border-line pl-3">
+                    <Button
+                      variant="ghost"
+                      className="px-2"
+                      aria-label={`Replace ${credential.name}`}
+                      title="Replace Credential"
+                      onClick={() => onReplace(credential)}
+                    >
+                      <RefreshCw size={14} aria-hidden="true" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      className="px-2 hover:text-danger"
+                      aria-label={`Delete ${credential.name}`}
+                      title="Delete Credential"
+                      onClick={() => onDelete(credential)}
+                    >
+                      <Trash2 size={14} aria-hidden="true" />
+                    </Button>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <div className="flex items-start gap-4 border border-dashed border-line-strong px-5 py-7">
+          <Icon
+            size={20}
+            className="mt-0.5 shrink-0 text-dim"
+            strokeWidth={1.5}
+            aria-hidden="true"
+          />
+          <div>
+            <p className="text-sm font-medium">
+              {sandbox ? "No Sandbox Credentials" : "No Model Credentials"}
+            </p>
+            <p className="mt-1 text-sm leading-6 text-muted">
+              {sandbox
+                ? "Add a cloud sandbox credential to run tasks in isolated environments."
+                : "Connect ChatGPT or add a provider API key to use your models."}
+            </p>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/review/src/web/evaluation/CredentialSecret.tsx
+++ b/review/src/web/evaluation/CredentialSecret.tsx
@@ -1,0 +1,102 @@
+import { Eye, EyeOff } from "lucide-react";
+import React from "react";
+import type { CredentialDraft } from "../../../../src/evaluation/credentials";
+import { Input } from "../ui";
+
+const field = "grid gap-2 text-sm font-medium text-ink";
+export function CredentialSecret({
+  draft,
+  setDraft,
+  importing,
+  org,
+  setError,
+  keyLabel,
+}: {
+  draft: CredentialDraft;
+  setDraft: React.Dispatch<React.SetStateAction<CredentialDraft>>;
+  importing: boolean;
+  org: string;
+  setError(error: string): void;
+  keyLabel: string;
+}) {
+  const [visible, setVisible] = React.useState(false);
+  const fileVersion = React.useRef(0);
+  React.useEffect(
+    () => () => {
+      fileVersion.current++;
+    },
+    [],
+  );
+  return (
+    <>
+      {importing ? (
+        <label className={field} htmlFor="credential-auth-file">
+          Codex auth.json
+          <Input
+            id="credential-auth-file"
+            type="file"
+            required
+            accept="application/json,.json"
+            onChange={async (event) => {
+              const file = event.target.files?.[0];
+              const version = ++fileVersion.current;
+              setDraft((current) => ({ ...current, value: "" }));
+              setError("");
+              if (!file) return;
+              if (file.size > 24000) {
+                setError("Auth file exceeds 24 KB.");
+                return;
+              }
+              try {
+                const value = await file.text();
+                if (version !== fileVersion.current) return;
+                const parsed = JSON.parse(value);
+                if (
+                  !parsed.tokens?.access_token ||
+                  !parsed.tokens?.refresh_token ||
+                  parsed.OPENAI_API_KEY
+                )
+                  throw new Error();
+                setDraft((current) => ({ ...current, value }));
+              } catch {
+                if (version !== fileVersion.current) return;
+                setError("Choose a Codex ChatGPT auth.json containing a subscription sign-in.");
+              }
+            }}
+          />
+          <span className="text-xs font-normal leading-5 text-muted">
+            Import a sign-in from the Codex CLI. This saves access for Codex runs across {org}.
+          </span>
+        </label>
+      ) : (
+        <div className={field}>
+          <label htmlFor="credential-secret">{keyLabel}</label>
+          <div className="relative">
+            <Input
+              id="credential-secret"
+              className="pr-12"
+              required
+              type={visible ? "text" : "password"}
+              autoComplete="new-password"
+              maxLength={4096}
+              value={draft.value}
+              onChange={(event) => setDraft({ ...draft, value: event.target.value })}
+            />
+            <button
+              type="button"
+              aria-label={visible ? "Hide Secret" : "Show Secret"}
+              className="absolute inset-y-0 right-0 px-3 text-muted hover:text-ink"
+              onClick={() => setVisible((value) => !value)}
+            >
+              {visible ? (
+                <EyeOff size={16} aria-hidden="true" />
+              ) : (
+                <Eye size={16} aria-hidden="true" />
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/review/src/web/evaluation/CredentialsPage.tsx
+++ b/review/src/web/evaluation/CredentialsPage.tsx
@@ -1,12 +1,24 @@
+import { ArrowUpRight, LockKeyhole, Plus, Terminal } from "lucide-react";
 import React from "react";
 import { Link, useSearchParams } from "react-router";
 import type { CredentialInfo } from "../../../../src/evaluation/account";
 import type { CredentialDraft } from "../../../../src/evaluation/credentials";
+import { Skeleton } from "../LoadingSkeleton";
 import { useOrg } from "../SiteLayout";
 import { useDocumentTitle } from "../session";
-import { Button, buttonStyles, DataTable, PageContent, PageHeader } from "../ui";
+import { Button, buttonStyles, PageHeader } from "../ui";
 import { evaluationRequest } from "./api";
 import { CredentialEditor } from "./CredentialEditor";
+import { CredentialGroup } from "./CredentialGroup";
+import { isSandbox } from "./credential-presentation";
+import { DeleteCredentialDialog } from "./DeleteCredentialDialog";
+
+type Editor = {
+  previous?: CredentialInfo;
+  kind?: CredentialDraft["kind"];
+  auth?: CredentialDraft["auth"];
+};
+type Credentials = { credentials: CredentialInfo[]; canManage: boolean };
 
 export function CredentialsPage() {
   const { org } = useOrg();
@@ -14,153 +26,181 @@ export function CredentialsPage() {
 }
 function CredentialsContent({ org }: { org: string }) {
   useDocumentTitle(`Credentials · ${org}`);
-  const url = `/api/orgs/${encodeURIComponent(org)}`;
-  const [canManage, setCanManage] = React.useState(false);
-  const [credentials, setCredentials] = React.useState<CredentialInfo[]>([]);
-  const [editing, setEditing] = React.useState<CredentialInfo | "new">();
+  const url = `/api/orgs/${encodeURIComponent(org)}/credentials`;
+  const [data, setData] = React.useState<Credentials>();
+  const [editing, setEditing] = React.useState<Editor>();
+  const [deleting, setDeleting] = React.useState<CredentialInfo>();
   const [error, setError] = React.useState("");
-  const [busy, setBusy] = React.useState(false);
+  const [notice, setNotice] = React.useState("");
   const [search] = useSearchParams();
   const target = search.get("return");
   const returnTo =
     target && /^\/repos\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/run$/.test(target) ? target : undefined;
-  const refresh = async () => {
-    const result = await evaluationRequest<{ credentials: CredentialInfo[]; canManage: boolean }>(
-      `${url}/credentials`,
-    );
-    setCredentials(result.credentials);
-    setCanManage(result.canManage);
-  };
   React.useEffect(() => {
     let disposed = false;
-    evaluationRequest<{ credentials: CredentialInfo[]; canManage: boolean }>(
-      `${url}/credentials`,
-    ).then(
+    setError("");
+    evaluationRequest<Credentials>(url).then(
       (result) => {
-        if (!disposed) {
-          setCredentials(result.credentials);
-          setCanManage(result.canManage);
-        }
+        if (!disposed) setData(result);
       },
       (cause) => {
-        if (!disposed) setError(cause.message);
+        if (!disposed) setError(`Could not load credentials: ${cause.message}`);
       },
     );
     return () => {
       disposed = true;
     };
   }, [url]);
-  const action = async (operation: () => Promise<unknown>) => {
-    setBusy(true);
-    setError("");
+  const refresh = async () => {
     try {
-      await operation();
-      await refresh();
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Credential operation failed");
-    } finally {
-      setBusy(false);
+      setData(await evaluationRequest<Credentials>(url));
+      setError("");
+    } catch {
+      setError("Could not refresh credentials. Reload the list to try again.");
     }
   };
-  const save = async (draft: CredentialDraft) => {
-    await evaluationRequest(`${url}/credentials`, draft);
+  const saved = async () => {
     setEditing(undefined);
+    setNotice("Credential saved. It is now available across this organization.");
     await refresh();
+  };
+  const save = async (draft: CredentialDraft) => {
+    await evaluationRequest(url, draft);
+    await saved();
+  };
+  const canManage = data?.canManage ?? false;
+  const credentials = data?.credentials ?? [];
+  const groupProps = {
+    loading: !data && !error,
+    canManage,
+    onReplace: (previous: CredentialInfo) => setEditing({ previous }),
+    onDelete: setDeleting,
   };
   return (
     <main className="w-full min-w-0 flex-1 px-4 pt-8 pb-12 sm:px-[var(--site-gutter)]">
-      <PageContent>
-        <PageHeader
-          title="Credentials"
-          description={`Shared across ${org} repositories. Organization admins manage credentials.`}
-        >
-          {returnTo && (
-            <Link className={buttonStyles.secondary} to={returnTo}>
-              Back to Run
-            </Link>
-          )}
+      <div className="mx-auto w-full max-w-5xl">
+        <PageHeader title="Credentials" description={`Shared across ${org} repositories.`}>
+          <div className="flex gap-2">
+            {returnTo && (
+              <Link className={buttonStyles.secondary} to={returnTo}>
+                Back to Run
+              </Link>
+            )}
+            {(canManage || !data) && (
+              <Button variant="primary" disabled={!canManage} onClick={() => setEditing({})}>
+                <Plus size={15} aria-hidden="true" />
+                Add Credential
+              </Button>
+            )}
+          </div>
         </PageHeader>
         {error && (
-          <p className="my-4 font-mono text-base text-danger" role="alert">
-            {error}
+          <div
+            role="alert"
+            className="mb-6 flex flex-wrap items-center justify-between gap-3 border border-danger/30 bg-danger/5 px-4 py-3 text-sm text-danger"
+          >
+            <p>{error}</p>
+            <Button onClick={() => void refresh()}>Reload List</Button>
+          </div>
+        )}
+        {notice && (
+          <p
+            role="status"
+            className="mb-5 border-l-2 border-mint bg-mint/5 px-4 py-3 text-sm text-mint"
+          >
+            {notice}
           </p>
         )}
-        <div className="flex flex-wrap items-center justify-between gap-4 py-3.5">
-          <Button
-            type="button"
-            variant="primary"
-            disabled={busy || !canManage}
-            onClick={() => setEditing("new")}
+        {!data && !error && (
+          <div
+            role="status"
+            aria-label="Loading Account Options"
+            className="mb-9 flex flex-wrap items-center gap-5 border border-line bg-surface px-5 py-6 sm:px-6"
           >
-            Add Credential
-          </Button>
+            <Skeleton className="size-11 shrink-0" />
+            <div className="min-w-0 flex-1 basis-52 space-y-3">
+              <Skeleton className="h-4 w-48 max-w-full" />
+              <Skeleton className="h-4 w-80 max-w-full" />
+            </div>
+            <Skeleton className="h-9 w-48" />
+            <span className="sr-only">Loading account options…</span>
+          </div>
+        )}
+        {canManage && (
+          <section
+            className="mb-9 flex flex-wrap items-center gap-5 border border-line bg-surface px-5 py-6 sm:px-6"
+            aria-label="Connect Codex"
+          >
+            <span className="grid size-11 shrink-0 place-items-center border border-mint/25 bg-mint/5 text-mint">
+              <Terminal size={22} strokeWidth={1.5} aria-hidden="true" />
+            </span>
+            <div className="min-w-0 flex-1 basis-52">
+              <h2 className="text-base font-semibold">Use Your ChatGPT Account</h2>
+              <p className="mt-1.5 max-w-lg text-sm leading-6 text-muted">
+                Connect Codex for evaluations with your ChatGPT plan. Your subscription limits
+                apply.
+              </p>
+            </div>
+            <Button onClick={() => setEditing({ kind: "openai", auth: "codex-login" })}>
+              Sign in with ChatGPT
+              <ArrowUpRight size={15} aria-hidden="true" />
+            </Button>
+          </section>
+        )}
+        {data && !canManage && (
+          <p className="mb-7 border-l-2 border-line-strong pl-4 text-sm text-muted">
+            You can use these credentials in runs. An organization admin can add, replace, or delete
+            them.
+          </p>
+        )}
+        {(!error || data) && (
+          <div className="space-y-9">
+            <CredentialGroup
+              {...groupProps}
+              title="Model Providers"
+              description="Accounts and API keys for the models you evaluate."
+              credentials={credentials.filter((entry) => !isSandbox(entry.kind))}
+              onAdd={() => setEditing({})}
+            />
+            <CredentialGroup
+              {...groupProps}
+              title="Sandboxes"
+              description="Credentials for the environments that run your tasks."
+              credentials={credentials.filter((entry) => isSandbox(entry.kind))}
+              sandbox
+              onAdd={() => setEditing({ kind: "modal" })}
+            />
+          </div>
+        )}
+        <div className="mt-8 flex items-start gap-2.5 border-t border-line pt-5 text-xs leading-5 text-muted">
+          <LockKeyhole size={14} className="mt-0.5 shrink-0 text-dim" aria-hidden="true" />
+          <p>
+            Secrets are encrypted and never displayed after saving. API keys are saved without
+            checking account access.
+          </p>
         </div>
         {editing && (
           <CredentialEditor
-            key={typeof editing === "string" ? "new" : editing.id}
-            previous={typeof editing === "string" ? undefined : editing}
+            {...editing}
+            org={org}
             onSave={save}
+            onSaved={saved}
             onCancel={() => setEditing(undefined)}
           />
         )}
-        <div className="min-w-0">
-          <DataTable className="min-w-[850px]">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Provider / Sandbox</th>
-                <th>Authentication</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {credentials.map((credential) => (
-                <tr key={credential.id}>
-                  <td>{credential.name}</td>
-                  <td>{credential.kind}</td>
-                  <td>
-                    {credential.auth === "codex-login" ? "Codex Sign-In" : "API Key"}
-                    <small>{credential.endpoint}</small>
-                  </td>
-                  <td>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={busy || !canManage}
-                      onClick={() => setEditing(credential)}
-                    >
-                      Replace
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={busy || !canManage}
-                      onClick={() => {
-                        if (
-                          window.confirm(
-                            `Delete ${credential.name}? Active comparisons prevent deletion.`,
-                          )
-                        )
-                          void action(() =>
-                            evaluationRequest(`${url}/credentials/${credential.id}/delete`, {}),
-                          );
-                      }}
-                    >
-                      Delete
-                    </Button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </DataTable>
-          {!credentials.length && (
-            <p className="px-4 py-7 text-base text-muted">
-              No credentials saved. Add a provider credential and a sandbox credential to run
-              evaluations.
-            </p>
-          )}
-        </div>
-      </PageContent>
+        {deleting && (
+          <DeleteCredentialDialog
+            credential={deleting}
+            onClose={() => setDeleting(undefined)}
+            onDelete={async () => {
+              await evaluationRequest(`${url}/${deleting.id}/delete`, {});
+              setDeleting(undefined);
+              setNotice("Credential deleted.");
+              await refresh();
+            }}
+          />
+        )}
+      </div>
     </main>
   );
 }

--- a/review/src/web/evaluation/DeleteCredentialDialog.tsx
+++ b/review/src/web/evaluation/DeleteCredentialDialog.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import type { CredentialInfo } from "../../../../src/evaluation/account";
+import { Button } from "../ui";
+import { useModalDialog } from "../useModalDialog";
+
+export function DeleteCredentialDialog({
+  credential,
+  onDelete,
+  onClose,
+}: {
+  credential: CredentialInfo;
+  onDelete(): Promise<void>;
+  onClose(): void;
+}) {
+  const cancel = React.useRef<HTMLButtonElement>(null);
+  const dialog = useModalDialog(cancel);
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState("");
+  return (
+    <dialog
+      ref={dialog}
+      aria-labelledby="delete-credential-title"
+      aria-describedby="delete-credential-description"
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) onClose();
+      }}
+      className="fixed inset-0 m-auto w-[calc(100%-2rem)] max-w-md border border-line-strong bg-surface p-6 text-ink shadow-2xl backdrop:bg-black/65"
+    >
+      <h2 id="delete-credential-title" className="text-lg font-semibold">
+        Delete Credential
+      </h2>
+      <p id="delete-credential-description" className="mt-3 text-sm leading-6 text-muted">
+        Delete <strong className="break-all text-ink">{credential.name}</strong>? You’ll need to add
+        it again to use it in new runs. Credentials used by active comparisons cannot be deleted.
+      </p>
+      {error && (
+        <p role="alert" className="mt-4 text-sm text-danger">
+          {error}
+        </p>
+      )}
+      <div className="mt-6 flex justify-end gap-2">
+        <Button ref={cancel} disabled={busy} onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          disabled={busy}
+          className="border-danger/50 text-danger hover:border-danger hover:text-danger"
+          onClick={async () => {
+            setBusy(true);
+            try {
+              await onDelete();
+            } catch (cause) {
+              setError(cause instanceof Error ? cause.message : "Could not delete credential");
+            } finally {
+              setBusy(false);
+            }
+          }}
+        >
+          {busy ? "Deleting…" : "Delete Credential"}
+        </Button>
+      </div>
+    </dialog>
+  );
+}

--- a/review/src/web/evaluation/EvaluationPage.tsx
+++ b/review/src/web/evaluation/EvaluationPage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link, useParams, useSearchParams } from "react-router";
+import { ListSkeleton } from "../LoadingSkeleton";
 import { useOrg } from "../SiteLayout";
 import { useDocumentTitle } from "../session";
 import { Button, DataTable, PageContent, PageHeader, RunStatus, Select } from "../ui";
@@ -100,7 +101,7 @@ export function EvaluationPage() {
         current ? (
           <EvaluationResults key={current.id} run={current} baseUrl={url} repo={repo} />
         ) : (
-          !error && <p role="status">Loading run…</p>
+          !error && <ListSkeleton label="Loading Run" />
         )
       ) : (
         <>
@@ -128,7 +129,7 @@ export function EvaluationPage() {
           <ComparisonHistory key={url} repo={repo} url={url} />
           <section className="mt-8 [&_h2]:mb-4">
             <h2>Runs</h2>
-            {loading && <p role="status">Loading runs…</p>}
+            {loading && !runs.length && !error && <ListSkeleton label="Loading Runs" />}
             {!loading && !runs.length && (
               <p className="mt-2 text-base text-muted">
                 No runs yet. <Link to={`/repos/${repo}`}>Run Your Dataset →</Link>

--- a/review/src/web/evaluation/credential-presentation.ts
+++ b/review/src/web/evaluation/credential-presentation.ts
@@ -1,0 +1,29 @@
+import type { CredentialInfo } from "../../../../src/evaluation/account";
+
+export const providers = [
+  { id: "openai", label: "OpenAI" },
+  { id: "anthropic", label: "Anthropic" },
+  { id: "openrouter", label: "OpenRouter" },
+  { id: "custom", label: "Custom Endpoint" },
+] as const;
+export const sandboxes = [
+  { id: "e2b", label: "E2B" },
+  { id: "modal", label: "Modal" },
+  { id: "daytona", label: "Daytona" },
+] as const;
+export function isSandbox(kind: CredentialInfo["kind"]) {
+  return sandboxes.some((entry) => entry.id === kind);
+}
+export function credentialProvider(credential: Pick<CredentialInfo, "kind" | "auth">) {
+  return credential.auth === "codex-login"
+    ? "Codex"
+    : ([...providers, ...sandboxes].find((entry) => entry.id === credential.kind)?.label ??
+        credential.kind);
+}
+export function credentialAccess(credential: Pick<CredentialInfo, "kind" | "auth">) {
+  return credential.auth === "codex-login"
+    ? "ChatGPT Sign-In"
+    : credential.kind === "modal"
+      ? "Token Pair"
+      : "API Key";
+}

--- a/review/src/web/evaluation/run-table.test.tsx
+++ b/review/src/web/evaluation/run-table.test.tsx
@@ -37,6 +37,10 @@ test("model table remains visible without credentials and never embeds secret fi
 test("credential editor is separate and offers only supported providers and hosted sandboxes", () => {
   const html = renderToStaticMarkup(
     <CredentialEditor
+      org="mupt-ai"
+      onSaved={async () => {
+        throw new Error("Render must not finish sign-in");
+      }}
       onSave={async () => {
         throw new Error("Render must not save a credential");
       }}

--- a/review/src/web/pages/ReposPage.tsx
+++ b/review/src/web/pages/ReposPage.tsx
@@ -9,6 +9,7 @@ import {
   type RepoTaskCounts,
 } from "../api";
 import { ConnectRepoSheet } from "../ConnectRepoSheet";
+import { ListSkeleton, Skeleton } from "../LoadingSkeleton";
 import { GitHubMark, UnlinkIcon, useOrg } from "../SiteLayout";
 import { useDocumentTitle } from "../session";
 
@@ -118,9 +119,17 @@ export function ReposPage() {
         </div>
       </div>
       {error && <p className="mb-4 font-mono text-base text-danger">{error}</p>}
+      {repos.status === "loading" && !error && <ListSkeleton label="Loading Repositories" />}
       {repos.status === "ok" && repos.repos.length === 0 && (
-        <div className="border border-dashed border-line-strong px-6 py-12 text-center text-muted">
-          <p>Nothing connected yet. Connect a repository in {org.login} to start building tasks.</p>
+        <div className="border border-line-strong border-l-2 border-l-mint bg-surface px-5 py-6 sm:px-7">
+          <div className="max-w-2xl">
+            <h2 className="font-sans text-base leading-6 font-semibold text-ink">
+              Connect a Repository to Get Started
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              Choose a repository in {org.login} to turn merged pull requests into reviewable tasks.
+            </p>
+          </div>
         </div>
       )}
       {repos.status === "ok" && repos.repos.length > 0 && (
@@ -197,15 +206,21 @@ function RepoCardStats({ stats }: { stats: RepoStats | undefined }) {
       <dl className="m-0 grid grid-cols-3 gap-6 [&_dt]:font-mono [&_dt]:text-sm [&_dt]:font-medium [&_dt]:tracking-[0.14em] [&_dt]:text-dim [&_dt]:uppercase [&_dd]:mt-1.5 [&_dd]:font-sans [&_dd]:text-base [&_dd]:font-medium [&_dd]:text-ink">
         <div>
           <dt>Tasks</dt>
-          <dd className="text-dim">…</dd>
+          <dd>
+            <Skeleton className="h-5 w-10" />
+          </dd>
         </div>
         <div>
           <dt>Awaiting Review</dt>
-          <dd className="text-dim">…</dd>
+          <dd>
+            <Skeleton className="h-5 w-10" />
+          </dd>
         </div>
         <div>
           <dt>Last PR</dt>
-          <dd className="text-dim">…</dd>
+          <dd>
+            <Skeleton className="h-5 w-16" />
+          </dd>
         </div>
       </dl>
     );

--- a/review/src/web/primitives/sidebar.tsx
+++ b/review/src/web/primitives/sidebar.tsx
@@ -50,11 +50,11 @@ export function SidebarMenuItem({ className, ...props }: ComponentProps<"li">) {
   );
 }
 const menuButton = cva(
-  "flex w-full items-center gap-2.5 overflow-hidden px-2.5 text-left font-mono text-[13px] outline-none transition-colors hover:bg-surface-2 hover:text-ink focus-visible:outline-2 focus-visible:outline-mint disabled:pointer-events-none disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+  "flex w-full items-center gap-3 overflow-hidden px-3 text-left font-sans text-[15px] leading-5 font-medium outline-none transition-colors hover:bg-surface-2 hover:text-ink focus-visible:outline-2 focus-visible:outline-mint disabled:pointer-events-none disabled:opacity-50 [&>svg]:size-[18px] [&>svg]:shrink-0",
   {
     variants: {
       active: { true: "bg-surface-2 text-mint", false: "text-muted" },
-      size: { default: "h-9", lg: "h-12" },
+      size: { default: "h-11", lg: "h-12" },
     },
     defaultVariants: { active: false, size: "default" },
   },

--- a/src/evaluation/codex-login-process.ts
+++ b/src/evaluation/codex-login-process.ts
@@ -1,0 +1,135 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+export interface CodexDeviceCode {
+  verificationUrl: string;
+  userCode: string;
+}
+export interface CodexLoginProcess {
+  instructions: Promise<CodexDeviceCode>;
+  auth: Promise<string>;
+  close(): Promise<void>;
+}
+
+/** Only the authentication RPCs run here. Each attempt has its own private Codex home. */
+export async function startCodexLogin(): Promise<CodexLoginProcess> {
+  const directory = await mkdtemp(join(tmpdir(), "selfbench-codex-login-"));
+  let executable: string;
+  try {
+    executable = createRequire(import.meta.url).resolve("@openai/codex/bin/codex.js");
+  } catch {
+    await rm(directory, { recursive: true, force: true });
+    throw new Error("Codex sign-in is unavailable on this server. Import an auth file instead.");
+  }
+  const child = spawn(
+    process.execPath,
+    [executable, "app-server", "-c", 'cli_auth_credentials_store="file"'],
+    {
+      cwd: directory,
+      env: {
+        PATH: process.env.PATH,
+        CODEX_HOME: directory,
+        ...(process.env.SSL_CERT_FILE ? { SSL_CERT_FILE: process.env.SSL_CERT_FILE } : {}),
+        ...(process.env.CODEX_CA_CERTIFICATE
+          ? { CODEX_CA_CERTIFICATE: process.env.CODEX_CA_CERTIFICATE }
+          : {}),
+      },
+      stdio: ["pipe", "pipe", "ignore"],
+    },
+  );
+  let resolveInstructions!: (value: CodexDeviceCode) => void;
+  let rejectInstructions!: (error: Error) => void;
+  let resolveAuth!: (value: string) => void;
+  let rejectAuth!: (error: Error) => void;
+  const instructions = new Promise<CodexDeviceCode>((resolve, reject) => {
+    resolveInstructions = resolve;
+    rejectInstructions = reject;
+  });
+  const auth = new Promise<string>((resolve, reject) => {
+    resolveAuth = resolve;
+    rejectAuth = reject;
+  });
+  // Callers can await instructions before auth without an unhandled rejection.
+  void instructions.catch(() => undefined);
+  void auth.catch(() => undefined);
+  let closed: Promise<void> | undefined;
+  const exited = new Promise<void>((resolve) => child.once("close", () => resolve()));
+  const lines = createInterface({ input: child.stdout });
+  const fail = (message: string) => {
+    const error = new Error(message);
+    rejectInstructions(error);
+    rejectAuth(error);
+  };
+  const close = () => {
+    if (closed) return closed;
+    closed = (async () => {
+      clearTimeout(startupTimeout);
+      lines.close();
+      fail("Sign-in was cancelled. Start again when you’re ready.");
+      child.kill("SIGTERM");
+      const force = setTimeout(() => child.kill("SIGKILL"), 2_000);
+      force.unref();
+      await exited;
+      clearTimeout(force);
+      await rm(directory, { recursive: true, force: true });
+    })();
+    return closed;
+  };
+  const startupTimeout = setTimeout(() => {
+    fail("Codex took too long to start. Try signing in again.");
+    void close();
+  }, 30_000);
+  startupTimeout.unref();
+  child.once("error", () =>
+    fail("Could not start Codex sign-in. Try again or import an auth file."),
+  );
+  child.once("close", () => fail("Codex sign-in ended. Try again or import an auth file."));
+  child.stdin.on("error", () => fail("Could not communicate with Codex. Try signing in again."));
+  const send = (value: object) => child.stdin.write(`${JSON.stringify(value)}\n`);
+  lines.on("line", (line) => {
+    try {
+      const message = JSON.parse(line);
+      if (message.error) {
+        fail(
+          "Could not start device sign-in. Check that device code login is enabled in your ChatGPT security settings, then try again.",
+        );
+        void close();
+      } else if (message.id === 1) {
+        send({ method: "initialized" });
+        send({ id: 2, method: "account/login/start", params: { type: "chatgptDeviceCode" } });
+      } else if (message.id === 2) {
+        const result = message.result;
+        if (
+          result?.type !== "chatgptDeviceCode" ||
+          result.verificationUrl !== "https://auth.openai.com/codex/device" ||
+          typeof result.userCode !== "string"
+        ) {
+          fail("Codex returned unexpected sign-in instructions. Try again later.");
+          void close();
+          return;
+        }
+        clearTimeout(startupTimeout);
+        resolveInstructions({ verificationUrl: result.verificationUrl, userCode: result.userCode });
+      } else if (message.method === "account/login/completed") {
+        if (message.params?.success) {
+          void readFile(join(directory, "auth.json"), "utf8").then(resolveAuth, () =>
+            rejectAuth(new Error("Could not read the completed sign-in. Try again.")),
+          );
+        } else fail("Sign-in was not completed. The code may have expired; try again.");
+      }
+    } catch {
+      fail("Codex returned an invalid sign-in response. Try again.");
+      void close();
+    }
+  });
+  send({
+    id: 1,
+    method: "initialize",
+    params: { clientInfo: { name: "selfbench", title: "SelfBench", version: "0.3.6" } },
+  });
+  return { instructions, auth, close };
+}

--- a/src/evaluation/codex-login-routes.ts
+++ b/src/evaluation/codex-login-routes.ts
@@ -1,0 +1,62 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { z } from "zod";
+import { readBody, sendJson } from "../api/http.js";
+import type { User } from "../auth/users.js";
+import { tenantFor } from "../site/tenant.js";
+import { codexLogins } from "./codex-login.js";
+import { RecordStoreError } from "./encrypted-records.js";
+import type { EvaluationRoutesOptions } from "./routes.js";
+
+const pattern =
+  /^\/api\/orgs\/([A-Za-z0-9_.-]+)\/credentials\/codex-login(?:\/([a-f0-9-]{36})(?:\/(complete|cancel))?)?$/;
+const startSchema = z.object({ name: z.string().trim().min(1).max(80) }).strict();
+
+export async function codexLoginRoutes(
+  options: EvaluationRoutesOptions,
+  request: IncomingMessage,
+  url: URL,
+  response: ServerResponse,
+  user: User,
+) {
+  const match = pattern.exec(url.pathname);
+  if (!match) return false;
+  response.setHeader("cache-control", "no-store");
+  const org = await tenantFor(options.users, user, match[1] ?? "");
+  if (!org) {
+    sendJson(response, 404, { error: "Organization not found" });
+    return true;
+  }
+  if (
+    org.role !== "admin" ||
+    (request.method !== "GET" &&
+      (request.method !== "POST" ||
+        request.headers.origin !== new URL(options.publicUrl).origin ||
+        !request.headers["content-type"]?.startsWith("application/json")))
+  ) {
+    sendJson(response, 403, { error: "Organization admin and same-origin JSON request required" });
+    return true;
+  }
+  const logins = options.codexLogins ?? codexLogins;
+  try {
+    if (!options.records) throw new RecordStoreError(503);
+    const id = match[2];
+    const action = match[3];
+    if (request.method === "GET" && id && !action) {
+      sendJson(response, 200, logins.status(org.id, user.id, id));
+    } else if (request.method === "POST" && !id) {
+      const { name } = startSchema.parse(JSON.parse((await readBody(request, 1024)).toString()));
+      sendJson(response, 202, await logins.start(org.id, user.id, name));
+    } else if (request.method === "POST" && id && action === "complete") {
+      sendJson(response, 200, await logins.complete(org.id, user.id, id, options.records));
+    } else if (request.method === "POST" && id && action === "cancel") {
+      await logins.cancel(org.id, user.id, id);
+      sendJson(response, 200, { cancelled: true });
+    } else sendJson(response, 405, { error: "Method not allowed" });
+  } catch (error) {
+    sendJson(response, error instanceof RecordStoreError ? error.status : 400, {
+      error: error instanceof RecordStoreError ? error.message : "Invalid sign-in request",
+    });
+  }
+  request.resume();
+  return true;
+}

--- a/src/evaluation/codex-login.ts
+++ b/src/evaluation/codex-login.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from "node:crypto";
+import type { CredentialInfo } from "./account.js";
+import {
+  type CodexDeviceCode,
+  type CodexLoginProcess,
+  startCodexLogin,
+} from "./codex-login-process.js";
+import { credentialSchema, saveCredential } from "./credentials.js";
+import { type EncryptedRecordStore, RecordStoreError } from "./encrypted-records.js";
+import { orgRecords } from "./org-records.js";
+
+export interface CodexLoginStatus {
+  id: string;
+  status: "starting" | "waiting" | "ready" | "saving" | "saved" | "failed";
+  expiresAt: string;
+  instructions?: CodexDeviceCode;
+  error?: string;
+  credential?: CredentialInfo;
+}
+interface Attempt {
+  orgId: number;
+  userId: number;
+  name: string;
+  view: CodexLoginStatus;
+  process?: CodexLoginProcess;
+  auth?: string;
+  saving?: Promise<CredentialInfo>;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** Short-lived, user-scoped ceremonies. No tokens are returned to the browser. */
+export function createCodexLogins(start = startCodexLogin, lifetimeMs = 15 * 60_000) {
+  const attempts = new Map<string, Attempt>();
+  const startingUsers = new Set<number>();
+  const cancel = async (id: string) => {
+    const attempt = attempts.get(id);
+    if (!attempt) return;
+    attempts.delete(id);
+    clearTimeout(attempt.timer);
+    delete attempt.auth;
+    await attempt.process?.close();
+  };
+  const get = (orgId: number, userId: number, id: string) => {
+    const attempt = attempts.get(id);
+    if (!attempt || attempt.orgId !== orgId || attempt.userId !== userId)
+      throw new RecordStoreError(410, "This sign-in has expired. Start a new sign-in.");
+    return attempt;
+  };
+  return {
+    async start(orgId: number, userId: number, name: string) {
+      if (startingUsers.has(userId))
+        throw new RecordStoreError(429, "A sign-in is already starting. Please wait.");
+      startingUsers.add(userId);
+      try {
+        const normalized = name.trim();
+        if (!normalized || normalized.length > 80)
+          throw new RecordStoreError(400, "Enter a credential name of 1–80 characters.");
+        const previous = [...attempts.values()].find((attempt) => attempt.userId === userId);
+        if (previous) {
+          if (previous.view.status === "saving")
+            throw new RecordStoreError(409, "Your sign-in is being saved. Please wait.");
+          await cancel(previous.view.id);
+        }
+        if (attempts.size >= 32)
+          throw new RecordStoreError(429, "Too many sign-ins in progress. Try again shortly.");
+        const id = randomUUID();
+        const view: CodexLoginStatus = {
+          id,
+          status: "starting",
+          expiresAt: new Date(Date.now() + lifetimeMs).toISOString(),
+        };
+        const timer = setTimeout(() => {
+          void cancel(id);
+        }, lifetimeMs);
+        timer.unref();
+        const attempt: Attempt = { orgId, userId, name: normalized, view, timer };
+        attempts.set(id, attempt);
+        void (async () => {
+          try {
+            const process = await start();
+            attempt.process = process;
+            if (!attempts.has(id)) {
+              await process.close();
+              return;
+            }
+            view.instructions = await process.instructions;
+            view.status = "waiting";
+            const auth = await process.auth;
+            if (!attempts.has(id)) return;
+            const draft = credentialSchema.parse({
+              name: normalized,
+              kind: "openai",
+              auth: "codex-login",
+              value: auth,
+            });
+            attempt.auth = draft.value;
+            view.status = "ready";
+          } catch (cause) {
+            if (attempts.has(id)) {
+              view.status = "failed";
+              view.error =
+                cause instanceof Error && cause.name !== "ZodError"
+                  ? cause.message
+                  : "Codex did not return a valid ChatGPT sign-in. Try again.";
+            }
+          } finally {
+            const process = attempt.process;
+            delete attempt.process;
+            await process?.close();
+          }
+        })();
+        return { ...view };
+      } finally {
+        startingUsers.delete(userId);
+      }
+    },
+    status(orgId: number, userId: number, id: string): CodexLoginStatus {
+      return { ...get(orgId, userId, id).view };
+    },
+    async complete(orgId: number, userId: number, id: string, records: EncryptedRecordStore) {
+      const attempt = get(orgId, userId, id);
+      if (attempt.view.credential) return attempt.view.credential;
+      if (attempt.saving) return attempt.saving;
+      if (!attempt.auth || attempt.view.status !== "ready")
+        throw new RecordStoreError(409, "Finish signing in with ChatGPT first.");
+      attempt.view.status = "saving";
+      // A migration key also makes retries safe after a partial storage write.
+      attempt.saving = saveCredential(
+        orgRecords(records, orgId),
+        orgId,
+        {
+          name: attempt.name,
+          kind: "openai",
+          auth: "codex-login",
+          value: attempt.auth,
+        },
+        {},
+        `codex-login:${id}`,
+      )
+        .then((credential) => {
+          delete attempt.auth;
+          attempt.view.credential = credential;
+          attempt.view.status = "saved";
+          return credential;
+        })
+        .catch(() => {
+          attempt.view.status = "ready";
+          throw new RecordStoreError(
+            503,
+            "Sign-in completed, but saving failed. Retry saving your credential.",
+          );
+        })
+        .finally(() => {
+          delete attempt.saving;
+        });
+      return attempt.saving;
+    },
+    async cancel(orgId: number, userId: number, id: string) {
+      const attempt = get(orgId, userId, id);
+      if (attempt.saving) await attempt.saving;
+      await cancel(id);
+    },
+    async close() {
+      await Promise.all([...attempts.keys()].map(cancel));
+    },
+  };
+}
+export type CodexLogins = ReturnType<typeof createCodexLogins>;
+export const codexLogins = createCodexLogins();

--- a/src/evaluation/routes.ts
+++ b/src/evaluation/routes.ts
@@ -6,6 +6,8 @@ import type { User, UserStore } from "../auth/users.js";
 import type { RepoStore } from "../site/repo-store.js";
 import type { TaskStore } from "../site/task-store.js";
 import { tenantFor } from "../site/tenant.js";
+import type { CodexLogins } from "./codex-login.js";
+import { codexLoginRoutes } from "./codex-login-routes.js";
 import { evaluationSandboxes } from "./config.js";
 import type { EncryptedRecordStore } from "./encrypted-records.js";
 import { orgCredentialRoutes } from "./org-credential-routes.js";
@@ -49,6 +51,7 @@ export interface EvaluationRoutesOptions {
   start(input: EvaluationInput): Promise<void>;
   env?: NodeJS.ProcessEnv;
   records?: EncryptedRecordStore;
+  codexLogins?: CodexLogins;
 }
 export function createEvaluationRoutes(options: EvaluationRoutesOptions) {
   const { users, repos, tasks, artifacts } = options;
@@ -59,6 +62,7 @@ export function createEvaluationRoutes(options: EvaluationRoutesOptions) {
       response: ServerResponse,
       user: User,
     ): Promise<boolean> {
+      if (await codexLoginRoutes(options, request, url, response, user)) return true;
       if (await orgCredentialRoutes(options, request, url, response, user)) return true;
       if (await platformRoutes(options, request, url, response, user)) return true;
       const match = route.exec(url.pathname);

--- a/tests/codex-login.test.ts
+++ b/tests/codex-login.test.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "bun:test";
+import { createCodexLogins } from "../src/evaluation/codex-login.js";
+import { listCredentials } from "../src/evaluation/credentials.js";
+import { orgRecords } from "../src/evaluation/org-records.js";
+import { evaluationServer } from "./support/evaluation-fixture.js";
+import { MemoryRecords } from "./support/evaluation-records.js";
+
+const auth = JSON.stringify({
+  tokens: { access_token: "test-access-never-return", refresh_token: "test-refresh-never-return" },
+});
+function loginFixture(lifetime?: number) {
+  let resolve!: (value: string) => void;
+  let reject!: (error: Error) => void;
+  let closed = 0;
+  const logins = createCodexLogins(
+    async () => ({
+      instructions: Promise.resolve({
+        verificationUrl: "https://auth.openai.com/codex/device",
+        userCode: "TEST-CODE",
+      }),
+      auth: new Promise<string>((yes, no) => {
+        resolve = yes;
+        reject = no;
+      }),
+      close: async () => {
+        closed++;
+      },
+    }),
+    lifetime,
+  );
+  return {
+    logins,
+    resolve: (value = auth) => resolve(value),
+    reject: () => reject(new Error("Sign-in expired")),
+    closed: () => closed,
+  };
+}
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("device sign-in saves once, keeps secrets out of status, and enforces ceremony ownership", async () => {
+  const fixture = loginFixture();
+  const records = new MemoryRecords();
+  try {
+    const pending = await fixture.logins.start(4, 7, " Team Codex ");
+    await settle();
+    expect(fixture.logins.status(4, 7, pending.id).status).toBe("waiting");
+    expect(() => fixture.logins.status(4, 8, pending.id)).toThrow("expired");
+    expect(() => fixture.logins.status(5, 7, pending.id)).toThrow("expired");
+    await expect(fixture.logins.cancel(5, 7, pending.id)).rejects.toThrow("expired");
+    await expect(fixture.logins.complete(4, 7, pending.id, records)).rejects.toThrow(
+      "Finish signing in",
+    );
+    fixture.resolve();
+    await settle();
+    expect(fixture.closed()).toBe(1);
+    const ready = fixture.logins.status(4, 7, pending.id);
+    expect(ready.status).toBe("ready");
+    expect(JSON.stringify(ready)).not.toContain("test-access");
+    const saved = await Promise.all([
+      fixture.logins.complete(4, 7, pending.id, records),
+      fixture.logins.complete(4, 7, pending.id, records),
+    ]);
+    expect(saved[0]?.id).toBe(saved[1]?.id);
+    expect(saved[0]?.name).toBe("Team Codex");
+    expect(JSON.stringify(saved)).not.toContain("test-refresh");
+    expect((await fixture.logins.complete(4, 7, pending.id, records)).id).toBe(saved[0]?.id);
+    expect(await listCredentials(orgRecords(records, 4), 4)).toHaveLength(1);
+    expect(await listCredentials(orgRecords(records, 5), 5)).toHaveLength(0);
+  } finally {
+    await fixture.logins.close();
+  }
+});
+
+test("failed saves can retry without signing in again", async () => {
+  const fixture = loginFixture();
+  class FlakyRecords extends MemoryRecords {
+    fail = true;
+    override async write(path: string, value: unknown, version: number) {
+      if (this.fail) {
+        this.fail = false;
+        throw new Error("Storage offline");
+      }
+      return super.write(path, value, version);
+    }
+  }
+  const records = new FlakyRecords();
+  try {
+    const pending = await fixture.logins.start(4, 7, "Codex");
+    await settle();
+    fixture.resolve();
+    await settle();
+    await expect(fixture.logins.complete(4, 7, pending.id, records)).rejects.toThrow(
+      "saving failed",
+    );
+    expect(fixture.logins.status(4, 7, pending.id).status).toBe("ready");
+    await fixture.logins.complete(4, 7, pending.id, records);
+    expect(await listCredentials(orgRecords(records, 4), 4)).toHaveLength(1);
+  } finally {
+    await fixture.logins.close();
+  }
+});
+
+test("cancellation and expiry discard sign-ins; invalid credentials never become ready", async () => {
+  const fixture = loginFixture();
+  try {
+    const pending = await fixture.logins.start(4, 7, "Codex");
+    await settle();
+    await fixture.logins.cancel(4, 7, pending.id);
+    fixture.resolve();
+    await settle();
+    expect(() => fixture.logins.status(4, 7, pending.id)).toThrow("expired");
+    const invalid = await fixture.logins.start(4, 7, "Codex");
+    await settle();
+    fixture.resolve('{"OPENAI_API_KEY":"do-not-accept"}');
+    await settle();
+    expect(fixture.logins.status(4, 7, invalid.id).status).toBe("failed");
+  } finally {
+    await fixture.logins.close();
+  }
+  const expiring = loginFixture(20);
+  const pending = await expiring.logins.start(4, 7, "Codex");
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  expect(() => expiring.logins.status(4, 7, pending.id)).toThrow("expired");
+  expect(expiring.closed()).toBe(1);
+  await expiring.logins.close();
+});
+
+test("HTTP sign-in requires admin, same origin and current user; completion exposes only saved metadata", async () => {
+  const fixture = loginFixture();
+  const records = new MemoryRecords();
+  const site = await evaluationServer(records, fixture.logins);
+  const base = "/api/orgs/avyay/credentials/codex-login";
+  const post = (body: object) => ({ method: "POST", body: JSON.stringify(body) });
+  try {
+    expect((await site.request(base, post({ name: "Codex" }), null)).status).toBe(401);
+    expect((await site.request(base, post({ name: "Codex" }), 2)).status).toBe(404);
+    expect(
+      (
+        await site.request(base, {
+          ...post({ name: "Codex" }),
+          headers: { origin: "https://evil.example" },
+        })
+      ).status,
+    ).toBe(403);
+    expect((await site.request(base, post({ name: "" }))).status).toBe(400);
+    const team = { githubId: 20, login: "team", role: "member" as const };
+    await site.users.upsert({
+      githubId: 2,
+      login: "outsider",
+      token: "other-secret",
+      scopes: "repo",
+      orgs: [team],
+    });
+    expect(
+      (await site.request("/api/orgs/team/credentials/codex-login", post({ name: "Codex" }), 2))
+        .status,
+    ).toBe(403);
+    const start = await site.request(base, post({ name: "Team Codex" }));
+    expect(start.status).toBe(202);
+    const pending = await start.json();
+    await settle();
+    fixture.resolve();
+    await settle();
+    const ready = await site.request(`${base}/${pending.id}`);
+    expect(ready.headers.get("cache-control")).toBe("no-store");
+    expect((await ready.json()).status).toBe("ready");
+    expect((await site.request(`${base}/${pending.id}/complete`)).status).toBe(405);
+    const complete = await site.request(`${base}/${pending.id}/complete`, post({}));
+    expect(complete.status).toBe(200);
+    expect(await complete.text()).not.toContain("test-access");
+    const list = await (await site.request("/api/orgs/avyay/credentials")).json();
+    expect(list.credentials).toHaveLength(1);
+    expect(list.credentials[0].auth).toBe("codex-login");
+    expect((await site.request(`${base}/${pending.id}/cancel`, post({}))).status).toBe(200);
+    expect((await site.request(`${base}/${pending.id}`)).status).toBe(410);
+  } finally {
+    await fixture.logins.close();
+    await site.close();
+  }
+});

--- a/tests/support/evaluation-fixture.ts
+++ b/tests/support/evaluation-fixture.ts
@@ -6,6 +6,7 @@ import { LocalArtifactStore } from "../../src/artifacts.js";
 import { createSiteAuth } from "../../src/auth/routes.js";
 import { createSessionSigner, SESSION_COOKIE } from "../../src/auth/session.js";
 import { createUserStore } from "../../src/auth/users.js";
+import type { CodexLogins } from "../../src/evaluation/codex-login.js";
 import {
   createEncryptedRecords,
   type EncryptedRecordStore,
@@ -45,7 +46,7 @@ export function evaluationInput(): EvaluationInput {
     tasks: [{ runId: "run-one", taskId: "task-one", bundleKey: "tasks/task.tar.gz" }],
   };
 }
-export async function evaluationServer(records?: EncryptedRecordStore) {
+export async function evaluationServer(records?: EncryptedRecordStore, codexLogins?: CodexLogins) {
   const directory = await mkdtemp(join(tmpdir(), "evaluation-routes-"));
   const artifacts = new LocalArtifactStore(directory);
   const database = await testDatabase();
@@ -138,6 +139,7 @@ export async function evaluationServer(records?: EncryptedRecordStore) {
         tasks,
         artifacts,
         publicUrl,
+        ...(codexLogins ? { codexLogins } : {}),
         env: evaluationEnv,
         records:
           records ??


### PR DESCRIPTION
## Summary
Make credentials easier to scan and manage, and let organization admins connect Codex through OpenAI device sign-in. Replace blank or text-only loading states with layout-matched skeletons.

Stacked on #61 (`avyay-harbor-review-page`); that parent currently has a separate merge conflict with `main`.

## Design
### Credentials and Loading
- `review/src/web/evaluation/CredentialsPage.tsx`, `CredentialGroup.tsx`, and `CredentialEditor.tsx` group model and sandbox credentials and move add/replace flows into a focused dialog. Include an explicit delete confirmation, masked secret entry, API-key and ChatGPT authentication choices, and auth-file import fallback.
- `review/src/web/evaluation/CodexSignIn.tsx` shows the device code and OpenAI approval link, polls status, saves after approval, and handles cancellation, expiry, and save retries. Restarting discards stale polling; the dialog blocks dismissal while an approved credential is saving.
- `review/src/web/LoadingSkeleton.tsx` supplies skeletons for application/workspace startup, credentials, repository lookup, and results. Sidebar and account-picker spacing and menu placement are also refined.
### Authentication
- `src/evaluation/codex-login-process.ts` runs the pinned Codex app server in a private temporary home, using only authentication RPCs. `codex-login.ts` scopes short-lived attempts to the initiating user and organization and saves through the existing encrypted record store. Tokens never go to the browser; completion is idempotent.
- `src/evaluation/codex-login-routes.ts` requires organization-admin access and same-origin JSON mutations. `tests/codex-login.test.ts` covers ownership, cancellation, expiry, duplicate completion, invalid credentials, and storage retries.

## Validation
- `bun run check` and `bun run build:review` passed; existing unused-import and bundle-size warnings remain.
- Three React DOM regressions cover restart after a polling error, blocked dismissal during save, and retry after storage failure. Both reported race tests failed before the fix and pass afterward.
- Full `bun run validate` passed: 478 tests, 0 failures (2,223 assertions), server/frontend builds, and packed application verification. GitHub `validate` and Cursor Bugbot both explicitly passed on `a6e1b4ed13e3bffd1d70352689554da6f0c7658c`; CI also passed packaged Docker build verification.
- Chrome verified sample credential save/delete, dialog and list updates, narrow layout, and real OpenAI device-code issuance. Final live account approval/save remains unverified because OpenAI requires the user’s ChatGPT login.
- No model inference or paid sandbox run was performed.
